### PR TITLE
dependabot: pin kubernetes specific packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,7 @@ updates:
       - dependency-name: "k8s.io/apimachinery"
       - dependency-name: "k8s.io/client-go"
       - dependency-name: "sigs.k8s.io/controller-runtime"
+      - dependency-name: "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,12 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    ignore:
+      # These pacakges are dependent on the Kubernetes version we are targeting
+      - dependency-name: "k8s.io/api"
+      - dependency-name: "k8s.io/apimachinery"
+      - dependency-name: "k8s.io/client-go"
+      - dependency-name: "sigs.k8s.io/controller-runtime"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
Ignore packages that are dependent on Kubernetes version from being updated by Dependabot.