### PR TITLE
Make ApiToken secret keys environment variables

### DIFF
--- a/api/v1/meta.go
+++ b/api/v1/meta.go
@@ -27,4 +27,7 @@ const (
 
 	UnleashSecretNamePrefix = "unleasherator"
 	UnleashSecretTokenKey   = "token"
+
+	ApiTokenSecretTokenEnv  = "UNLEASH_SERVER_API_TOKEN"
+	ApiTokenSecretServerEnv = "UNLEASH_SERVER_API_URL"
 )

--- a/controllers/apitoken_controller.go
+++ b/controllers/apitoken_controller.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -174,7 +175,7 @@ func (r *ApiTokenReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 				return ctrl.Result{}, err
 			}
 
-			return ctrl.Result{}, nil
+			return ctrl.Result{RequeueAfter: 1 * time.Minute}, nil
 		}
 
 		log.Error(err, "Failed to get Unleash resource")
@@ -325,7 +326,6 @@ func (r *ApiTokenReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	}
 
 	log.Info("Successfully reconciled ApiToken")
-
 	return ctrl.Result{}, nil
 }
 

--- a/controllers/apitoken_controller.go
+++ b/controllers/apitoken_controller.go
@@ -277,7 +277,8 @@ func (r *ApiTokenReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 				Namespace: token.GetObjectMeta().GetNamespace(),
 			},
 			Data: map[string][]byte{
-				unleashv1.UnleashSecretTokenKey: []byte(apiToken.Secret),
+				unleashv1.ApiTokenSecretTokenEnv:  []byte(apiToken.Secret),
+				unleashv1.ApiTokenSecretServerEnv: []byte(unleash.GetURL()),
 			},
 		}
 

--- a/controllers/apitoken_controller_test.go
+++ b/controllers/apitoken_controller_test.go
@@ -1,0 +1,168 @@
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/jarcoal/httpmock"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	unleashv1 "github.com/nais/unleasherator/api/v1"
+)
+
+var _ = Describe("ApiToken controller", func() {
+
+	// Define utility constants for object names and testing timeouts/durations and intervals.
+	const (
+		ApiTokenNamespace = "default"
+		ApiTokenServerURL = "http://unleash.nais.io"
+		ApiTokenToken     = "test"
+
+		timeout  = time.Second * 10
+		duration = time.Second * 10
+		interval = time.Millisecond * 250
+	)
+
+	Context("When creating a ApiToken", func() {
+		It("Should fail when Unleash does not exist", func() {
+
+		})
+
+		It("Should fail when RemoteUnleash does not exist", func() {
+
+		})
+
+		It("Should succeed when it can create token for Unleash", func() {
+
+		})
+
+		It("Should succeed when it can create token for RemoteUnleash", func() {
+			ctx := context.Background()
+
+			apiTokenName := "test-apitoken-remoteunleash-success"
+			apiTokenLookupKey := types.NamespacedName{Name: apiTokenName, Namespace: ApiTokenNamespace}
+
+			By("Mocking RemoteUnleash endpoints")
+			httpmock.Activate()
+			defer httpmock.DeactivateAndReset()
+			httpmock.RegisterResponder("GET", fmt.Sprintf("%s/health", ApiTokenServerURL),
+				httpmock.NewStringResponder(200, `{"health": "GOOD"}`))
+			httpmock.RegisterResponder("GET", fmt.Sprintf("%s/api/admin/api-tokens", ApiTokenServerURL),
+				httpmock.NewStringResponder(200, `{"tokens": []}`))
+			httpmock.RegisterResponder("POST", fmt.Sprintf("%s/api/admin/api-tokens", ApiTokenServerURL),
+				httpmock.NewStringResponder(201, `{
+					"username": "test",
+					"tokenName": "test",
+					"secret": "*:*.be44368985f7fb3237c584ef86f3d6bdada42ddbd63a019d26955178",
+					"type": "client"
+				}`))
+
+			By("By creating a new RemoteUnleash")
+			createdRemoteUnleashSecret := &corev1.Secret{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+					Kind:       "Secret",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf("unleasherator-%s", apiTokenName),
+					Namespace: ApiTokenNamespace,
+				},
+				Data: map[string][]byte{
+					"token": []byte(ApiTokenToken),
+				},
+			}
+			Expect(k8sClient.Create(ctx, createdRemoteUnleashSecret)).Should(Succeed())
+
+			remoteUnleashLookupKey := types.NamespacedName{Name: apiTokenName, Namespace: ApiTokenNamespace}
+			createdRemoteUnleash := &unleashv1.RemoteUnleash{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "unleash.nais.io/v1",
+					Kind:       "RemoteUnleash",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      remoteUnleashLookupKey.Name,
+					Namespace: remoteUnleashLookupKey.Namespace,
+				},
+				Spec: unleashv1.RemoteUnleashSpec{
+					Server: unleashv1.RemoteUnleashServer{
+						URL: ApiTokenServerURL,
+					},
+					AdminSecret: unleashv1.RemoteUnleashSecret{
+						Name: createdRemoteUnleashSecret.Name,
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, createdRemoteUnleash)).Should(Succeed())
+
+			Eventually(func() ([]metav1.Condition, error) {
+				err := k8sClient.Get(ctx, remoteUnleashLookupKey, createdRemoteUnleash)
+				if err != nil {
+					return nil, err
+				}
+
+				// unset condition.LastTransitionTime to make comparison easier
+				unsetConditionLastTransitionTime(createdRemoteUnleash.Status.Conditions)
+
+				return createdRemoteUnleash.Status.Conditions, nil
+			}, timeout, interval).Should(ContainElement(metav1.Condition{
+				Type:    unleashv1.UnleashStatusConditionTypeConnection,
+				Status:  metav1.ConditionTrue,
+				Reason:  "Reconciling",
+				Message: "Successfully connected to Unleash",
+			}))
+
+			By("By creating a new ApiToken")
+			createdApiToken := unleashv1.ApiToken{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "unleash.nais.io/v1",
+					Kind:       "ApiToken",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      apiTokenName,
+					Namespace: ApiTokenNamespace,
+				},
+				Spec: unleashv1.ApiTokenSpec{
+					UnleashInstance: unleashv1.ApiTokenUnleashInstance{
+						ApiVersion: "unleash.nais.io/v1",
+						Kind:       "RemoteUnleash",
+						Name:       createdRemoteUnleash.Name,
+					},
+					SecretName: apiTokenName,
+				},
+			}
+			Expect(k8sClient.Create(ctx, &createdApiToken)).Should(Succeed())
+
+			Eventually(func() ([]metav1.Condition, error) {
+				err := k8sClient.Get(ctx, apiTokenLookupKey, &createdApiToken)
+				if err != nil {
+					return nil, err
+				}
+
+				// unset condition.LastTransitionTime to make comparison easier
+				unsetConditionLastTransitionTime(createdApiToken.Status.Conditions)
+
+				return createdApiToken.Status.Conditions, nil
+			}, timeout, interval).Should(ContainElement(metav1.Condition{
+				Type:    typeCreatedToken,
+				Status:  metav1.ConditionTrue,
+				Reason:  "CreatedToken",
+				Message: "Created token",
+			}))
+
+			By("By checking that the ApiToken secret has been created")
+			createdApiTokenSecret := &corev1.Secret{}
+			k8sClient.Get(ctx, apiTokenLookupKey, createdApiTokenSecret)
+
+			Expect(createdApiTokenSecret.Data).Should(HaveKey(unleashv1.ApiTokenSecretTokenEnv))
+			Expect(createdApiTokenSecret.Data[unleashv1.ApiTokenSecretTokenEnv]).ShouldNot(BeEmpty())
+
+			Expect(createdApiTokenSecret.Data).Should(HaveKey(unleashv1.ApiTokenSecretServerEnv))
+			Expect(createdApiTokenSecret.Data[unleashv1.ApiTokenSecretServerEnv]).ShouldNot(BeEmpty())
+		})
+	})
+})

--- a/controllers/apitoken_controller_test.go
+++ b/controllers/apitoken_controller_test.go
@@ -46,6 +46,7 @@ var _ = Describe("ApiToken controller", func() {
 
 			apiTokenName := "test-apitoken-remoteunleash-success"
 			apiTokenLookupKey := types.NamespacedName{Name: apiTokenName, Namespace: ApiTokenNamespace}
+			apiTokenSecret := "*:*.be44368985f7fb3237c584ef86f3d6bdada42ddbd63a019d26955178"
 
 			By("Mocking RemoteUnleash endpoints")
 			httpmock.Activate()
@@ -55,12 +56,12 @@ var _ = Describe("ApiToken controller", func() {
 			httpmock.RegisterResponder("GET", fmt.Sprintf("%s/api/admin/api-tokens", ApiTokenServerURL),
 				httpmock.NewStringResponder(200, `{"tokens": []}`))
 			httpmock.RegisterResponder("POST", fmt.Sprintf("%s/api/admin/api-tokens", ApiTokenServerURL),
-				httpmock.NewStringResponder(201, `{
+				httpmock.NewStringResponder(201, fmt.Sprintf(`{
 					"username": "test",
 					"tokenName": "test",
-					"secret": "*:*.be44368985f7fb3237c584ef86f3d6bdada42ddbd63a019d26955178",
+					"secret": "%s",
 					"type": "client"
-				}`))
+				}`, apiTokenSecret)))
 
 			By("By creating a new RemoteUnleash")
 			createdRemoteUnleashSecret := &corev1.Secret{
@@ -160,9 +161,11 @@ var _ = Describe("ApiToken controller", func() {
 
 			Expect(createdApiTokenSecret.Data).Should(HaveKey(unleashv1.ApiTokenSecretTokenEnv))
 			Expect(createdApiTokenSecret.Data[unleashv1.ApiTokenSecretTokenEnv]).ShouldNot(BeEmpty())
+			Expect(createdApiTokenSecret.Data[unleashv1.ApiTokenSecretTokenEnv]).Should(Equal([]byte(apiTokenSecret)))
 
 			Expect(createdApiTokenSecret.Data).Should(HaveKey(unleashv1.ApiTokenSecretServerEnv))
 			Expect(createdApiTokenSecret.Data[unleashv1.ApiTokenSecretServerEnv]).ShouldNot(BeEmpty())
+			Expect(createdApiTokenSecret.Data[unleashv1.ApiTokenSecretServerEnv]).Should(Equal([]byte(ApiTokenServerURL)))
 		})
 	})
 })

--- a/controllers/remoteunleash_controller.go
+++ b/controllers/remoteunleash_controller.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -146,7 +147,11 @@ func (r *RemoteUnleashReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 			return ctrl.Result{}, err
 		}
 
-		return ctrl.Result{}, err
+		if apierrors.IsNotFound(err) {
+			return ctrl.Result{RequeueAfter: 1 * time.Minute}, nil
+		} else {
+			return ctrl.Result{}, err
+		}
 	}
 
 	// Check admin token
@@ -191,7 +196,7 @@ func (r *RemoteUnleashReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{}, err
 	}
 
-	return ctrl.Result{}, nil
+	return ctrl.Result{RequeueAfter: 1 * time.Minute}, nil
 }
 
 func (r *RemoteUnleashReconciler) updateStatusConnectionSuccess(ctx context.Context, remoteUnleash *unleashv1.RemoteUnleash) error {

--- a/docs/apitoken.md
+++ b/docs/apitoken.md
@@ -8,7 +8,10 @@ Status: `alpha`
 
 Creates a new unleash API token for the Unleash instance specified in the `unleashInstance` field. This can be either an `Unleash` or a `RemoteUnleash` resource in the same namespace.
 
-The token will be stored in secret in the same namespace as the `ApiToken` resource. The name of the secret is specified in the `secretName` field and contains a single key `token` with the value of the token.
+The token will be stored in secret in the same namespace as the `ApiToken` resource. The name of the secret is specified in the `secretName` field and contains two keys:
+
+- `UNLEASH_SERVER_API_TOKEN` - the token itself
+- `UNLEASH_SERVER_API_URL` - the URL of the Unleash instance
 
 ## Spec
 

--- a/pkg/unleash/client.go
+++ b/pkg/unleash/client.go
@@ -67,7 +67,7 @@ func (c *Client) HTTPGet(requestPath string, v any) (*http.Response, error) {
 		return res, err
 	}
 
-	if res.StatusCode != 200 {
+	if res.StatusCode != http.StatusOK {
 		return res, fmt.Errorf("unexpected http status code %d", res.StatusCode)
 	}
 
@@ -108,7 +108,7 @@ func (c *Client) HTTPPost(requestPath string, p, v any) (*http.Response, error) 
 		return res, err
 	}
 
-	if res.StatusCode != 201 {
+	if res.StatusCode != http.StatusCreated {
 		return res, fmt.Errorf("unexpected http status code %d with body %s", res.StatusCode, string(body))
 	}
 


### PR DESCRIPTION
The token will be stored in secret in the same namespace as the `ApiToken` resource. The name of the secret is specified in the `secretName` field and contains two keys:

- `UNLEASH_SERVER_API_TOKEN` - the token itself
- `UNLEASH_SERVER_API_URL` - the URL of the Unleash instance

Tasks

* [x] `ApiToken` Controller implementation
* [x] `ApiToken` docs updated
* [ ] `ApiToken` Controller tests
	* [x] Missing `Unleash` instance
	* [x] Missing `RemoteUnleash` instance
	* [ ] Successful created api token for `Unleash` 
	* [x] Successful created api token for `RemoteUnleash`
	* [ ] Error handling from Unleash API failures