### PR TITLE
Use App Token for Dependabot Auto-merge

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -2,22 +2,32 @@ name: Dependabot auto-merge
 on: pull_request
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
+  pull-requests: read
 
 jobs:
   dependabot:
     runs-on: ubuntu-latest
     if: ${{ github.actor == 'dependabot[bot]' }}
     steps:
+      - name: Generate token
+        id: generate_token
+        uses: tibdex/github-app-token@v2.1.0
+        with:
+          app_id: "${{ secrets.DEPENDABOT_AUTO_MERGE_APP_ID}}"
+          private_key: "${{ secrets.DEPENDABOT_AUTO_MERGE_APP_SECRET }}"
+
       - name: Dependabot metadata
         id: metadata
         uses: dependabot/fetch-metadata@v1.6.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Authenticate cli
+        run: echo "${{ steps.generate_token.outputs.token }}" | gh auth login --with-token
+
       - name: Enable auto-merge for Dependabot PRs
         if: steps.metadata.outputs.update-type != 'version-update:semver-major'
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
When using the `secrets.GITHUB_TOKEN` token to auto-merge pull requests
subsequent workflow actions are not triggered. The solution is to use a GitHub
App instead.

Related: https://github.com/dependabot/fetch-metadata/issues/111

Close #246
