### PR TITLE
Set seccompProfile to RuntimeDefault

### DIFF
--- a/charts/unleasherator-crds/Chart.yaml
+++ b/charts/unleasherator-crds/Chart.yaml
@@ -6,4 +6,4 @@ maintainers:
     name: "nais"
 name: unleasherator-crds
 type: application
-version: 1.10.2
+version: 1.10.3

--- a/charts/unleasherator/Chart.yaml
+++ b/charts/unleasherator/Chart.yaml
@@ -6,4 +6,4 @@ maintainers:
     name: "nais"
 name: unleasherator
 type: application
-version: 1.10.2
+version: 1.10.3

--- a/charts/unleasherator/templates/deployment.yaml
+++ b/charts/unleasherator/templates/deployment.yaml
@@ -102,6 +102,8 @@ spec:
           | nindent 10 }}
       securityContext:
         runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: {{ include "unleasherator.fullname" . }}-controller-manager
       terminationGracePeriodSeconds: 10
       volumes:

--- a/charts/unleasherator/values.yaml
+++ b/charts/unleasherator/values.yaml
@@ -10,6 +10,8 @@ controllerManager:
       capabilities:
         drop:
         - ALL
+      seccompProfile:
+        type: RuntimeDefault
     image:
       repository: gcr.io/kubebuilder/kube-rbac-proxy
       tag: v0.13.0
@@ -28,6 +30,8 @@ controllerManager:
       capabilities:
         drop:
         - ALL
+      seccompProfile:
+        type: RuntimeDefault
     env:
       apiTokenNameSuffix: unleasherator
     image:

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -28,6 +28,8 @@ spec:
       - name: kube-rbac-proxy
         securityContext:
           allowPrivilegeEscalation: false
+          seccompProfile:
+            type: RuntimeDefault
           capabilities:
             drop:
               - "ALL"

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -58,13 +58,8 @@ spec:
       #               - linux
       securityContext:
         runAsNonRoot: true
-        # TODO(user): For common cases that do not require escalating privileges
-        # it is recommended to ensure that all your Pods/Containers are restrictive.
-        # More info: https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted
-        # Please uncomment the following code if your project does NOT have to work on old Kubernetes
-        # versions < 1.19 or on vendors versions which do NOT support this field by default (i.e. Openshift < 4.11 ).
-        # seccompProfile:
-        #   type: RuntimeDefault
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -72,6 +67,8 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          seccompProfile:
+            type: RuntimeDefault
           capabilities:
             drop:
               - "ALL"


### PR DESCRIPTION
```
policy Pod/nais-system/unleasherator-controller-manager-64847c75d5-vmdv6 for resource violation:

restrict-seccomp-strict:
  check-seccomp-strict: 'validation error: Use of custom Seccomp profiles is disallowed.
    The fields spec.securityContext.seccompProfile.type, spec.containers[*].securityContext.seccompProfile.type,
    spec.initContainers[*].securityContext.seccompProfile.type, and spec.ephemeralContainers[*].securityContext.seccompProfile.type
    must be set to `RuntimeDefault` or `Localhost`. rule check-seccomp-strict[0] failed
    at path /spec/securityContext/seccompProfile/ rule check-seccomp-strict[1] failed
    at path /spec/containers/0/securityContext/seccompProfile/'
```
