### PR TITLE
Add Dependabot groups for kubernetes and prometheus packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,17 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    groups:
+      k8s-core:
+        patterns:
+          - "k8s.io/*"
+      k8s-controller:
+        patterns:
+          - "sigs.k8s.io/controller-runtime/*"
+          - "sigs.k8s.io/controller-tools/*"
+      prometheus:
+        patterns:
+          - "github.com/prometheus/*"
     ignore:
       # These pacakges are dependent on the Kubernetes version we are targeting
       - dependency-name: "k8s.io/api"


### PR DESCRIPTION
Add the following dependabot groups:

* `k8s-core`
* `k8s-controller`
* `prometheus`

https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups
