### PR TITLE
Allow node-local-dns

### DIFF
--- a/pkg/resources/unleash.go
+++ b/pkg/resources/unleash.go
@@ -335,6 +335,14 @@ func NetworkPolicyForUnleash(unleash *unleashv1.Unleash, scheme *runtime.Scheme,
 						},
 					},
 				},
+				{
+					NamespaceSelector: &metav1.LabelSelector{},
+					PodSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"k8s-app": "node-local-dns",
+						},
+					},
+				},
 			},
 			Ports: []networkingv1.NetworkPolicyPort{
 				{


### PR DESCRIPTION
Allow egress traffic to node local DNS cache

https://kubernetes.io/docs/tasks/administer-cluster/nodelocaldns/
