### PR TITLE
Fix federation error when remote object already exists

### DIFF
--- a/.github/workflows/chart.yaml
+++ b/.github/workflows/chart.yaml
@@ -76,7 +76,7 @@ jobs:
 
   lint-test:
     name: Lint and test
-    runs-on: ubuntu-latest-4-cores
+    runs-on: ubuntu-latest-16-cores
     needs: meta
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -36,7 +36,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-16-cores
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -116,7 +116,7 @@ jobs:
           key: ${{ runner.os }}-bin-${{ hashFiles('Makefile', 'go.mod') }}
   docker:
     name: Build and Push Docker image
-    runs-on: ubuntu-latest-4-cores
+    runs-on: ubuntu-latest-16-cores
     needs: [meta, lint, build]
     steps:
       - uses: actions/checkout@v3

--- a/controllers/remoteunleash_controller_test.go
+++ b/controllers/remoteunleash_controller_test.go
@@ -128,7 +128,7 @@ var _ = Describe("RemoteUnleash controller", func() {
 			httpmock.RegisterResponder("GET", unleashclient.InstanceAdminStatsEndpoint,
 				httpmock.NewStringResponder(200, `{"versionOSS": "v4.0.0"}`))
 
-			var remoteUnleashes []client.Object
+			var remoteUnleashes []*unleashv1.RemoteUnleash
 
 			By("By creating a new RemoteUnleash that does not match cluster")
 			name := "test-unleash-other-cluster"
@@ -136,7 +136,7 @@ var _ = Describe("RemoteUnleash controller", func() {
 			clusters := []string{"some-cluster"}
 			secret := remoteUnleashSecretResource(name, namespaces[0], "test")
 			_, remoteUnleash := remoteUnleashResource(name, namespaces[0], "http://unleash-1.nais.io", secret)
-			remoteUnleashes = append([]client.Object{}, remoteUnleash)
+			remoteUnleashes = append([]*unleashv1.RemoteUnleash{}, remoteUnleash)
 
 			err := handler(ctx, remoteUnleashes, secret, clusters, pb.Status_Provisioned)
 			Expect(err).ToNot(HaveOccurred())
@@ -149,7 +149,7 @@ var _ = Describe("RemoteUnleash controller", func() {
 			clusters = []string{"test-cluster"}
 			secret = remoteUnleashSecretResource(name, namespaces[0], "test")
 			_, remoteUnleash = remoteUnleashResource(name, namespaces[0], "http://unleash-1.nais.io", secret)
-			remoteUnleashes = append([]client.Object{}, remoteUnleash)
+			remoteUnleashes = append([]*unleashv1.RemoteUnleash{}, remoteUnleash)
 
 			err = handler(ctx, remoteUnleashes, secret, clusters, pb.Status_Provisioned)
 			Expect(err).ToNot(HaveOccurred())
@@ -157,6 +157,17 @@ var _ = Describe("RemoteUnleash controller", func() {
 			Expect(k8sClient.Get(ctx, remoteUnleash.NamespacedName(), remoteUnleash)).Should(Succeed())
 
 			By("By updating an existing RemoteUnleash that matches cluster")
+			name = "test-unleash-same-cluster"
+			namespaces = []string{"default"}
+			clusters = []string{"test-cluster"}
+			secret = remoteUnleashSecretResource(name, namespaces[0], "test")
+			_, remoteUnleash = remoteUnleashResource(name, namespaces[0], "http://unleash-1.nais.io", secret)
+			remoteUnleashes = append([]*unleashv1.RemoteUnleash{}, remoteUnleash)
+
+			err = handler(ctx, remoteUnleashes, secret, clusters, pb.Status_Provisioned)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(k8sClient.Get(ctx, remoteUnleash.NamespacedName(), remoteUnleash)).Should(Succeed())
 		})
 	})
 })

--- a/controllers/remoteunleash_controller_test.go
+++ b/controllers/remoteunleash_controller_test.go
@@ -136,7 +136,7 @@ var _ = Describe("RemoteUnleash controller", func() {
 			clusters := []string{"some-cluster"}
 			secret := remoteUnleashSecretResource(name, namespaces[0], "test")
 			_, remoteUnleash := remoteUnleashResource(name, namespaces[0], "http://unleash-1.nais.io", secret)
-			remoteUnleashes = append([]*unleashv1.RemoteUnleash{}, remoteUnleash)
+			remoteUnleashes = []*unleashv1.RemoteUnleash{remoteUnleash}
 
 			err := handler(ctx, remoteUnleashes, secret, clusters, pb.Status_Provisioned)
 			Expect(err).ToNot(HaveOccurred())
@@ -149,7 +149,7 @@ var _ = Describe("RemoteUnleash controller", func() {
 			clusters = []string{"test-cluster"}
 			secret = remoteUnleashSecretResource(name, namespaces[0], "test")
 			_, remoteUnleash = remoteUnleashResource(name, namespaces[0], "http://unleash-1.nais.io", secret)
-			remoteUnleashes = append([]*unleashv1.RemoteUnleash{}, remoteUnleash)
+			remoteUnleashes = []*unleashv1.RemoteUnleash{remoteUnleash}
 
 			err = handler(ctx, remoteUnleashes, secret, clusters, pb.Status_Provisioned)
 			Expect(err).ToNot(HaveOccurred())
@@ -162,7 +162,7 @@ var _ = Describe("RemoteUnleash controller", func() {
 			clusters = []string{"test-cluster"}
 			secret = remoteUnleashSecretResource(name, namespaces[0], "test")
 			_, remoteUnleash = remoteUnleashResource(name, namespaces[0], "http://unleash-1.nais.io", secret)
-			remoteUnleashes = append([]*unleashv1.RemoteUnleash{}, remoteUnleash)
+			remoteUnleashes = []*unleashv1.RemoteUnleash{remoteUnleash}
 
 			err = handler(ctx, remoteUnleashes, secret, clusters, pb.Status_Provisioned)
 			Expect(err).ToNot(HaveOccurred())

--- a/controllers/remoteunleash_controller_test.go
+++ b/controllers/remoteunleash_controller_test.go
@@ -164,8 +164,9 @@ var _ = Describe("RemoteUnleash controller", func() {
 			_, remoteUnleash = remoteUnleashResource(name, namespaces[0], "http://unleash-1.nais.io", secret)
 			remoteUnleashes = []*unleashv1.RemoteUnleash{remoteUnleash}
 
-			err = handler(ctx, remoteUnleashes, secret, clusters, pb.Status_Provisioned)
-			Expect(err).ToNot(HaveOccurred())
+			Eventually(func() error {
+				return handler(ctx, remoteUnleashes, secret, clusters, pb.Status_Provisioned)
+			}, timeout, interval).ShouldNot(HaveOccurred())
 
 			Expect(k8sClient.Get(ctx, remoteUnleash.NamespacedName(), remoteUnleash)).Should(Succeed())
 		})

--- a/pkg/federation/subscriber.go
+++ b/pkg/federation/subscriber.go
@@ -9,8 +9,9 @@ import (
 	"github.com/nais/unleasherator/pkg/resources"
 	"google.golang.org/protobuf/proto"
 	corev1 "k8s.io/api/core/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	unleashv1 "github.com/nais/unleasherator/api/v1"
 )
 
 type Subscriber interface {
@@ -18,7 +19,7 @@ type Subscriber interface {
 	Close() error
 }
 
-type Handler func(ctx context.Context, remoteUnleash []client.Object, adminSecret *corev1.Secret, clusters []string, status pb.Status) error
+type Handler func(ctx context.Context, remoteUnleash []*unleashv1.RemoteUnleash, adminSecret *corev1.Secret, clusters []string, status pb.Status) error
 
 type subscriber struct {
 	client            *pubsub.Client

--- a/pkg/resources/remoteunleash.go
+++ b/pkg/resources/remoteunleash.go
@@ -3,10 +3,9 @@ package resources
 import (
 	unleashv1 "github.com/nais/unleasherator/api/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func RemoteunleashInstance(name, url, namespace, secretName, secretNamespace string) client.Object {
+func RemoteunleashInstance(name, url, namespace, secretName, secretNamespace string) *unleashv1.RemoteUnleash {
 	return &unleashv1.RemoteUnleash{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "RemoteUnleash",
@@ -29,8 +28,8 @@ func RemoteunleashInstance(name, url, namespace, secretName, secretNamespace str
 	}
 }
 
-func RemoteunleashInstances(name, url string, namespaces []string, secretName, secretNamespace string) []client.Object {
-	resources := make([]client.Object, 0, len(namespaces))
+func RemoteunleashInstances(name, url string, namespaces []string, secretName, secretNamespace string) []*unleashv1.RemoteUnleash {
+	resources := make([]*unleashv1.RemoteUnleash, 0, len(namespaces))
 	for _, namespace := range namespaces {
 		resources = append(resources, RemoteunleashInstance(name, url, namespace, secretName, secretNamespace))
 	}

--- a/pkg/resources/remoteunleash_test.go
+++ b/pkg/resources/remoteunleash_test.go
@@ -9,8 +9,7 @@ import (
 
 // test the RemoteunleashInstance function
 func TestRemoteunleashInstance(t *testing.T) {
-	object := RemoteunleashInstance("name", "url", "namespace", "secretName", "secretNamespace")
-	remoteUnleash := object.(*unleashv1.RemoteUnleash)
+	remoteUnleash := RemoteunleashInstance("name", "url", "namespace", "secretName", "secretNamespace")
 
 	assert.Equal(t, "name", remoteUnleash.GetName())
 	assert.Equal(t, "namespace", remoteUnleash.GetNamespace())
@@ -39,6 +38,6 @@ func TestRemoteunleashInstances(t *testing.T) {
 	assert.Equal(t, len(namespaces), len(resources))
 
 	for i := 0; i < len(namespaces); i++ {
-		assertPair(resources[i].(*unleashv1.RemoteUnleash), namespaces[i])
+		assertPair(resources[i], namespaces[i])
 	}
 }

--- a/pkg/utils/k8s.go
+++ b/pkg/utils/k8s.go
@@ -1,7 +1,12 @@
 package utils
 
 import (
+	"context"
+
 	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
 // envVar returns an environment variable for the given name and value
@@ -25,4 +30,37 @@ func SecretEnvVar(name, secretName, secretKey string) corev1.EnvVar {
 			},
 		},
 	}
+}
+
+// UpsertObject upserts the given object in Kubernetes. If the object already exists, it is updated.
+// If the object does not exist, it is created. The object is identified by its key, which is extracted
+// from the object itself. The function returns an error if the upsert operation fails.
+func UpsertObject[T client.Object](ctx context.Context, r client.Client, obj T) error {
+	objectKey := client.ObjectKeyFromObject(obj)
+	existing := obj.DeepCopyObject().(T)
+
+	err := r.Get(ctx, objectKey, existing)
+	if apierrors.IsNotFound(err) {
+		return r.Create(ctx, obj)
+	} else if err != nil {
+		return err
+	}
+
+	obj.SetCreationTimestamp(existing.GetCreationTimestamp())
+	obj.SetResourceVersion(existing.GetResourceVersion())
+	obj.SetUID(existing.GetUID())
+
+	return r.Update(ctx, obj)
+}
+
+// UpsertAllObjects upserts all objects in the given slice to the Kubernetes API server.
+// If an error occurs while upserting an object, the function returns the error and stops upserting.
+func UpsertAllObjects[T client.Object](ctx context.Context, r client.Client, objects []T) error {
+	for _, obj := range objects {
+		err := UpsertObject(ctx, r, obj)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
```
2023-08-14T14:38:16Z    ERROR   subscribe       nack message    {"error": "secrets \"unleasherator-team1-xxxxxxxx\" already exists"}
github.com/nais/unleasherator/pkg/federation.(*subscriber).Subscribe.func1
        /workspace/pkg/federation/subscriber.go:47
cloud.google.com/go/pubsub.(*Subscription).Receive.func2.2
        /go/pkg/mod/cloud.google.com/go/pubsub@v1.33.0/subscription.go:1410
cloud.google.com/go/pubsub/internal/scheduler.(*ReceiveScheduler).Add.func2
        /go/pkg/mod/cloud.google.com/go/pubsub@v1.33.0/internal/scheduler/receive_scheduler.go:97
cloud.google.com/go/pubsub/internal/scheduler.(*ReceiveScheduler).Add.func3
        /go/pkg/mod/cloud.google.com/go/pubsub@v1.33.0/internal/scheduler/receive_scheduler.go:126
```
