### PR TITLE
Handle missing ApiToken secret in Kubernetes

### DIFF
--- a/api/v1/apitoken_types.go
+++ b/api/v1/apitoken_types.go
@@ -2,6 +2,7 @@ package unleash_nais_io_v1
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 // ApiTokenUnleashInstance defines the Unleash instance this token is for.
@@ -100,6 +101,13 @@ type ApiTokenList struct {
 // Unleash instance.
 func (t *ApiToken) UnleashClientName(suffix string) string {
 	return t.Name + "-" + suffix
+}
+
+func (t *ApiToken) NamespacedName() types.NamespacedName {
+	return types.NamespacedName{
+		Namespace: t.Namespace,
+		Name:      t.Name,
+	}
 }
 
 func init() {

--- a/api/v1/remoteunleash_types.go
+++ b/api/v1/remoteunleash_types.go
@@ -97,13 +97,13 @@ type RemoteUnleashStatus struct {
 	Connected bool `json:"connected,omitempty"`
 }
 
-// GetURL returns the URL of the Unleash instance.
-func (u *RemoteUnleash) GetURL() string {
+// URL returns the URL of the Unleash instance.
+func (u *RemoteUnleash) URL() string {
 	return u.Spec.Server.URL
 }
 
-// GetAdminSecretNamespacedName returns the namespaced name of the secret containing the Unleash instance's API token.
-func (u *RemoteUnleash) GetAdminSecretNamespacedName() types.NamespacedName {
+// AdminSecretNamespacedName returns the namespaced name of the secret containing the Unleash instance's API token.
+func (u *RemoteUnleash) AdminSecretNamespacedName() types.NamespacedName {
 	namespacedName := types.NamespacedName{
 		Name:      u.Spec.AdminSecret.Name,
 		Namespace: u.Spec.AdminSecret.Namespace,
@@ -116,27 +116,27 @@ func (u *RemoteUnleash) GetAdminSecretNamespacedName() types.NamespacedName {
 	return namespacedName
 }
 
-// GetAdminToken returns the admin API token for the Unleash instance.
-func (u *RemoteUnleash) GetAdminToken(ctx context.Context, client client.Client, operatorNamespace string) ([]byte, error) {
+// AdminToken returns the admin API token for the Unleash instance.
+func (u *RemoteUnleash) AdminToken(ctx context.Context, client client.Client, operatorNamespace string) ([]byte, error) {
 	// operatorNamespace is not used, and is only here to satisfy the interface of UnleashInstance.
 	_ = operatorNamespace
 
 	secret := &v1.Secret{}
-	if err := client.Get(ctx, u.GetAdminSecretNamespacedName(), secret); err != nil {
+	if err := client.Get(ctx, u.AdminSecretNamespacedName(), secret); err != nil {
 		return nil, err
 	}
 
 	return secret.Data[u.Spec.AdminSecret.Key], nil
 }
 
-// GetApiClient returns an Unleash API client for the Unleash instance.
-func (u *RemoteUnleash) GetApiClient(ctx context.Context, client client.Client, operatorNamespace string) (*unleash.Client, error) {
-	token, err := u.GetAdminToken(ctx, client, operatorNamespace)
+// ApiClient returns an Unleash API client for the Unleash instance.
+func (u *RemoteUnleash) ApiClient(ctx context.Context, client client.Client, operatorNamespace string) (*unleash.Client, error) {
+	token, err := u.AdminToken(ctx, client, operatorNamespace)
 	if err != nil {
 		return nil, err
 	}
 
-	return unleash.NewClient(u.GetURL(), string(token))
+	return unleash.NewClient(u.URL(), string(token))
 }
 
 // IsReady returns true if the Unleash instance is ready.

--- a/api/v1/remoteunleash_types.go
+++ b/api/v1/remoteunleash_types.go
@@ -102,6 +102,14 @@ func (u *RemoteUnleash) URL() string {
 	return u.Spec.Server.URL
 }
 
+// NamespacedName returns the namespaced name of the Unleash instance.
+func (u *RemoteUnleash) NamespacedName() types.NamespacedName {
+	return types.NamespacedName{
+		Name:      u.Name,
+		Namespace: u.Namespace,
+	}
+}
+
 // AdminSecretNamespacedName returns the namespaced name of the secret containing the Unleash instance's API token.
 func (u *RemoteUnleash) AdminSecretNamespacedName() types.NamespacedName {
 	namespacedName := types.NamespacedName{

--- a/api/v1/unleash_types.go
+++ b/api/v1/unleash_types.go
@@ -283,11 +283,11 @@ func (u *Unleash) GetOperatorSecretName() string {
 	return fmt.Sprintf("%s-%s-%s-admin-key", UnleashSecretNamePrefix, u.Namespace, u.Name)
 }
 
-func (u *Unleash) GetURL() string {
+func (u *Unleash) URL() string {
 	return fmt.Sprintf("http://%s.%s", u.Name, u.Namespace)
 }
 
-func (u *Unleash) GetAdminToken(ctx context.Context, client client.Client, operatorNamespace string) ([]byte, error) {
+func (u *Unleash) AdminToken(ctx context.Context, client client.Client, operatorNamespace string) ([]byte, error) {
 	secret := &corev1.Secret{}
 
 	err := client.Get(ctx, u.NamespacedOperatorSecretName(operatorNamespace), secret)
@@ -298,13 +298,13 @@ func (u *Unleash) GetAdminToken(ctx context.Context, client client.Client, opera
 	return secret.Data[UnleashSecretTokenKey], nil
 }
 
-func (u *Unleash) GetApiClient(ctx context.Context, client client.Client, operatorNamespace string) (*unleashclient.Client, error) {
-	token, err := u.GetAdminToken(ctx, client, operatorNamespace)
+func (u *Unleash) ApiClient(ctx context.Context, client client.Client, operatorNamespace string) (*unleashclient.Client, error) {
+	token, err := u.AdminToken(ctx, client, operatorNamespace)
 	if err != nil {
 		return nil, err
 	}
 
-	return unleashclient.NewClient(u.GetURL(), string(token))
+	return unleashclient.NewClient(u.URL(), string(token))
 }
 
 // IsReady returns true if the Unleash instance is ready.

--- a/api/v1/unleash_types_test.go
+++ b/api/v1/unleash_types_test.go
@@ -18,8 +18,8 @@ func TestUnleashURL(t *testing.T) {
 		},
 	}
 
-	if unleash.GetURL() != "http://test.test" {
-		t.Errorf("Expected URL to be http://test.test, got %s", unleash.GetURL())
+	if unleash.URL() != "http://test.test" {
+		t.Errorf("Expected URL to be http://test.test, got %s", unleash.URL())
 	}
 }
 

--- a/controllers/apitoken_controller.go
+++ b/controllers/apitoken_controller.go
@@ -139,7 +139,7 @@ func (r *ApiTokenReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	}
 
 	// Get Unleash API client
-	apiClient, err := unleash.GetApiClient(ctx, r.Client, r.OperatorNamespace)
+	apiClient, err := unleash.ApiClient(ctx, r.Client, r.OperatorNamespace)
 	if err != nil {
 		reason := "UnleashClientFailed"
 		message := "Failed to create Unleash client"
@@ -238,7 +238,7 @@ func (r *ApiTokenReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 			},
 			Data: map[string][]byte{
 				unleashv1.ApiTokenSecretTokenEnv:  []byte(apiToken.Secret),
-				unleashv1.ApiTokenSecretServerEnv: []byte(unleash.GetURL()),
+				unleashv1.ApiTokenSecretServerEnv: []byte(unleash.URL()),
 			},
 		}
 
@@ -304,6 +304,11 @@ func (r *ApiTokenReconciler) updateStatusSuccess(ctx context.Context, apiToken *
 
 	apiToken.Status.Created = true
 	apiToken.Status.Failed = false
+
+	if err := r.Get(ctx, types.NamespacedName{Name: apiToken.Spec.UnleashInstance.Name, Namespace: apiToken.Namespace}, apiToken); err != nil {
+		log.Error(err, "Failed to get ApiToken")
+		return err
+	}
 
 	meta.SetStatusCondition(&apiToken.Status.Conditions, metav1.Condition{
 		Type:    unleashv1.ApiTokenStatusConditionTypeCreated,

--- a/controllers/apitoken_controller.go
+++ b/controllers/apitoken_controller.go
@@ -305,7 +305,7 @@ func (r *ApiTokenReconciler) updateStatusSuccess(ctx context.Context, apiToken *
 	apiToken.Status.Created = true
 	apiToken.Status.Failed = false
 
-	if err := r.Get(ctx, types.NamespacedName{Name: apiToken.Spec.UnleashInstance.Name, Namespace: apiToken.Namespace}, apiToken); err != nil {
+	if err := r.Get(ctx, apiToken.NamespacedName(), apiToken); err != nil {
 		log.Error(err, "Failed to get ApiToken")
 		return err
 	}

--- a/controllers/apitoken_controller_test.go
+++ b/controllers/apitoken_controller_test.go
@@ -4,14 +4,15 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
+	"time"
+
 	"github.com/jarcoal/httpmock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"net/http"
-	"time"
 
 	unleashv1 "github.com/nais/unleasherator/api/v1"
 	"github.com/nais/unleasherator/pkg/unleash"
@@ -284,6 +285,98 @@ var _ = Describe("ApiToken controller", func() {
 				info := httpmock.GetCallCountInfo()
 				return info["DELETE =~http://unleash.nais.io/api/admin/api-tokens/.*"]
 			}, timeout, interval).ShouldNot(BeZero())
+		})
+
+		It("Should create secret when ApiToken exists in Unleash but not in Kubernetes", func() {
+			ctx := context.Background()
+
+			apiTokenName := "test-apitoken-exists"
+			apiTokenLookupKey := types.NamespacedName{Name: apiTokenName, Namespace: ApiTokenNamespace}
+			apiTokenSecret := "*:*.be44368985f7fb3237c584ef86f3d6bdada42ddbd63a019d26955178"
+
+			By("Mocking RemoteUnleash endpoints")
+			httpmock.Activate()
+			defer httpmock.DeactivateAndReset()
+			httpmock.RegisterResponder("GET", fmt.Sprintf("%s/health", ApiTokenServerURL),
+				httpmock.NewStringResponder(200, `{"health": "GOOD"}`))
+			httpmock.RegisterResponder("GET", fmt.Sprintf("%s/api/admin/api-tokens", ApiTokenServerURL),
+				func(req *http.Request) (*http.Response, error) {
+					resp, err := httpmock.NewJsonResponse(200, unleash.ApiTokenResult{
+						Tokens: []unleash.ApiToken{
+							{
+								Secret:      apiTokenSecret,
+								Username:    fmt.Sprintf("%s-%s", apiTokenName, ApiTokenNameSuffix),
+								Type:        "client",
+								Environment: "*",
+								Project:     "*",
+								Projects:    []string{},
+								ExpiresAt:   time.Now().UTC().AddDate(0, 0, 1).Format(time.RFC3339),
+								CreatedAt:   time.Now().UTC().Format(time.RFC3339),
+							},
+						},
+					})
+					if err != nil {
+						return httpmock.NewStringResponse(500, ""), nil
+					}
+					return resp, nil
+				})
+
+			By("By creating a new RemoteUnleash")
+			createdRemoteUnleashSecret := remoteUnleashSecretResource(apiTokenName, ApiTokenNamespace, apiTokenSecret)
+			Expect(k8sClient.Create(ctx, createdRemoteUnleashSecret)).Should(Succeed())
+
+			remoteUnleashLookupKey, createdRemoteUnleash := remoteUnleashResource(apiTokenName, ApiTokenNamespace, ApiTokenServerURL, createdRemoteUnleashSecret)
+			Expect(k8sClient.Create(ctx, createdRemoteUnleash)).Should(Succeed())
+
+			Eventually(func() ([]metav1.Condition, error) {
+				err := k8sClient.Get(ctx, remoteUnleashLookupKey, createdRemoteUnleash)
+				if err != nil {
+					return nil, err
+				}
+
+				// unset condition.LastTransitionTime to make comparison easier
+				unsetConditionLastTransitionTime(createdRemoteUnleash.Status.Conditions)
+
+				return createdRemoteUnleash.Status.Conditions, nil
+			}, timeout, interval).Should(ContainElement(metav1.Condition{
+				Type:    unleashv1.UnleashStatusConditionTypeConnected,
+				Status:  metav1.ConditionTrue,
+				Reason:  "Reconciling",
+				Message: "Successfully connected to Unleash",
+			}))
+
+			By("By creating a new ApiToken")
+			createdApiToken := remoteUnleashApiTokenResource(apiTokenName, ApiTokenNamespace, apiTokenName, createdRemoteUnleash)
+			Expect(k8sClient.Create(ctx, createdApiToken)).Should(Succeed())
+
+			Eventually(func() ([]metav1.Condition, error) {
+				err := k8sClient.Get(ctx, apiTokenLookupKey, createdApiToken)
+				if err != nil {
+					return nil, err
+				}
+
+				// unset condition.LastTransitionTime to make comparison easier
+				unsetConditionLastTransitionTime(createdApiToken.Status.Conditions)
+
+				return createdApiToken.Status.Conditions, nil
+			}, timeout, interval).Should(ContainElement(metav1.Condition{
+				Type:    unleashv1.ApiTokenStatusConditionTypeCreated,
+				Status:  metav1.ConditionTrue,
+				Reason:  "Reconciling",
+				Message: "API token successfully created",
+			}))
+
+			By("By checking that the ApiToken secret has been created")
+			createdApiTokenSecret := &corev1.Secret{}
+			Expect(k8sClient.Get(ctx, apiTokenLookupKey, createdApiTokenSecret)).Should(Succeed())
+
+			Expect(createdApiTokenSecret.Data).Should(HaveKey(unleashv1.ApiTokenSecretTokenEnv))
+			Expect(createdApiTokenSecret.Data[unleashv1.ApiTokenSecretTokenEnv]).ShouldNot(BeEmpty())
+			Expect(createdApiTokenSecret.Data[unleashv1.ApiTokenSecretTokenEnv]).Should(Equal([]byte(apiTokenSecret)))
+
+			Expect(createdApiTokenSecret.Data).Should(HaveKey(unleashv1.ApiTokenSecretServerEnv))
+			Expect(createdApiTokenSecret.Data[unleashv1.ApiTokenSecretServerEnv]).ShouldNot(BeEmpty())
+			Expect(createdApiTokenSecret.Data[unleashv1.ApiTokenSecretServerEnv]).Should(Equal([]byte(ApiTokenServerURL)))
 		})
 	})
 })

--- a/controllers/interfaces.go
+++ b/controllers/interfaces.go
@@ -9,7 +9,7 @@ import (
 
 type UnleashInstance interface {
 	IsReady() bool
-	GetURL() string
-	GetAdminToken(context.Context, client.Client, string) ([]byte, error)
-	GetApiClient(context.Context, client.Client, string) (*unleash.Client, error)
+	URL() string
+	AdminToken(context.Context, client.Client, string) ([]byte, error)
+	ApiClient(context.Context, client.Client, string) (*unleash.Client, error)
 }

--- a/controllers/remoteunleash_controller.go
+++ b/controllers/remoteunleash_controller.go
@@ -141,7 +141,7 @@ func (r *RemoteUnleashReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	}
 
 	// Get admin token from secret
-	adminToken, err := remoteUnleash.GetAdminToken(ctx, r.Client, r.OperatorNamespace)
+	adminToken, err := remoteUnleash.AdminToken(ctx, r.Client, r.OperatorNamespace)
 	if err != nil {
 		if err := r.updateStatusReconcileFailed(ctx, remoteUnleash, err, "Failed to get admin token secret"); err != nil {
 			return ctrl.Result{}, err

--- a/controllers/remoteunleash_controller.go
+++ b/controllers/remoteunleash_controller.go
@@ -254,6 +254,11 @@ func (r *RemoteUnleashReconciler) updateStatusReconcileFailed(ctx context.Contex
 func (r *RemoteUnleashReconciler) updateStatus(ctx context.Context, remoteUnleash *unleashv1.RemoteUnleash, status metav1.Condition) error {
 	log := log.FromContext(ctx)
 
+	if err := r.Get(ctx, remoteUnleash.NamespacedName(), remoteUnleash); err != nil {
+		log.Error(err, "Failed to get RemoteUnleash")
+		return err
+	}
+
 	switch status.Type {
 	case unleashv1.UnleashStatusConditionTypeReconciled:
 		remoteUnleash.Status.Reconciled = status.Status == metav1.ConditionTrue

--- a/controllers/unleash_controller.go
+++ b/controllers/unleash_controller.go
@@ -626,7 +626,7 @@ func (r *UnleashReconciler) reconcileService(ctx context.Context, unleash *unlea
 
 // testConnection will test the connection to the Unleash instance
 func (r *UnleashReconciler) testConnection(unleash *unleashv1.Unleash, ctx context.Context, log logr.Logger) error {
-	client, err := unleash.GetApiClient(ctx, r.Client, r.OperatorNamespace)
+	client, err := unleash.ApiClient(ctx, r.Client, r.OperatorNamespace)
 	if err != nil {
 		log.Error(err, "Failed to set up client for Unleash")
 		return err

--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -4,12 +4,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func unsetConditionLastTransitionTime(conditions []metav1.Condition) {
-	for i := range conditions {
-		conditions[i].LastTransitionTime = metav1.Time{}
-	}
-}
-
 func promGaugeValueForStatus(status metav1.ConditionStatus) float64 {
 	if status == metav1.ConditionTrue {
 		return 1

--- a/controllers/utils_test.go
+++ b/controllers/utils_test.go
@@ -1,0 +1,77 @@
+package controllers
+
+import (
+	"fmt"
+
+	unleashv1 "github.com/nais/unleasherator/api/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func remoteUnleashSecretResource(name, namespace, token string) *corev1.Secret {
+	return &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Secret",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("unleasherator-%s", name),
+			Namespace: namespace,
+		},
+		Data: map[string][]byte{
+			"token": []byte(token),
+		},
+	}
+}
+
+func remoteUnleashResource(name, namespace, url string, secret *corev1.Secret) (types.NamespacedName, *unleashv1.RemoteUnleash) {
+	lookupKey := types.NamespacedName{Name: name, Namespace: namespace}
+	remoteUnleash := &unleashv1.RemoteUnleash{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "unleash.nais.io/v1",
+			Kind:       "RemoteUnleash",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      lookupKey.Name,
+			Namespace: lookupKey.Namespace,
+		},
+		Spec: unleashv1.RemoteUnleashSpec{
+			Server: unleashv1.RemoteUnleashServer{
+				URL: url,
+			},
+			AdminSecret: unleashv1.RemoteUnleashSecret{
+				Name: secret.Name,
+			},
+		},
+	}
+
+	return lookupKey, remoteUnleash
+}
+
+func remoteUnleashApiTokenResource(name, namespace, secretName string, remoteUnleash *unleashv1.RemoteUnleash) *unleashv1.ApiToken {
+	return &unleashv1.ApiToken{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "unleash.nais.io/v1",
+			Kind:       "ApiToken",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: unleashv1.ApiTokenSpec{
+			UnleashInstance: unleashv1.ApiTokenUnleashInstance{
+				ApiVersion: "unleash.nais.io/v1",
+				Kind:       "RemoteUnleash",
+				Name:       remoteUnleash.Name,
+			},
+			SecretName: secretName,
+		},
+	}
+}
+
+func unsetConditionLastTransitionTime(conditions []metav1.Condition) {
+	for i := range conditions {
+		conditions[i].LastTransitionTime = metav1.Time{}
+	}
+}

--- a/pkg/unleash/admin_api.go
+++ b/pkg/unleash/admin_api.go
@@ -92,7 +92,7 @@ func (c *Client) CreateAPIToken(req ApiTokenRequest) (*ApiToken, error) {
 	return res, nil
 }
 
-// GetAllAPITokens returns all API tokens (admin only endpoint - requires admin token).
+// GetAllAPITokens returns all API tokens.
 // https://docs.getunleash.io/reference/api/unleash/get-all-api-tokens
 func (c *Client) GetAllAPITokens() (*ApiTokenResult, error) {
 	res := &ApiTokenResult{}
@@ -105,20 +105,28 @@ func (c *Client) GetAllAPITokens() (*ApiTokenResult, error) {
 	return res, nil
 }
 
-// CheckAPITokenExists checks if an API token with the given username exists.
-func (c *Client) CheckAPITokenExists(userName string) (bool, error) {
+// GetAPIToken returns an API token with the given username.
+func (c *Client) GetAPIToken(userName string) (*ApiToken, error) {
 	tokens, err := c.GetAllAPITokens()
 	if err != nil {
-		return false, err
+		return nil, err
 	}
 
 	for _, t := range tokens.Tokens {
 		if t.Username == userName {
-			return true, nil
+			return &t, nil
 		}
 	}
 
-	return false, nil
+	return nil, nil
+}
+
+// CheckAPITokenExists checks if an API token with the given username exists.
+func (c *Client) CheckAPITokenExists(userName string) (bool, error) {
+	token, err := c.GetAPIToken(userName)
+	exists := token != nil
+
+	return exists, err
 }
 
 func (c *Client) DeleteApiToken(tokenString string) error {


### PR DESCRIPTION
- Make handler functions more readable
- Refresh token before updating status

Close #16 