### PR TITLE
Fix unmarshal error in Unleash Client admin instance stats

### DIFF
--- a/pkg/unleash/admin_api.go
+++ b/pkg/unleash/admin_api.go
@@ -16,8 +16,8 @@ type InstanceAdminStatsResult struct {
 	Environments      float64 `json:"environments"`
 	Segments          float64 `json:"segments"`
 	Strategies        float64 `json:"strategies"`
-	SAMLenabled       float64 `json:"SAMLenabled"`
-	OIDCenabled       float64 `json:"OIDCenabled"`
+	SAMLenabled       bool    `json:"SAMLenabled"`
+	OIDCenabled       bool    `json:"OIDCenabled"`
 	Sum               string  `json:"sum"`
 }
 

--- a/pkg/unleash/admin_api_test.go
+++ b/pkg/unleash/admin_api_test.go
@@ -1,0 +1,15 @@
+package unleash
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestInstanceAdminStatsResult(t *testing.T) {
+	jsonString := `{"timestamp":"2023-04-11T10:19:45.131Z","instanceId":"9bb58ff2-f295-4dd1-80a9-13e0c22de2fd","versionOSS":"4.19.3","versionEnterprise":"","users":3,"featureToggles":2,"projects":1,"contextFields":4,"roles":5,"groups":0,"environments":3,"segments":0,"strategies":8,"SAMLenabled":false,"OIDCenabled":false,"sum":"b9d48b54fad852075c0d5407acc35e79238f00b41d877196b9e37767588b8553"}`
+	var result InstanceAdminStatsResult
+	err := json.Unmarshal([]byte(jsonString), &result)
+	if err != nil {
+		t.Errorf("Error unmarshalling json: %s", err)
+	}
+}


### PR DESCRIPTION
```
json: cannot unmarshal bool into Go struct field InstanceAdminStatsResult.SAMLenabled of type float64
```
