### PR TITLE
Add status printing to kubect get commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ vet: ## Run go vet against code.
 	go vet ./...
 
 .PHONY: test
-test: manifests generate fmt vet envtest ## Run tests.
+test: manifests generate fmt vet lint envtest ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test ./... -coverprofile cover.out
 
 ##@ Build

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ SHELL = /usr/bin/env bash -o pipefail
 .SHELLFLAGS = -ec
 
 .PHONY: all
-all: generate manifests helm build
+all: fmt lint vet build generate helm
 
 ##@ General
 

--- a/api/v1/apitoken_types.go
+++ b/api/v1/apitoken_types.go
@@ -29,17 +29,20 @@ type ApiTokenSpec struct {
 
 	// SecretName is the name of the secret where the token will be stored.
 	// +kubebuilder:validation:Required
+	// +kubebuilder:printcolumn:name="Secret",type=string,JSONPath=`.spec.secretName`
 	SecretName string `json:"secretName"`
 
 	// Type is the type of token to create. Valid values are "CLIENT" and "FRONTEND".
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:validation:Enum=CLIENT;FRONTEND
 	// +kubebuilder:default=CLIENT
+	// +kubebuilder:printcolumn:name="Type",type=string,JSONPath=`.spec.type`
 	Type string `json:"type,omitempty"`
 
 	// Environment is the environment to create the token for.
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=development
+	// +kubebuilder:printcolumn:name="Environment",type=string,JSONPath=`.spec.environment`
 	Environment string `json:"environment,omitempty"`
 
 	// Projects is the list of projects to create the token for.
@@ -51,13 +54,27 @@ type ApiTokenSpec struct {
 // ApiTokenStatus defines the observed state of ApiToken
 type ApiTokenStatus struct {
 	// Represents the observations of a ApiToken's current state.
-	// Unleash.status.conditions.type are: "Created", "Creating", and "Failed"
+	// Unleash.status.conditions.type are: "Created", and "Failed"
 	// Unleash.status.conditions.status are one of True, False, Unknown.
 	// Unleash.status.conditions.reason the value should be a CamelCase string and producers of specific
 	// condition types may define expected values and meanings for this field, and whether the values
 	// are considered a guaranteed API.
 	// Unleash.status.conditions.Message is a human readable message indicating details about the transition.
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
+
+	// Created is true when the Unleash API token has been created successfully
+	// This is used for kubectl printing purposes. Rather than relying on this
+	// value, check the conditions instead.
+	// +kubebuilder:default=false
+	// +kubebuilder:printcolumn:name="Created",type=boolean,JSONPath=`.status.created`
+	Created bool `json:"created,omitempty"`
+
+	// Failed is true when the Unleash API token creation has failed
+	// This is used for kubectl printing purposes. Rather than relying on this
+	// value, check the conditions instead.
+	// +kubebuilder:default=false
+	// +kubebuilder:printcolumn:name="Failed",type=boolean,JSONPath=`.status.failed`
+	Failed bool `json:"failed,omitempty"`
 }
 
 // +kubebuilder:object:root=true
@@ -77,6 +94,10 @@ type ApiTokenList struct {
 	Items           []ApiToken `json:"items"`
 }
 
+// UnleashClientName returns the name of the Unleash client for this token.
+// The name is the same as the token name, but with a suffix. This is to avoid
+// name collisions between multiple Unleasherator instances operating on the same
+// Unleash instance.
 func (t *ApiToken) UnleashClientName(suffix string) string {
 	return t.Name + "-" + suffix
 }

--- a/api/v1/meta.go
+++ b/api/v1/meta.go
@@ -21,9 +21,13 @@ var (
 )
 
 const (
-	UnleashStatusConditionTypeAvailable  = "Available"
-	UnleashStatusConditionTypeConnection = "Connection"
+	UnleashStatusConditionTypeReconciled = "Reconciled"
+	UnleashStatusConditionTypeConnected  = "Connected"
 	UnleashStatusConditionTypeDegraded   = "Degraded"
+
+	ApiTokenStatusConditionTypeCreated = "Created"
+	ApiTokenStatusConditionTypeFailed  = "Failed"
+	ApiTokenStatusConditionTypeDeleted = "Deleted"
 
 	UnleashSecretNamePrefix = "unleasherator"
 	UnleashSecretTokenKey   = "token"

--- a/api/v1/remoteunleash_types.go
+++ b/api/v1/remoteunleash_types.go
@@ -72,13 +72,28 @@ type RemoteUnleashServer struct {
 // RemoteUnleashStatus defines the observed state of RemoteUnleash
 type RemoteUnleashStatus struct {
 	// Represents the observations of a RemoteUnleash's current state.
-	// RemoteUnleash.status.conditions.type are: "Available", "Connection", and "Degraded"
+	// RemoteUnleash.status.conditions.type are: "Reconciled", "Connected", and "Degraded"
 	// RemoteUnleash.status.conditions.status are one of True, False, Unknown.
 	// RemoteUnleash.status.conditions.reason the value should be a CamelCase string and producers of specific
 	// condition types may define expected values and meanings for this field, and whether the values
 	// are considered a guaranteed API.
 	// RemoteUnleash.status.conditions.Message is a human readable message indicating details about the transition.
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
+
+	// Reconciled is true when the Unleash resources hav been reconciled
+	// successfully.
+	// This is used for kubectl printing purposes. Rather than relying on this
+	// value, check the conditions instead.
+	// +kubebuilder:default=false
+	// +kubebuilder:printcolumn:name="Reconciled",type=boolean,JSONPath=`.status.reconciled`
+	Reconciled bool `json:"reconciled,omitempty"`
+
+	// Connected is true when the Unleash resource has been connected to the Unleash server
+	// This is used for kubectl printing purposes. Rather than relying on this
+	// value, check the conditions instead.
+	// +kubebuilder:default=false
+	// +kubebuilder:printcolumn:name="Connected",type=boolean,JSONPath=`.status.connected`
+	Connected bool `json:"connected,omitempty"`
 }
 
 // GetURL returns the URL of the Unleash instance.

--- a/api/v1/status.go
+++ b/api/v1/status.go
@@ -13,8 +13,8 @@ func getConditionStatus(conditions []metav1.Condition, t string) metav1.Conditio
 }
 
 func conditionStatusIsReady(conditions []metav1.Condition) bool {
-	statusAvailable := getConditionStatus(conditions, UnleashStatusConditionTypeAvailable)
-	statusConnection := getConditionStatus(conditions, UnleashStatusConditionTypeConnection)
+	statusAvailable := getConditionStatus(conditions, UnleashStatusConditionTypeReconciled)
+	statusConnection := getConditionStatus(conditions, UnleashStatusConditionTypeConnected)
 
 	return statusAvailable == metav1.ConditionTrue && statusConnection == metav1.ConditionTrue
 }

--- a/api/v1/unleash_types.go
+++ b/api/v1/unleash_types.go
@@ -221,13 +221,28 @@ type UnleashDatabaseConfig struct {
 // UnleashStatus defines the observed state of Unleash
 type UnleashStatus struct {
 	// Represents the observations of a Unleash's current state.
-	// Unleash.status.conditions.type are: "Available", "Connection", and "Degraded"
+	// Unleash.status.conditions.type are: "Reconciled", "Connected", and "Degraded"
 	// Unleash.status.conditions.status are one of True, False, Unknown.
 	// Unleash.status.conditions.reason the value should be a CamelCase string and producers of specific
 	// condition types may define expected values and meanings for this field, and whether the values
 	// are considered a guaranteed API.
 	// Unleash.status.conditions.Message is a human readable message indicating details about the transition.
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
+
+	// Reconciled is true when the Unleash resources hav been reconciled
+	// successfully.
+	// This is used for kubectl printing purposes. Rather than relying on this
+	// value, check the conditions instead.
+	// +kubebuilder:default=false
+	// +kubebuilder:printcolumn:name="Reconciled",type=boolean,JSONPath=`.status.reconciled`
+	Reconciled bool `json:"reconciled,omitempty"`
+
+	// Connected is true when the Unleash resource has been connected to the Unleash server
+	// This is used for kubectl printing purposes. Rather than relying on this
+	// value, check the conditions instead.
+	// +kubebuilder:default=false
+	// +kubebuilder:printcolumn:name="Connected",type=boolean,JSONPath=`.status.connected`
+	Connected bool `json:"connected,omitempty"`
 }
 
 func (u *Unleash) NamespacedName() types.NamespacedName {

--- a/api/v1/unleash_types_test.go
+++ b/api/v1/unleash_types_test.go
@@ -28,7 +28,7 @@ func TestUnleashIsReady(t *testing.T) {
 		Status: UnleashStatus{
 			Conditions: []metav1.Condition{
 				{
-					Type:   UnleashStatusConditionTypeAvailable,
+					Type:   UnleashStatusConditionTypeReconciled,
 					Status: metav1.ConditionFalse,
 				},
 			},
@@ -41,7 +41,7 @@ func TestUnleashIsReady(t *testing.T) {
 	assert.Equal(t, unleash.IsReady(), false, "Unleash should not be ready when connection condition is missing")
 
 	unleash.Status.Conditions = append(unleash.Status.Conditions, metav1.Condition{
-		Type:   UnleashStatusConditionTypeConnection,
+		Type:   UnleashStatusConditionTypeConnected,
 		Status: metav1.ConditionFalse,
 	})
 	assert.Equal(t, unleash.IsReady(), false, "Unleash should not be ready when connection condition is false")

--- a/charts/unleasherator-crds/Chart.yaml
+++ b/charts/unleasherator-crds/Chart.yaml
@@ -6,4 +6,4 @@ maintainers:
     name: "nais"
 name: unleasherator-crds
 type: application
-version: 1.10.3
+version: 1.11.0

--- a/charts/unleasherator-crds/templates/apitoken-crd.yaml
+++ b/charts/unleasherator-crds/templates/apitoken-crd.yaml
@@ -87,13 +87,12 @@ spec:
             properties:
               conditions:
                 description: 'Represents the observations of a ApiToken''s current state.
-                  Unleash.status.conditions.type are: "Created", "Creating", and "Failed"
-                  Unleash.status.conditions.status are one of True, False, Unknown.
-                  Unleash.status.conditions.reason the value should be a CamelCase string
-                  and producers of specific condition types may define expected values
-                  and meanings for this field, and whether the values are considered
-                  a guaranteed API. Unleash.status.conditions.Message is a human readable
-                  message indicating details about the transition.'
+                  Unleash.status.conditions.type are: "Created", and "Failed" Unleash.status.conditions.status
+                  are one of True, False, Unknown. Unleash.status.conditions.reason
+                  the value should be a CamelCase string and producers of specific condition
+                  types may define expected values and meanings for this field, and
+                  whether the values are considered a guaranteed API. Unleash.status.conditions.Message
+                  is a human readable message indicating details about the transition.'
                 items:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
@@ -161,6 +160,18 @@ spec:
                   - type
                   type: object
                 type: array
+              created:
+                default: false
+                description: Created is true when the Unleash API token has been created
+                  successfully This is used for kubectl printing purposes. Rather than
+                  relying on this value, check the conditions instead.
+                type: boolean
+              failed:
+                default: false
+                description: Failed is true when the Unleash API token creation has
+                  failed This is used for kubectl printing purposes. Rather than relying
+                  on this value, check the conditions instead.
+                type: boolean
             type: object
         type: object
     served: true

--- a/charts/unleasherator-crds/templates/remoteunleash-crd.yaml
+++ b/charts/unleasherator-crds/templates/remoteunleash-crd.yaml
@@ -75,7 +75,7 @@ spec:
             properties:
               conditions:
                 description: 'Represents the observations of a RemoteUnleash''s current
-                  state. RemoteUnleash.status.conditions.type are: "Available", "Connection",
+                  state. RemoteUnleash.status.conditions.type are: "Reconciled", "Connected",
                   and "Degraded" RemoteUnleash.status.conditions.status are one of True,
                   False, Unknown. RemoteUnleash.status.conditions.reason the value should
                   be a CamelCase string and producers of specific condition types may
@@ -149,6 +149,18 @@ spec:
                   - type
                   type: object
                 type: array
+              connected:
+                default: false
+                description: Connected is true when the Unleash resource has been connected
+                  to the Unleash server This is used for kubectl printing purposes.
+                  Rather than relying on this value, check the conditions instead.
+                type: boolean
+              reconciled:
+                default: false
+                description: Reconciled is true when the Unleash resources hav been
+                  reconciled successfully. This is used for kubectl printing purposes.
+                  Rather than relying on this value, check the conditions instead.
+                type: boolean
             type: object
         type: object
     served: true

--- a/charts/unleasherator-crds/templates/unleash-crd.yaml
+++ b/charts/unleasherator-crds/templates/unleash-crd.yaml
@@ -3573,7 +3573,7 @@ spec:
             properties:
               conditions:
                 description: 'Represents the observations of a Unleash''s current state.
-                  Unleash.status.conditions.type are: "Available", "Connection", and
+                  Unleash.status.conditions.type are: "Reconciled", "Connected", and
                   "Degraded" Unleash.status.conditions.status are one of True, False,
                   Unknown. Unleash.status.conditions.reason the value should be a CamelCase
                   string and producers of specific condition types may define expected
@@ -3647,6 +3647,18 @@ spec:
                   - type
                   type: object
                 type: array
+              connected:
+                default: false
+                description: Connected is true when the Unleash resource has been connected
+                  to the Unleash server This is used for kubectl printing purposes.
+                  Rather than relying on this value, check the conditions instead.
+                type: boolean
+              reconciled:
+                default: false
+                description: Reconciled is true when the Unleash resources hav been
+                  reconciled successfully. This is used for kubectl printing purposes.
+                  Rather than relying on this value, check the conditions instead.
+                type: boolean
             type: object
         type: object
     served: true

--- a/charts/unleasherator/Chart.yaml
+++ b/charts/unleasherator/Chart.yaml
@@ -6,4 +6,4 @@ maintainers:
     name: "nais"
 name: unleasherator
 type: application
-version: 1.10.3
+version: 1.11.0

--- a/config/crd/bases/unleash.nais.io_apitokens.yaml
+++ b/config/crd/bases/unleash.nais.io_apitokens.yaml
@@ -88,13 +88,13 @@ spec:
             properties:
               conditions:
                 description: 'Represents the observations of a ApiToken''s current
-                  state. Unleash.status.conditions.type are: "Created", "Creating",
-                  and "Failed" Unleash.status.conditions.status are one of True, False,
-                  Unknown. Unleash.status.conditions.reason the value should be a
-                  CamelCase string and producers of specific condition types may define
-                  expected values and meanings for this field, and whether the values
-                  are considered a guaranteed API. Unleash.status.conditions.Message
-                  is a human readable message indicating details about the transition.'
+                  state. Unleash.status.conditions.type are: "Created", and "Failed"
+                  Unleash.status.conditions.status are one of True, False, Unknown.
+                  Unleash.status.conditions.reason the value should be a CamelCase
+                  string and producers of specific condition types may define expected
+                  values and meanings for this field, and whether the values are considered
+                  a guaranteed API. Unleash.status.conditions.Message is a human readable
+                  message indicating details about the transition.'
                 items:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
@@ -162,6 +162,18 @@ spec:
                   - type
                   type: object
                 type: array
+              created:
+                default: false
+                description: Created is true when the Unleash API token has been created
+                  successfully This is used for kubectl printing purposes. Rather
+                  than relying on this value, check the conditions instead.
+                type: boolean
+              failed:
+                default: false
+                description: Failed is true when the Unleash API token creation has
+                  failed This is used for kubectl printing purposes. Rather than relying
+                  on this value, check the conditions instead.
+                type: boolean
             type: object
         type: object
     served: true

--- a/config/crd/bases/unleash.nais.io_remoteunleashes.yaml
+++ b/config/crd/bases/unleash.nais.io_remoteunleashes.yaml
@@ -74,7 +74,7 @@ spec:
             properties:
               conditions:
                 description: 'Represents the observations of a RemoteUnleash''s current
-                  state. RemoteUnleash.status.conditions.type are: "Available", "Connection",
+                  state. RemoteUnleash.status.conditions.type are: "Reconciled", "Connected",
                   and "Degraded" RemoteUnleash.status.conditions.status are one of
                   True, False, Unknown. RemoteUnleash.status.conditions.reason the
                   value should be a CamelCase string and producers of specific condition
@@ -148,6 +148,19 @@ spec:
                   - type
                   type: object
                 type: array
+              connected:
+                default: false
+                description: Connected is true when the Unleash resource has been
+                  connected to the Unleash server This is used for kubectl printing
+                  purposes. Rather than relying on this value, check the conditions
+                  instead.
+                type: boolean
+              reconciled:
+                default: false
+                description: Reconciled is true when the Unleash resources hav been
+                  reconciled successfully. This is used for kubectl printing purposes.
+                  Rather than relying on this value, check the conditions instead.
+                type: boolean
             type: object
         type: object
     served: true

--- a/config/crd/bases/unleash.nais.io_unleashes.yaml
+++ b/config/crd/bases/unleash.nais.io_unleashes.yaml
@@ -3631,7 +3631,7 @@ spec:
             properties:
               conditions:
                 description: 'Represents the observations of a Unleash''s current
-                  state. Unleash.status.conditions.type are: "Available", "Connection",
+                  state. Unleash.status.conditions.type are: "Reconciled", "Connected",
                   and "Degraded" Unleash.status.conditions.status are one of True,
                   False, Unknown. Unleash.status.conditions.reason the value should
                   be a CamelCase string and producers of specific condition types
@@ -3705,6 +3705,19 @@ spec:
                   - type
                   type: object
                 type: array
+              connected:
+                default: false
+                description: Connected is true when the Unleash resource has been
+                  connected to the Unleash server This is used for kubectl printing
+                  purposes. Rather than relying on this value, check the conditions
+                  instead.
+                type: boolean
+              reconciled:
+                default: false
+                description: Reconciled is true when the Unleash resources hav been
+                  reconciled successfully. This is used for kubectl printing purposes.
+                  Rather than relying on this value, check the conditions instead.
+                type: boolean
             type: object
         type: object
     served: true

--- a/controllers/apitoken_controller.go
+++ b/controllers/apitoken_controller.go
@@ -19,9 +19,21 @@ import (
 
 	unleashv1 "github.com/nais/unleasherator/api/v1"
 	unleashclient "github.com/nais/unleasherator/pkg/unleash"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 const tokenFinalizer = "unleash.nais.io/finalizer"
+
+var (
+	// apiTokenStatus is a Prometheus metric which will be used to expose the status of the Unleash instances
+	apiTokenStatus = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "unleasherator_unleash_status",
+			Help: "Status of Unleash instances",
+		},
+		[]string{"namespace", "name", "status"},
+	)
+)
 
 // ApiTokenReconciler reconciles a ApiToken object
 type ApiTokenReconciler struct {
@@ -152,24 +164,12 @@ func (r *ApiTokenReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	unleash, err := r.getUnleashInstance(ctx, token)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			meta.SetStatusCondition(&token.Status.Conditions, metav1.Condition{
-				Type:    unleashv1.ApiTokenStatusConditionTypeCreated,
-				Status:  metav1.ConditionFalse,
-				Reason:  "UnleashNotFound",
-				Message: fmt.Sprintf("%s resource with name %s not found in namespace %s", token.Spec.UnleashInstance.Kind, token.Spec.UnleashInstance.Name, token.Namespace),
-			})
-			meta.SetStatusCondition(&token.Status.Conditions, metav1.Condition{
-				Type:    unleashv1.ApiTokenStatusConditionTypeFailed,
-				Status:  metav1.ConditionTrue,
-				Reason:  "UnleashNotFound",
-				Message: fmt.Sprintf("%s resource with name %s not found in namespace %s", token.Spec.UnleashInstance.Kind, token.Spec.UnleashInstance.Name, token.Namespace),
-			})
-			if err = r.Status().Update(ctx, token); err != nil {
-				log.Error(err, "Failed to update ApiToken status")
+			message := fmt.Sprintf("%s resource with name %s not found in namespace %s", token.Spec.UnleashInstance.Kind, token.Spec.UnleashInstance.Name, token.Namespace)
+			if err := r.updateStatusFailed(ctx, token, err, "UnleashNotFound", message); err != nil {
 				return ctrl.Result{}, err
 			}
 
-			return ctrl.Result{RequeueAfter: 1 * time.Minute}, nil
+			return ctrl.Result{RequeueAfter: 5 * time.Minute}, nil
 		}
 
 		log.Error(err, "Failed to get Unleash resource")
@@ -178,15 +178,7 @@ func (r *ApiTokenReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 
 	// Check if Unleash instance is ready
 	if !unleash.IsReady() {
-		log.Info("Unleash instance for ApiToken is not ready")
-		meta.SetStatusCondition(&token.Status.Conditions, metav1.Condition{
-			Type:    unleashv1.ApiTokenStatusConditionTypeCreated,
-			Status:  metav1.ConditionFalse,
-			Reason:  "UnleashNotReady",
-			Message: "Unleash resource not ready",
-		})
-		if err = r.Status().Update(ctx, token); err != nil {
-			log.Error(err, "Failed to update ApiToken status")
+		if err := r.updateStatusFailed(ctx, token, nil, "UnleashNotReady", "Unleash instance not ready"); err != nil {
 			return ctrl.Result{}, err
 		}
 
@@ -196,29 +188,16 @@ func (r *ApiTokenReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	// Get Unleash API client
 	apiClient, err := unleash.GetApiClient(ctx, r.Client, r.OperatorNamespace)
 	if err != nil {
-		log.Error(err, "Failed to get Unleash client")
+		reason := "UnleashClientFailed"
+		message := "Failed to create Unleash client"
+
 		if apierrors.IsNotFound(err) {
-			meta.SetStatusCondition(&token.Status.Conditions, metav1.Condition{
-				Type:    unleashv1.ApiTokenStatusConditionTypeCreated,
-				Status:  metav1.ConditionFalse,
-				Reason:  "UnleashSecretNotFound",
-				Message: "Unleash secret not found",
-			})
-			if err = r.Status().Update(ctx, token); err != nil {
-				log.Error(err, "Failed to update ApiToken status")
-				return ctrl.Result{}, err
-			}
-		} else {
-			meta.SetStatusCondition(&token.Status.Conditions, metav1.Condition{
-				Type:    unleashv1.ApiTokenStatusConditionTypeCreated,
-				Status:  metav1.ConditionFalse,
-				Reason:  "FailedToCreateUnleashClient",
-				Message: "Failed to create Unleash client",
-			})
-			if err = r.Status().Update(ctx, token); err != nil {
-				log.Error(err, "Failed to update ApiToken status")
-				return ctrl.Result{}, err
-			}
+			reason = "UnleashSecretNotFound"
+			message = "Unleash secret not found"
+		}
+
+		if err := r.updateStatusFailed(ctx, token, err, reason, message); err != nil {
+			return ctrl.Result{}, err
 		}
 
 		return ctrl.Result{}, err
@@ -227,18 +206,9 @@ func (r *ApiTokenReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	// Check if token exists
 	exists, err := apiClient.CheckAPITokenExists(token.UnleashClientName(r.ApiTokenNameSuffix))
 	if err != nil {
-		log.Error(err, "Failed to check if token exists")
-		meta.SetStatusCondition(&token.Status.Conditions, metav1.Condition{
-			Type:    unleashv1.ApiTokenStatusConditionTypeCreated,
-			Status:  metav1.ConditionFalse,
-			Reason:  "FailedToCheckIfTokenExists",
-			Message: "Failed to check if token exists",
-		})
-		if err = r.Status().Update(ctx, token); err != nil {
-			log.Error(err, "Failed to update ApiToken status")
+		if err := r.updateStatusFailed(ctx, token, err, "TokenCheckFailed", "Failed to check if token exists"); err != nil {
 			return ctrl.Result{}, err
 		}
-
 		return ctrl.Result{}, err
 	}
 
@@ -252,17 +222,10 @@ func (r *ApiTokenReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 			Projects:    token.Spec.Projects,
 		})
 		if err != nil {
-			log.Error(err, "Failed to create token")
-			meta.SetStatusCondition(&token.Status.Conditions, metav1.Condition{
-				Type:    unleashv1.ApiTokenStatusConditionTypeCreated,
-				Status:  metav1.ConditionFalse,
-				Reason:  "FailedToCreateToken",
-				Message: "Failed to create token",
-			})
-			if err = r.Status().Update(ctx, token); err != nil {
-				log.Error(err, "Failed to update ApiToken status")
+			if err := r.updateStatusFailed(ctx, token, err, "TokenCreationFailed", "Failed to created token"); err != nil {
 				return ctrl.Result{}, err
 			}
+			return ctrl.Result{}, err
 		}
 
 		// Token secret
@@ -277,50 +240,31 @@ func (r *ApiTokenReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 			},
 		}
 
+		if err := controllerutil.SetControllerReference(token, secret, r.Scheme); err != nil {
+			log.Error(err, "Failed to set controller reference on secret for ApiToken")
+			return ctrl.Result{}, err
+		}
+
 		// Delete existing token secret if it exists
 		if err := r.Delete(ctx, secret); err != nil && !apierrors.IsNotFound(err) {
-			log.Error(err, "Failed to delete secret")
-			meta.SetStatusCondition(&token.Status.Conditions, metav1.Condition{
-				Type:    unleashv1.ApiTokenStatusConditionTypeCreated,
-				Status:  metav1.ConditionFalse,
-				Reason:  "FailedToDeleteExistingSecret",
-				Message: "Failed to delete existing secret",
-			})
-			if err = r.Status().Update(ctx, token); err != nil {
-				log.Error(err, "Failed to update ApiToken status")
+			if err := r.updateStatusFailed(ctx, token, err, "TokenSecretFailed", "Failed to delete existing token secret"); err != nil {
 				return ctrl.Result{}, err
 			}
+			return ctrl.Result{}, err
 		}
 
 		// Create new token secret
 		if err := r.Create(ctx, secret); err != nil {
-			log.Error(err, "Failed to create secret")
-			meta.SetStatusCondition(&token.Status.Conditions, metav1.Condition{
-				Type:    unleashv1.ApiTokenStatusConditionTypeCreated,
-				Status:  metav1.ConditionFalse,
-				Reason:  "FailedToCreateSecret",
-				Message: "Failed to create secret",
-			})
-			if err = r.Status().Update(ctx, token); err != nil {
-				log.Error(err, "Failed to update ApiToken status")
+			if err := r.updateStatusFailed(ctx, token, err, "TokenSecretFailed", "Failed to create token secret"); err != nil {
 				return ctrl.Result{}, err
 			}
-		}
-
-		meta.SetStatusCondition(&token.Status.Conditions, metav1.Condition{
-			Type:    unleashv1.ApiTokenStatusConditionTypeCreated,
-			Status:  metav1.ConditionTrue,
-			Reason:  "CreatedToken",
-			Message: "Created token",
-		})
-		if err = r.Status().Update(ctx, token); err != nil {
-			log.Error(err, "Failed to update ApiToken status")
 			return ctrl.Result{}, err
 		}
 	}
 
-	log.Info("Successfully reconciled ApiToken")
-	return ctrl.Result{}, nil
+	// Set ApiToken status to success
+	err = r.updateStatusSuccess(ctx, token)
+	return ctrl.Result{}, err
 }
 
 func (r *ApiTokenReconciler) getUnleashInstance(ctx context.Context, token *unleashv1.ApiToken) (UnleashInstance, error) {
@@ -345,6 +289,63 @@ func (r *ApiTokenReconciler) getUnleashInstance(ctx context.Context, token *unle
 	} else {
 		return nil, fmt.Errorf("unsupported api kind: %s", token.Spec.UnleashInstance.Kind)
 	}
+}
+
+// updateStatusSuccess will set the status condition as created and reset the failed status condition
+func (r *ApiTokenReconciler) updateStatusSuccess(ctx context.Context, apiToken *unleashv1.ApiToken) error {
+	log := log.FromContext(ctx)
+	log.Info("Successfully created ApiToken")
+
+	apiTokenStatus.WithLabelValues(apiToken.Namespace, apiToken.Name, unleashv1.ApiTokenStatusConditionTypeCreated).Set(1.0)
+	apiTokenStatus.WithLabelValues(apiToken.Namespace, apiToken.Name, unleashv1.ApiTokenStatusConditionTypeFailed).Set(0.0)
+
+	apiToken.Status.Created = true
+	apiToken.Status.Failed = false
+
+	meta.SetStatusCondition(&apiToken.Status.Conditions, metav1.Condition{
+		Type:    unleashv1.ApiTokenStatusConditionTypeCreated,
+		Status:  metav1.ConditionTrue,
+		Reason:  "Reconciling",
+		Message: "API token successfully created",
+	})
+
+	meta.RemoveStatusCondition(&apiToken.Status.Conditions, unleashv1.ApiTokenStatusConditionTypeFailed)
+
+	if err := r.Status().Update(ctx, apiToken); err != nil {
+		log.Error(err, "Failed to update status for ApiToken")
+		return err
+	}
+
+	return nil
+}
+
+// updateStatusFailed will set the status condition as failed, but not reset the created status condition
+func (r *ApiTokenReconciler) updateStatusFailed(ctx context.Context, apiToken *unleashv1.ApiToken, err error, reason, message string) error {
+	log := log.FromContext(ctx)
+
+	if err != nil {
+		log.Error(err, fmt.Sprintf("%s for ApiToken", message))
+	} else {
+		log.Info(fmt.Sprintf("%s for ApiToken", message))
+	}
+
+	apiTokenStatus.WithLabelValues(apiToken.Namespace, apiToken.Name, unleashv1.ApiTokenStatusConditionTypeFailed).Set(1.0)
+
+	apiToken.Status.Failed = true
+
+	meta.SetStatusCondition(&apiToken.Status.Conditions, metav1.Condition{
+		Type:    unleashv1.ApiTokenStatusConditionTypeFailed,
+		Status:  metav1.ConditionTrue,
+		Reason:  reason,
+		Message: message,
+	})
+
+	if err := r.Status().Update(ctx, apiToken); err != nil {
+		log.Error(err, "Failed to update status for ApiToken")
+		return err
+	}
+
+	return nil
 }
 
 func (r *ApiTokenReconciler) doFinalizerOperationsForToken(token *unleashv1.ApiToken) {

--- a/controllers/apitoken_controller_test.go
+++ b/controllers/apitoken_controller_test.go
@@ -70,7 +70,7 @@ var _ = Describe("ApiToken controller", func() {
 
 				return createdApiToken.Status.Conditions, nil
 			}, timeout, interval).Should(ContainElement(metav1.Condition{
-				Type:    typeCreatedToken,
+				Type:    unleashv1.ApiTokenStatusConditionTypeCreated,
 				Status:  metav1.ConditionFalse,
 				Reason:  "UnleashNotFound",
 				Message: "Unleash resource with name test-unleash-not-exist not found in namespace default",
@@ -118,7 +118,7 @@ var _ = Describe("ApiToken controller", func() {
 
 				return createdApiToken.Status.Conditions, nil
 			}, timeout, interval).Should(ContainElement(metav1.Condition{
-				Type:    typeCreatedToken,
+				Type:    unleashv1.ApiTokenStatusConditionTypeCreated,
 				Status:  metav1.ConditionFalse,
 				Reason:  "UnleashNotFound",
 				Message: "RemoteUnleash resource with name test-remoteunleash-not-exist not found in namespace default",
@@ -222,7 +222,7 @@ var _ = Describe("ApiToken controller", func() {
 
 				return createdRemoteUnleash.Status.Conditions, nil
 			}, timeout, interval).Should(ContainElement(metav1.Condition{
-				Type:    unleashv1.UnleashStatusConditionTypeConnection,
+				Type:    unleashv1.UnleashStatusConditionTypeConnected,
 				Status:  metav1.ConditionTrue,
 				Reason:  "Reconciling",
 				Message: "Successfully connected to Unleash",
@@ -260,7 +260,7 @@ var _ = Describe("ApiToken controller", func() {
 
 				return createdApiToken.Status.Conditions, nil
 			}, timeout, interval).Should(ContainElement(metav1.Condition{
-				Type:    typeCreatedToken,
+				Type:    unleashv1.ApiTokenStatusConditionTypeCreated,
 				Status:  metav1.ConditionTrue,
 				Reason:  "CreatedToken",
 				Message: "Created token",

--- a/controllers/apitoken_controller_test.go
+++ b/controllers/apitoken_controller_test.go
@@ -70,8 +70,8 @@ var _ = Describe("ApiToken controller", func() {
 
 				return createdApiToken.Status.Conditions, nil
 			}, timeout, interval).Should(ContainElement(metav1.Condition{
-				Type:    unleashv1.ApiTokenStatusConditionTypeCreated,
-				Status:  metav1.ConditionFalse,
+				Type:    unleashv1.ApiTokenStatusConditionTypeFailed,
+				Status:  metav1.ConditionTrue,
 				Reason:  "UnleashNotFound",
 				Message: "Unleash resource with name test-unleash-not-exist not found in namespace default",
 			}))
@@ -118,8 +118,8 @@ var _ = Describe("ApiToken controller", func() {
 
 				return createdApiToken.Status.Conditions, nil
 			}, timeout, interval).Should(ContainElement(metav1.Condition{
-				Type:    unleashv1.ApiTokenStatusConditionTypeCreated,
-				Status:  metav1.ConditionFalse,
+				Type:    unleashv1.ApiTokenStatusConditionTypeFailed,
+				Status:  metav1.ConditionTrue,
 				Reason:  "UnleashNotFound",
 				Message: "RemoteUnleash resource with name test-remoteunleash-not-exist not found in namespace default",
 			}))
@@ -262,8 +262,8 @@ var _ = Describe("ApiToken controller", func() {
 			}, timeout, interval).Should(ContainElement(metav1.Condition{
 				Type:    unleashv1.ApiTokenStatusConditionTypeCreated,
 				Status:  metav1.ConditionTrue,
-				Reason:  "CreatedToken",
-				Message: "Created token",
+				Reason:  "Reconciling",
+				Message: "API token successfully created",
 			}))
 
 			By("By checking that the ApiToken secret has been created")

--- a/controllers/remoteunleash_controller.go
+++ b/controllers/remoteunleash_controller.go
@@ -29,7 +29,7 @@ type RemoteUnleashReconciler struct {
 }
 
 var (
-	// unleashStatus is a Prometheus metric which will be used to expose the status of the Unleash instances
+	// remoteUnleashStatus is a Prometheus metric which will be used to expose the status of the RemoteUnleash instances
 	remoteUnleashStatus = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "unleasherator_remoteunleash_status",
@@ -258,7 +258,7 @@ func (r *RemoteUnleashReconciler) updateStatus(ctx context.Context, remoteUnleas
 	}
 
 	val := promGaugeValueForStatus(status.Status)
-	unleashStatus.WithLabelValues(remoteUnleash.Namespace, remoteUnleash.Name, status.Type).Set(val)
+	remoteUnleashStatus.WithLabelValues(remoteUnleash.Namespace, remoteUnleash.Name, status.Type).Set(val)
 
 	meta.SetStatusCondition(&remoteUnleash.Status.Conditions, status)
 	if err := r.Status().Update(ctx, remoteUnleash); err != nil {

--- a/controllers/remoteunleash_controller_test.go
+++ b/controllers/remoteunleash_controller_test.go
@@ -70,7 +70,7 @@ var _ = Describe("RemoteUnleash controller", func() {
 
 				return createdRemoteUnleash.Status.Conditions, nil
 			}, timeout, interval).Should(ContainElement(metav1.Condition{
-				Type:    unleashv1.UnleashStatusConditionTypeAvailable,
+				Type:    unleashv1.UnleashStatusConditionTypeReconciled,
 				Status:  metav1.ConditionFalse,
 				Reason:  "Reconciling",
 				Message: "Failed to get admin token secret",
@@ -155,7 +155,7 @@ var _ = Describe("RemoteUnleash controller", func() {
 
 				return createdRemoteUnleash.Status.Conditions, nil
 			}, timeout, interval).Should(ContainElement(metav1.Condition{
-				Type:    unleashv1.UnleashStatusConditionTypeConnection,
+				Type:    unleashv1.UnleashStatusConditionTypeConnected,
 				Status:  metav1.ConditionTrue,
 				Reason:  "Reconciling",
 				Message: "Successfully connected to Unleash",

--- a/controllers/unleash_controller.go
+++ b/controllers/unleash_controller.go
@@ -275,10 +275,8 @@ func (r *UnleashReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	}
 
 	// Set the connection status of the Unleash instance to available
-	if err = r.updateStatusConnectionSuccess(ctx, unleash); err != nil {
-		return ctrl.Result{}, err
-	}
-	return ctrl.Result{}, nil
+	err = r.updateStatusConnectionSuccess(ctx, unleash)
+	return ctrl.Result{}, err
 }
 
 // finalizeUnleash will perform the required operations before delete the CR.

--- a/controllers/unleash_controller.go
+++ b/controllers/unleash_controller.go
@@ -94,7 +94,7 @@ func (r *UnleashReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	// Let's just set the status as Unknown when no status are available
 	if unleash.Status.Conditions == nil || len(unleash.Status.Conditions) == 0 {
 		log.Info("Setting status as Unknown for Unleash")
-		meta.SetStatusCondition(&unleash.Status.Conditions, metav1.Condition{Type: unleashv1.UnleashStatusConditionTypeAvailable, Status: metav1.ConditionUnknown, Reason: "Reconciling", Message: "Starting reconciliation"})
+		meta.SetStatusCondition(&unleash.Status.Conditions, metav1.Condition{Type: unleashv1.UnleashStatusConditionTypeReconciled, Status: metav1.ConditionUnknown, Reason: "Reconciling", Message: "Starting reconciliation"})
 		if err = r.Status().Update(ctx, unleash); err != nil {
 			log.Error(err, "Failed to update Unleash status")
 			return ctrl.Result{}, err
@@ -655,7 +655,7 @@ func (r *UnleashReconciler) updateStatusReconcileSuccess(ctx context.Context, un
 
 	log.Info("Successfully reconciled Unleash")
 	return r.updateStatus(ctx, unleash, metav1.Condition{
-		Type:    unleashv1.UnleashStatusConditionTypeAvailable,
+		Type:    unleashv1.UnleashStatusConditionTypeReconciled,
 		Status:  metav1.ConditionTrue,
 		Reason:  "Reconciling",
 		Message: "Reconciled successfully",
@@ -671,7 +671,7 @@ func (r *UnleashReconciler) updateStatusReconcileFailed(ctx context.Context, unl
 
 	log.Error(err, message)
 	return r.updateStatus(ctx, unleash, metav1.Condition{
-		Type:    unleashv1.UnleashStatusConditionTypeAvailable,
+		Type:    unleashv1.UnleashStatusConditionTypeReconciled,
 		Status:  metav1.ConditionFalse,
 		Reason:  "Reconciling",
 		Message: message,
@@ -683,7 +683,7 @@ func (r *UnleashReconciler) updateStatusConnectionSuccess(ctx context.Context, u
 
 	log.Info("Successfully connected to Unleash")
 	return r.updateStatus(ctx, unleash, metav1.Condition{
-		Type:    unleashv1.UnleashStatusConditionTypeConnection,
+		Type:    unleashv1.UnleashStatusConditionTypeConnected,
 		Status:  metav1.ConditionTrue,
 		Reason:  "Reconciling",
 		Message: "Successfully connected to Unleash instance",
@@ -695,7 +695,7 @@ func (r *UnleashReconciler) updateStatusConnectionFailed(ctx context.Context, un
 
 	log.Error(err, fmt.Sprintf("%s for Unleash", message))
 	return r.updateStatus(ctx, unleash, metav1.Condition{
-		Type:    unleashv1.UnleashStatusConditionTypeConnection,
+		Type:    unleashv1.UnleashStatusConditionTypeConnected,
 		Status:  metav1.ConditionFalse,
 		Reason:  "Reconciling",
 		Message: message,
@@ -705,11 +705,14 @@ func (r *UnleashReconciler) updateStatusConnectionFailed(ctx context.Context, un
 func (r UnleashReconciler) updateStatus(ctx context.Context, unleash *unleashv1.Unleash, status metav1.Condition) error {
 	log := log.FromContext(ctx)
 
-	val := 0.0
-	if status.Status == metav1.ConditionTrue {
-		val = 1.0
+	switch status.Type {
+	case unleashv1.UnleashStatusConditionTypeReconciled:
+		unleash.Status.Reconciled = status.Status == metav1.ConditionTrue
+	case unleashv1.UnleashStatusConditionTypeConnected:
+		unleash.Status.Connected = status.Status == metav1.ConditionTrue
 	}
 
+	val := promGaugeValueForStatus(status.Status)
 	unleashStatus.WithLabelValues(unleash.Namespace, unleash.Name, status.Type).Set(val)
 
 	meta.SetStatusCondition(&unleash.Status.Conditions, status)

--- a/controllers/unleash_controller_test.go
+++ b/controllers/unleash_controller_test.go
@@ -65,7 +65,7 @@ var _ = Describe("Unleash controller", func() {
 
 				return createdUnleash.Status.Conditions, nil
 			}, timeout, interval).Should(ContainElement(metav1.Condition{
-				Type:    unleashv1.UnleashStatusConditionTypeAvailable,
+				Type:    unleashv1.UnleashStatusConditionTypeReconciled,
 				Status:  metav1.ConditionFalse,
 				Reason:  "Reconciling",
 				Message: "Failed to reconcile Deployment: validation failed for Deployment (either database.url or database.secretName must be set)",
@@ -118,7 +118,7 @@ var _ = Describe("Unleash controller", func() {
 
 				return createdUnleash.Status.Conditions, nil
 			}, timeout, interval).Should(ContainElement(metav1.Condition{
-				Type:    unleashv1.UnleashStatusConditionTypeConnection,
+				Type:    unleashv1.UnleashStatusConditionTypeConnected,
 				Status:  metav1.ConditionTrue,
 				Reason:  "Reconciling",
 				Message: "Successfully connected to Unleash instance",
@@ -145,11 +145,11 @@ var _ = Describe("Unleash controller", func() {
 			Expect(k8sClient.Get(ctx, unleashLookupKey, serviceMonitor)).Should(Succeed())
 
 			var m1 = &dto.Metric{}
-			Expect(unleashStatus.WithLabelValues(unleashLookupKey.Namespace, unleashLookupKey.Name, unleashv1.UnleashStatusConditionTypeConnection).Write(m1)).Should(Succeed())
+			Expect(unleashStatus.WithLabelValues(unleashLookupKey.Namespace, unleashLookupKey.Name, unleashv1.UnleashStatusConditionTypeConnected).Write(m1)).Should(Succeed())
 			Expect(m1.GetGauge().GetValue()).To(Equal(float64(1)))
 
 			var m2 = &dto.Metric{}
-			Expect(unleashStatus.WithLabelValues(unleashLookupKey.Namespace, unleashLookupKey.Name, unleashv1.UnleashStatusConditionTypeAvailable).Write(m2)).Should(Succeed())
+			Expect(unleashStatus.WithLabelValues(unleashLookupKey.Namespace, unleashLookupKey.Name, unleashv1.UnleashStatusConditionTypeReconciled).Write(m2)).Should(Succeed())
 			Expect(m2.GetGauge().GetValue()).To(Equal(float64(1)))
 
 			By("By cleaning up the Unleash")

--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -9,3 +9,10 @@ func unsetConditionLastTransitionTime(conditions []metav1.Condition) {
 		conditions[i].LastTransitionTime = metav1.Time{}
 	}
 }
+
+func promGaugeValueForStatus(status metav1.ConditionStatus) float64 {
+	if status == metav1.ConditionTrue {
+		return 1
+	}
+	return 0
+}


### PR DESCRIPTION
Add new status fields that can be used as column outputs in kubectl commands.

* [x] Unleash
* [x] RemoteUnleash
* [x] ApiToken

Resolve #108 
Resolve #95 
Resolve #94