### PR TITLE
apiToken: add token env to secret

### DIFF
--- a/api/v1/meta.go
+++ b/api/v1/meta.go
@@ -34,4 +34,5 @@ const (
 
 	ApiTokenSecretTokenEnv  = "UNLEASH_SERVER_API_TOKEN"
 	ApiTokenSecretServerEnv = "UNLEASH_SERVER_API_URL"
+	ApiTokenSecretEnvEnv    = "UNLEASH_SERVER_API_ENV"
 )

--- a/controllers/apitoken_controller_test.go
+++ b/controllers/apitoken_controller_test.go
@@ -198,6 +198,10 @@ var _ = Describe("ApiToken controller", func() {
 			Expect(createdApiTokenSecret.Data[unleashv1.ApiTokenSecretServerEnv]).ShouldNot(BeEmpty())
 			Expect(createdApiTokenSecret.Data[unleashv1.ApiTokenSecretServerEnv]).Should(Equal([]byte(ApiTokenServerURL)))
 
+			Expect(createdApiTokenSecret.Data).Should(HaveKey(unleashv1.ApiTokenSecretEnvEnv))
+			Expect(createdApiTokenSecret.Data[unleashv1.ApiTokenSecretEnvEnv]).ShouldNot(BeEmpty())
+			Expect(createdApiTokenSecret.Data[unleashv1.ApiTokenSecretEnvEnv]).Should(Equal([]byte("development")))
+
 			Expect(promGaugeVecVal(apiTokenStatus, ApiTokenNamespace, apiTokenName, unleashv1.ApiTokenStatusConditionTypeCreated)).Should(Equal(1.0))
 			Expect(promGaugeVecVal(apiTokenStatus, ApiTokenNamespace, apiTokenName, unleashv1.ApiTokenStatusConditionTypeFailed)).Should(Equal(0.0))
 
@@ -231,7 +235,7 @@ var _ = Describe("ApiToken controller", func() {
 								Secret:      apiTokenSecret,
 								Username:    fmt.Sprintf("%s-%s", apiTokenName, ApiTokenNameSuffix),
 								Type:        "client",
-								Environment: "*",
+								Environment: "development",
 								Project:     "*",
 								Projects:    []string{},
 								ExpiresAt:   time.Now().UTC().AddDate(0, 0, 1).Format(time.RFC3339),
@@ -301,6 +305,10 @@ var _ = Describe("ApiToken controller", func() {
 			Expect(createdApiTokenSecret.Data).Should(HaveKey(unleashv1.ApiTokenSecretServerEnv))
 			Expect(createdApiTokenSecret.Data[unleashv1.ApiTokenSecretServerEnv]).ShouldNot(BeEmpty())
 			Expect(createdApiTokenSecret.Data[unleashv1.ApiTokenSecretServerEnv]).Should(Equal([]byte(ApiTokenServerURL)))
+
+			Expect(createdApiTokenSecret.Data).Should(HaveKey(unleashv1.ApiTokenSecretEnvEnv))
+			Expect(createdApiTokenSecret.Data[unleashv1.ApiTokenSecretEnvEnv]).ShouldNot(BeEmpty())
+			Expect(createdApiTokenSecret.Data[unleashv1.ApiTokenSecretEnvEnv]).Should(Equal([]byte("development")))
 
 			Expect(promGaugeVecVal(apiTokenStatus, ApiTokenNamespace, apiTokenName, unleashv1.ApiTokenStatusConditionTypeCreated)).Should(Equal(1.0))
 			Expect(promGaugeVecVal(apiTokenStatus, ApiTokenNamespace, apiTokenName, unleashv1.ApiTokenStatusConditionTypeFailed)).Should(Equal(0.0))

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -17,6 +17,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	unleashv1 "github.com/nais/unleasherator/api/v1"
 	"github.com/nais/unleasherator/pkg/config"
@@ -81,7 +82,9 @@ var _ = BeforeSuite(func() {
 
 	k8sManager, err := ctrl.NewManager(cfg, ctrl.Options{
 		Scheme: scheme.Scheme,
-		//MetricsBindAddress: "0", // disable firewall prompt on mac
+		Metrics: server.Options{
+			BindAddress: "0", // disable firewall prompt on mac
+		},
 	})
 	Expect(err).ToNot(HaveOccurred())
 

--- a/controllers/unleash_controller.go
+++ b/controllers/unleash_controller.go
@@ -689,7 +689,7 @@ func (r *UnleashReconciler) reconcileService(ctx context.Context, unleash *unlea
 }
 
 // testConnection will test the connection to the Unleash instance
-func (r *UnleashReconciler) testConnection(unleash UnleashInstance, ctx context.Context, log logr.Logger) (*unleashclient.InstanceAdminStatsResult, error) {
+func (r *UnleashReconciler) testConnection(unleash resources.UnleashInstance, ctx context.Context, log logr.Logger) (*unleashclient.InstanceAdminStatsResult, error) {
 	client, err := unleash.ApiClient(ctx, r.Client, r.OperatorNamespace)
 	if err != nil {
 		log.Error(err, "Failed to set up client for Unleash")

--- a/docs/apitoken.md
+++ b/docs/apitoken.md
@@ -32,6 +32,7 @@ The token will be stored in secret in the same namespace as the `ApiToken` resou
 
 - `UNLEASH_SERVER_API_TOKEN` - the token itself
 - `UNLEASH_SERVER_API_URL` - the URL of the Unleash instance (remember to add `/api` to the end when authenticating to the Unleash API)
+- `UNLEASH_SERVER_API_ENV` - the environment the token is valid for. Defaults to `development` if not specified.
 
 ## Spec
 

--- a/pkg/resources/apitoken.go
+++ b/pkg/resources/apitoken.go
@@ -1,0 +1,22 @@
+package resources
+
+import (
+	unleashv1 "github.com/nais/unleasherator/api/v1"
+	"github.com/nais/unleasherator/pkg/unleashclient"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func ApiTokenSecret(unleash UnleashInstance, token *unleashv1.ApiToken, apiToken *unleashclient.ApiToken) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      token.Spec.SecretName,
+			Namespace: token.GetObjectMeta().GetNamespace(),
+		},
+		Data: map[string][]byte{
+			unleashv1.ApiTokenSecretTokenEnv:  []byte(apiToken.Secret),
+			unleashv1.ApiTokenSecretServerEnv: []byte(unleash.URL()),
+			unleashv1.ApiTokenSecretEnvEnv:    []byte(token.Spec.Environment),
+		},
+	}
+}

--- a/pkg/resources/apitoken_test.go
+++ b/pkg/resources/apitoken_test.go
@@ -1,0 +1,56 @@
+package resources
+
+import (
+	"testing"
+
+	unleashv1 "github.com/nais/unleasherator/api/v1"
+	"github.com/nais/unleasherator/pkg/unleashclient"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestApiTokenSecret(t *testing.T) {
+	unleash := unleashv1.RemoteUnleash{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-unleash",
+			Namespace: "default",
+		},
+		Spec: unleashv1.RemoteUnleashSpec{
+			Server: unleashv1.RemoteUnleashServer{
+				URL: "http://api-token-unleash.nais.io",
+			},
+		},
+	}
+
+	token := &unleashv1.ApiToken{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-apitoken",
+			Namespace: "default",
+		},
+		Spec: unleashv1.ApiTokenSpec{
+			SecretName:  "test-secret",
+			Environment: "development",
+		},
+	}
+
+	apiToken := &unleashclient.ApiToken{
+		Secret: "test-secret",
+	}
+
+	expectedSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-secret",
+			Namespace: "default",
+		},
+		Data: map[string][]byte{
+			unleashv1.ApiTokenSecretTokenEnv:  []byte("test-secret"),
+			unleashv1.ApiTokenSecretServerEnv: []byte("http://api-token-unleash.nais.io"),
+			unleashv1.ApiTokenSecretEnvEnv:    []byte("development"),
+		},
+	}
+
+	secret := ApiTokenSecret(&unleash, token, apiToken)
+
+	assert.Equal(t, expectedSecret, secret)
+}

--- a/pkg/resources/interfaces.go
+++ b/pkg/resources/interfaces.go
@@ -1,4 +1,4 @@
-package controllers
+package resources
 
 import (
 	"context"


### PR DESCRIPTION
Add api token env (as required by unleash sdk) to secret.

Close #156
