### PR TITLE
Add remoteunleashes to ClusterRole

### DIFF
--- a/charts/unleasherator-crds/Chart.yaml
+++ b/charts/unleasherator-crds/Chart.yaml
@@ -6,4 +6,4 @@ maintainers:
     name: "nais"
 name: unleasherator-crds
 type: application
-version: 1.7.1
+version: 1.7.2

--- a/charts/unleasherator/Chart.yaml
+++ b/charts/unleasherator/Chart.yaml
@@ -6,4 +6,4 @@ maintainers:
     name: "nais"
 name: unleasherator
 type: application
-version: 1.7.1
+version: 1.7.2

--- a/charts/unleasherator/templates/manager-rbac.yaml
+++ b/charts/unleasherator/templates/manager-rbac.yaml
@@ -115,32 +115,6 @@ rules:
 - apiGroups:
   - unleash.nais.io
   resources:
-  - RemoteUnleashs
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - unleash.nais.io
-  resources:
-  - RemoteUnleashs/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - unleash.nais.io
-  resources:
-  - RemoteUnleashs/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - unleash.nais.io
-  resources:
   - apitokens
   verbs:
   - create
@@ -160,6 +134,32 @@ rules:
   - unleash.nais.io
   resources:
   - apitokens/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - unleash.nais.io
+  resources:
+  - remoteunleashes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - unleash.nais.io
+  resources:
+  - remoteunleashes/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - unleash.nais.io
+  resources:
+  - remoteunleashes/status
   verbs:
   - get
   - patch


### PR DESCRIPTION
```
E0510 18:44:00.697367       1 reflector.go:140] pkg/mod/k8s.io/client-go@v0.26.3/tools/cache/reflector.go:169: Failed to watch *unleash_nais_io_v1.RemoteUnleash: failed to list *unleash_nais_io_v1.RemoteUnleash: remoteunleashes.unleash.nais.io is forbidden: User "system:serviceaccount:nais-system:unleasherator-controller-manager" cannot list resource "remoteunleashes" in API group "unleash.nais.io" at the cluster scope
```

Related #72 