### PR TITLE
Increase memory limit for Unleasherator deployment

### DIFF
--- a/charts/unleasherator-crds/Chart.yaml
+++ b/charts/unleasherator-crds/Chart.yaml
@@ -6,4 +6,4 @@ maintainers:
     name: "nais"
 name: unleasherator-crds
 type: application
-version: 1.10.1
+version: 1.10.2

--- a/charts/unleasherator/Chart.yaml
+++ b/charts/unleasherator/Chart.yaml
@@ -6,4 +6,4 @@ maintainers:
     name: "nais"
 name: unleasherator
 type: application
-version: 1.10.1
+version: 1.10.2

--- a/charts/unleasherator/values.yaml
+++ b/charts/unleasherator/values.yaml
@@ -36,10 +36,10 @@ controllerManager:
     imagePullPolicy: Always
     resources:
       limits:
-        memory: 256Mi
+        memory: 512Mi
       requests:
-        cpu: 100m
-        memory: 128Mi
+        cpu: 50m
+        memory: 256Mi
   replicas: 1
 kubernetesClusterDomain: cluster.local
 managerConfig:


### PR DESCRIPTION
We need 200Mi in a default running state, let's give some room for when we have
work to do. Don't want those OOMKilled to happen.
