### PR TITLE
Do not build application for config changes

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -10,7 +10,6 @@ on:
     paths:
       - "Makefile"
       - "Dockerfile"
-      - "config/**"
       - "go.mod"
       - "go.sum"
       - "**.go"
@@ -20,7 +19,6 @@ on:
     paths:
       - "Makefile"
       - "Dockerfile"
-      - "config/**"
       - "go.mod"
       - "go.sum"
       - "**.go"


### PR DESCRIPTION
Do not trigger a build of the application when config files are changed. These
are built by the Helm Chart workflow.
