### PR TITLE
Fix Unleash health endpoint URL

### DIFF
--- a/controllers/remoteunleash_controller_test.go
+++ b/controllers/remoteunleash_controller_test.go
@@ -85,7 +85,7 @@ var _ = Describe("RemoteUnleash controller", func() {
 		It("Should succeed when it can connect to Unleash", func() {
 			// Mock Unleash server with a health endpoint
 			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				if r.URL.Path != "/api/health" {
+				if r.URL.Path != "/health" {
 					w.WriteHeader(http.StatusNotFound)
 				}
 

--- a/controllers/unleash_controller_test.go
+++ b/controllers/unleash_controller_test.go
@@ -78,7 +78,7 @@ var _ = Describe("Unleash controller", func() {
 			By("By mocking Unleash API")
 			httpmock.Activate()
 			defer httpmock.DeactivateAndReset()
-			httpmock.RegisterResponder("GET", "http://test-unleash-success.default/api/health",
+			httpmock.RegisterResponder("GET", "http://test-unleash-success.default/health",
 				httpmock.NewStringResponder(200, `{"health": "GOOD"}`))
 
 			By("By creating a new Unleash")

--- a/pkg/unleash/admin_api.go
+++ b/pkg/unleash/admin_api.go
@@ -30,7 +30,7 @@ type HealthResult struct {
 // GetHealth returns the health of the Unleash instance.
 func (c *Client) GetHealth() (*HealthResult, *http.Response, error) {
 	health := &HealthResult{}
-	res, err := c.HTTPGet("/api/health", health)
+	res, err := c.HTTPGet("/health", health)
 
 	if err != nil {
 		return health, res, err


### PR DESCRIPTION
Unleash health endpoint is `/health`

Ref. https://docs.getunleash.io/reference/api/legacy/unleash/internal/health

Co-authored-by: Carl Hedgren <carl.hedgren@nav.no>
