### PR TITLE
Update API token in Unleash if there are changes

### DIFF
--- a/api/v1/apitoken_types.go
+++ b/api/v1/apitoken_types.go
@@ -1,6 +1,8 @@
 package unleash_nais_io_v1
 
 import (
+	"github.com/nais/unleasherator/pkg/unleashclient"
+	"github.com/nais/unleasherator/pkg/utils"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
@@ -35,12 +37,12 @@ type ApiTokenSpec struct {
 	// Type is the type of token to create. Valid values are "CLIENT" and "FRONTEND".
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:validation:Enum=CLIENT;FRONTEND
-	// +kubebuilder:default=CLIENT
+	// +kubebuilder:default="CLIENT"
 	Type string `json:"type,omitempty"`
 
 	// Environment is the environment to create the token for.
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default=development
+	// +kubebuilder:default="development"
 	Environment string `json:"environment,omitempty"`
 
 	// Projects is the list of projects to create the token for.
@@ -96,11 +98,11 @@ type ApiTokenList struct {
 	Items           []ApiToken `json:"items"`
 }
 
-// UnleashClientName returns the name of the Unleash client for this token.
+// ApiTokenName returns the name of the Unleash client for this token.
 // The name is the same as the token name, but with a suffix. This is to avoid
 // name collisions between multiple Unleasherator instances operating on the same
 // Unleash instance.
-func (t *ApiToken) UnleashClientName(suffix string) string {
+func (t *ApiToken) ApiTokenName(suffix string) string {
 	return t.Name + "-" + suffix
 }
 
@@ -109,6 +111,21 @@ func (t *ApiToken) NamespacedName() types.NamespacedName {
 		Namespace: t.Namespace,
 		Name:      t.Name,
 	}
+}
+
+func (t *ApiToken) ApiTokenRequest(suffix string) unleashclient.ApiTokenRequest {
+	return unleashclient.ApiTokenRequest{
+		Username:    t.ApiTokenName(suffix),
+		Type:        t.Spec.Type,
+		Environment: t.Spec.Environment,
+		Projects:    t.Spec.Projects,
+	}
+}
+
+func (t *ApiToken) ApiTokenIsEqual(token *unleashclient.ApiToken) bool {
+	return t.Spec.Type == token.Type &&
+		t.Spec.Environment == token.Environment &&
+		utils.StringSliceEquals(t.Spec.Projects, token.Projects)
 }
 
 func init() {

--- a/api/v1/apitoken_types.go
+++ b/api/v1/apitoken_types.go
@@ -47,7 +47,7 @@ type ApiTokenSpec struct {
 
 	// Projects is the list of projects to create the token for.
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default={"*"}
+	// +kubebuilder:default={"default"}
 	Projects []string `json:"projects,omitempty"`
 }
 

--- a/api/v1/apitoken_types_test.go
+++ b/api/v1/apitoken_types_test.go
@@ -1,0 +1,96 @@
+package unleash_nais_io_v1
+
+import (
+	"testing"
+
+	"github.com/nais/unleasherator/pkg/unleashclient"
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func TestApiToken_ApiTokenRequest(t *testing.T) {
+	apiToken := &ApiToken{
+		Spec: ApiTokenSpec{
+			Type:        "client",
+			Environment: "development",
+			Projects:    []string{"project1", "project2"},
+		},
+	}
+
+	suffix := "suffix"
+	expectedRequest := unleashclient.ApiTokenRequest{
+		Username:    apiToken.ApiTokenName(suffix),
+		Type:        apiToken.Spec.Type,
+		Environment: apiToken.Spec.Environment,
+		Projects:    apiToken.Spec.Projects,
+	}
+
+	actualRequest := apiToken.ApiTokenRequest(suffix)
+
+	assert.Equal(t, expectedRequest, actualRequest)
+}
+
+func TestApiToken_ApiTokenName(t *testing.T) {
+	apiToken := &ApiToken{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "name",
+		},
+	}
+
+	suffix := "suffix"
+	expectedName := apiToken.Name + "-" + suffix
+
+	actualName := apiToken.ApiTokenName(suffix)
+
+	assert.Equal(t, expectedName, actualName)
+}
+func TestApiToken_NamespacedName(t *testing.T) {
+	apiToken := &ApiToken{
+		ObjectMeta: v1.ObjectMeta{
+			Namespace: "test-namespace",
+			Name:      "test-name",
+		},
+	}
+
+	expectedNamespacedName := types.NamespacedName{
+		Namespace: "test-namespace",
+		Name:      "test-name",
+	}
+
+	actualNamespacedName := apiToken.NamespacedName()
+
+	assert.Equal(t, expectedNamespacedName, actualNamespacedName)
+}
+func TestApiToken_IsEqual(t *testing.T) {
+	apiToken := &ApiToken{
+		Spec: ApiTokenSpec{
+			Type:        "client",
+			Environment: "development",
+			Projects:    []string{"project1", "project2"},
+		},
+	}
+
+	unleashToken := &unleashclient.ApiToken{
+		Type:        "client",
+		Environment: "development",
+		Projects:    []string{"project1", "project2"},
+	}
+
+	// Test when the tokens are equal
+	assert.True(t, apiToken.ApiTokenIsEqual(unleashToken))
+
+	// Test when the tokens have different types
+	unleashToken.Type = "server"
+	assert.False(t, apiToken.ApiTokenIsEqual(unleashToken))
+
+	// Test when the tokens have different environments
+	unleashToken.Type = "client"
+	unleashToken.Environment = "production"
+	assert.False(t, apiToken.ApiTokenIsEqual(unleashToken))
+
+	// Test when the tokens have different projects
+	unleashToken.Environment = "development"
+	unleashToken.Projects = []string{"project1", "project3"}
+	assert.False(t, apiToken.ApiTokenIsEqual(unleashToken))
+}

--- a/api/v1/meta.go
+++ b/api/v1/meta.go
@@ -32,7 +32,9 @@ const (
 	UnleashSecretNamePrefix = "unleasherator"
 	UnleashSecretTokenKey   = "token"
 
-	ApiTokenSecretTokenEnv  = "UNLEASH_SERVER_API_TOKEN"
-	ApiTokenSecretServerEnv = "UNLEASH_SERVER_API_URL"
-	ApiTokenSecretEnvEnv    = "UNLEASH_SERVER_API_ENV"
+	ApiTokenSecretTokenEnv    = "UNLEASH_SERVER_API_TOKEN"
+	ApiTokenSecretServerEnv   = "UNLEASH_SERVER_API_URL"
+	ApiTokenSecretEnvEnv      = "UNLEASH_SERVER_API_ENV"
+	ApiTokenSecretTypeEnv     = "UNLEASH_SERVER_API_TYPE"
+	ApiTokenSecretProjectsEnv = "UNLEASH_SERVER_API_PROJECTS"
 )

--- a/api/v1/unleash_types_test.go
+++ b/api/v1/unleash_types_test.go
@@ -5,23 +5,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
-
-func TestUnleashURL(t *testing.T) {
-	unleash := Unleash{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test",
-			Namespace: "test",
-		},
-		Spec: UnleashSpec{
-			Size: 1,
-		},
-	}
-
-	if unleash.URL() != "http://test.test" {
-		t.Errorf("Expected URL to be http://test.test, got %s", unleash.URL())
-	}
-}
 
 func TestUnleashIsReady(t *testing.T) {
 	unleash := Unleash{
@@ -48,4 +33,140 @@ func TestUnleashIsReady(t *testing.T) {
 
 	unleash.Status.Conditions[1].Status = metav1.ConditionTrue
 	assert.Equal(t, unleash.IsReady(), true, "Unleash should be ready when available and connection conditions are true")
+}
+
+func TestUnleashNamespacedName(t *testing.T) {
+	unleash := Unleash{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "test",
+		},
+	}
+
+	expected := types.NamespacedName{
+		Namespace: "test",
+		Name:      "test",
+	}
+
+	assert.Equal(t, unleash.NamespacedName(), expected, "Unexpected NamespacedName")
+}
+
+func TestUnleashNamespacedNameWithSuffix(t *testing.T) {
+	unleash := Unleash{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "test",
+		},
+	}
+
+	suffix := "suffix"
+	expected := types.NamespacedName{
+		Namespace: "test",
+		Name:      "test-suffix",
+	}
+
+	assert.Equal(t, unleash.NamespacedNameWithSuffix(suffix), expected, "Unexpected NamespacedName with suffix")
+}
+
+func TestUnleashNamespacedOperatorSecretName(t *testing.T) {
+	unleash := Unleash{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "test",
+		},
+	}
+
+	operatorNamespace := "operator-namespace"
+	expected := types.NamespacedName{
+		Namespace: operatorNamespace,
+		Name:      unleash.GetOperatorSecretName(),
+	}
+
+	assert.Equal(t, unleash.NamespacedOperatorSecretName(operatorNamespace), expected, "Unexpected NamespacedName for operator secret")
+}
+
+func TestUnleashNamespacedInstanceSecretName(t *testing.T) {
+	unleash := Unleash{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "test",
+		},
+	}
+
+	expected := types.NamespacedName{
+		Namespace: "test",
+		Name:      unleash.GetInstanceSecretName(),
+	}
+
+	assert.Equal(t, unleash.NamespacedInstanceSecretName(), expected, "Unexpected NamespacedName for instance secret")
+}
+
+func TestUnleashGetInstanceSecretName(t *testing.T) {
+	unleash := Unleash{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "test",
+		},
+	}
+
+	expected := "unleasherator-test-admin-key"
+	assert.Equal(t, unleash.GetInstanceSecretName(), expected, "Unexpected instance secret name")
+}
+
+func TestUnleashGetOperatorSecretName(t *testing.T) {
+	unleash := Unleash{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "test",
+		},
+	}
+
+	expected := "unleasherator-test-test-admin-key"
+	assert.Equal(t, unleash.GetOperatorSecretName(), expected, "Unexpected operator secret name")
+}
+
+func TestUnleashURL(t *testing.T) {
+	unleash := Unleash{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "test",
+		},
+	}
+
+	expectedURL := "http://test.test"
+	actualURL := unleash.URL()
+
+	if actualURL != expectedURL {
+		t.Errorf("Expected URL to be %s, got %s", expectedURL, actualURL)
+	}
+}
+
+func TestUnleashPublicApiURL(t *testing.T) {
+	unleash := Unleash{
+		Spec: UnleashSpec{
+			ApiIngress: UnleashIngressConfig{
+				Host: "example.com",
+			},
+		},
+	}
+
+	expectedURL := "https://example.com"
+	actualURL := unleash.PublicApiURL()
+
+	assert.Equal(t, expectedURL, actualURL, "Unexpected Public API URL")
+}
+
+func TestUnleashPublicWebURL(t *testing.T) {
+	unleash := Unleash{
+		Spec: UnleashSpec{
+			WebIngress: UnleashIngressConfig{
+				Host: "example.com",
+			},
+		},
+	}
+
+	expectedURL := "https://example.com"
+	actualURL := unleash.PublicWebURL()
+
+	assert.Equal(t, expectedURL, actualURL, "Unexpected Public Web URL")
 }

--- a/charts/unleasherator-crds/templates/apitoken-crd.yaml
+++ b/charts/unleasherator-crds/templates/apitoken-crd.yaml
@@ -56,7 +56,7 @@ spec:
                 type: string
               projects:
                 default:
-                - '*'
+                - default
                 description: Projects is the list of projects to create the token for.
                 items:
                   type: string

--- a/config/crd/bases/unleash.nais.io_apitokens.yaml
+++ b/config/crd/bases/unleash.nais.io_apitokens.yaml
@@ -55,7 +55,7 @@ spec:
                 type: string
               projects:
                 default:
-                - '*'
+                - default
                 description: Projects is the list of projects to create the token
                   for.
                 items:

--- a/controllers/apitoken_controller.go
+++ b/controllers/apitoken_controller.go
@@ -79,7 +79,7 @@ func (r *ApiTokenReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			log.Info("ApiToken resource not found. Ignoring since object must be deleted")
-			return ctrl.Result{}, nil
+			return ctrl.Result{Requeue: false}, nil
 		}
 		log.Error(err, "Failed to get ApiToken")
 		return ctrl.Result{}, err
@@ -110,6 +110,7 @@ func (r *ApiTokenReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	// Add finalizer if not present
 	if !controllerutil.ContainsFinalizer(token, tokenFinalizer) {
 		log.Info("Adding finalizer to ApiToken")
+
 		if ok := controllerutil.AddFinalizer(token, tokenFinalizer); !ok {
 			log.Error(err, "Failed to add finalizer to ApiToken")
 			return ctrl.Result{}, err

--- a/controllers/apitoken_controller_test.go
+++ b/controllers/apitoken_controller_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/jarcoal/httpmock"
@@ -28,16 +29,85 @@ func getApiToken(k8sClient client.Client, ctx context.Context, apiToken *unleash
 }
 
 var _ = Describe("ApiToken controller", func() {
+	existingTokens := unleashclient.ApiTokenResult{}
+
 	const (
 		ApiTokenNamespace = "default"
 		ApiTokenServerURL = "http://api-token-unleash.nais.io"
-		ApiTokenToken     = "test"
+		ApiTokenSecret    = "*:*.be44368985f7fb3237c584ef86f3d6bdada42ddbd63a019d26955178"
 
 		timeout  = time.Second * 10
 		interval = time.Millisecond * 250
 	)
 
-	Context("When creating an ApiToken", func() {
+	BeforeEach(func() {
+		existingTokens = unleashclient.ApiTokenResult{}
+
+		httpmock.Activate()
+		httpmock.RegisterResponder("GET", unleashclient.InstanceAdminStatsEndpoint,
+			httpmock.NewStringResponder(200, `{"versionOSS": "v5.1.2"}`))
+		httpmock.RegisterResponder("GET", unleashclient.ApiTokensEndpoint,
+			func(req *http.Request) (*http.Response, error) {
+				defer GinkgoRecover()
+				resp, err := httpmock.NewJsonResponse(200, existingTokens)
+
+				if err != nil {
+					return httpmock.NewStringResponse(500, ""), nil
+				}
+				return resp, nil
+			})
+		httpmock.RegisterResponder("POST", unleashclient.ApiTokensEndpoint,
+			func(req *http.Request) (*http.Response, error) {
+				defer GinkgoRecover()
+
+				tokenRequest := unleashclient.ApiTokenRequest{}
+				if err := json.NewDecoder(req.Body).Decode(&tokenRequest); err != nil {
+					return httpmock.NewStringResponse(400, ""), nil
+				}
+
+				existingTokens.Tokens = append(existingTokens.Tokens, unleashclient.ApiToken{
+					Secret:      ApiTokenSecret,
+					Username:    tokenRequest.Username,
+					Type:        tokenRequest.Type,
+					Environment: tokenRequest.Environment,
+					Project:     tokenRequest.Project,
+					Projects:    tokenRequest.Projects,
+					ExpiresAt:   tokenRequest.ExpiresAt,
+					CreatedAt:   time.Now().Format(time.RFC3339),
+				})
+
+				resp, err := httpmock.NewJsonResponse(201, existingTokens.Tokens[len(existingTokens.Tokens)-1])
+
+				if err != nil {
+					return httpmock.NewStringResponse(500, ""), nil
+				}
+				return resp, nil
+			})
+		httpmock.RegisterResponder("DELETE", fmt.Sprintf("=~%s/.*", unleashclient.ApiTokensEndpoint),
+			func(req *http.Request) (*http.Response, error) {
+				defer GinkgoRecover()
+
+				urlPath := strings.Split(req.URL.Path, "/")
+				tokenName := urlPath[len(urlPath)-1]
+				fmt.Printf("Deleting token %s\n", tokenName)
+
+				for i, token := range existingTokens.Tokens {
+					if token.Username == tokenName {
+						fmt.Printf("Deleting token %s\n", tokenName)
+						existingTokens.Tokens = append(existingTokens.Tokens[:i], existingTokens.Tokens[i+1:]...)
+						break
+					}
+				}
+
+				return httpmock.NewStringResponse(200, ""), nil
+			})
+	})
+
+	AfterEach(func() {
+		httpmock.DeactivateAndReset()
+	})
+
+	Context("Missing Unleash Server", func() {
 		It("Should fail when Unleash does not exist", func() {
 			ctx := context.Background()
 
@@ -48,22 +118,22 @@ var _ = Describe("ApiToken controller", func() {
 			apiToken := unleashApiTokenResource(apiTokenName, ApiTokenNamespace, apiTokenName, unleash)
 			Expect(k8sClient.Create(ctx, apiToken)).Should(Succeed())
 
-			createdApiToken := &unleashv1.ApiToken{ObjectMeta: apiToken.ObjectMeta}
-			Eventually(getApiToken, timeout, interval).WithArguments(k8sClient, ctx, createdApiToken).Should(ContainElement(metav1.Condition{
+			apiTokenCreated := &unleashv1.ApiToken{ObjectMeta: apiToken.ObjectMeta}
+			Eventually(getApiToken, timeout, interval).WithArguments(k8sClient, ctx, apiTokenCreated).Should(ContainElement(metav1.Condition{
 				Type:    unleashv1.ApiTokenStatusConditionTypeFailed,
 				Status:  metav1.ConditionTrue,
 				Reason:  "UnleashNotFound",
 				Message: "Unleash resource with name test-unleash-not-exist not found in namespace default",
 			}))
 
-			Expect(createdApiToken.Status.Created).Should(Equal(false))
-			Expect(createdApiToken.Status.Failed).Should(Equal(true))
+			Expect(apiTokenCreated.Status.Created).Should(Equal(false))
+			Expect(apiTokenCreated.Status.Failed).Should(Equal(true))
 
 			Expect(promGaugeVecVal(apiTokenStatus, ApiTokenNamespace, apiTokenName, unleashv1.ApiTokenStatusConditionTypeCreated)).Should(Equal(0.0))
 			Expect(promGaugeVecVal(apiTokenStatus, ApiTokenNamespace, apiTokenName, unleashv1.ApiTokenStatusConditionTypeFailed)).Should(Equal(1.0))
 
 			By("Cleaning up the ApiToken")
-			Expect(k8sClient.Delete(ctx, createdApiToken)).Should(Succeed())
+			Expect(k8sClient.Delete(ctx, apiTokenCreated)).Should(Succeed())
 		})
 
 		It("Should fail when RemoteUnleash does not exist", func() {
@@ -77,8 +147,8 @@ var _ = Describe("ApiToken controller", func() {
 			apiToken := remoteUnleashApiTokenResource(apiTokenName, ApiTokenNamespace, apiTokenName, remoteUnleash)
 			Expect(k8sClient.Create(ctx, apiToken)).Should(Succeed())
 
-			createdApiToken := &unleashv1.ApiToken{ObjectMeta: apiToken.ObjectMeta}
-			Eventually(getApiToken, timeout, interval).WithArguments(k8sClient, ctx, createdApiToken).Should(ContainElement(metav1.Condition{
+			apiTokenCreated := &unleashv1.ApiToken{ObjectMeta: apiToken.ObjectMeta}
+			Eventually(getApiToken, timeout, interval).WithArguments(k8sClient, ctx, apiTokenCreated).Should(ContainElement(metav1.Condition{
 				Type:    unleashv1.ApiTokenStatusConditionTypeFailed,
 				Status:  metav1.ConditionTrue,
 				Reason:  "UnleashNotFound",
@@ -89,9 +159,11 @@ var _ = Describe("ApiToken controller", func() {
 			Expect(promGaugeVecVal(apiTokenStatus, ApiTokenNamespace, apiTokenName, unleashv1.ApiTokenStatusConditionTypeFailed)).Should(Equal(1.0))
 
 			By("Cleaning up the ApiToken")
-			Expect(k8sClient.Delete(ctx, createdApiToken)).Should(Succeed())
+			Expect(k8sClient.Delete(ctx, apiTokenCreated)).Should(Succeed())
 		})
+	})
 
+	Context("When creating a new ApiToken", func() {
 		PIt("Should succeed when it can create token for Unleash", func() {
 
 		})
@@ -100,227 +172,122 @@ var _ = Describe("ApiToken controller", func() {
 			ctx := context.Background()
 
 			apiTokenName := "test-apitoken-remoteunleash-success"
-			apiTokenLookupKey := types.NamespacedName{Name: apiTokenName, Namespace: ApiTokenNamespace}
-			apiTokenSecret := "*:*.be44368985f7fb3237c584ef86f3d6bdada42ddbd63a019d26955178"
-
-			By("Mocking RemoteUnleash endpoints")
-			httpmock.Activate()
-			defer httpmock.DeactivateAndReset()
-			httpmock.RegisterResponder("GET", unleashclient.InstanceAdminStatsEndpoint,
-				httpmock.NewStringResponder(200, `{"versionOSS": "v4.0.0"}`))
-			httpmock.RegisterResponder("GET", unleashclient.ApiTokensEndpoint,
-				httpmock.NewStringResponder(200, `{"tokens": []}`))
-			httpmock.RegisterResponder("POST", unleashclient.ApiTokensEndpoint,
-				func(req *http.Request) (*http.Response, error) {
-					defer GinkgoRecover()
-
-					tokenRequest := unleashclient.ApiTokenRequest{}
-					if err := json.NewDecoder(req.Body).Decode(&tokenRequest); err != nil {
-						return httpmock.NewStringResponse(400, ""), nil
-					}
-
-					Expect(tokenRequest.Username).Should(Equal(fmt.Sprintf("%s-%s", apiTokenName, ApiTokenNameSuffix)))
-
-					resp, err := httpmock.NewJsonResponse(201, unleashclient.ApiToken{
-						Secret:      apiTokenSecret,
-						Username:    tokenRequest.Username,
-						Type:        tokenRequest.Type,
-						Environment: tokenRequest.Environment,
-						Project:     tokenRequest.Project,
-						Projects:    tokenRequest.Projects,
-						ExpiresAt:   tokenRequest.ExpiresAt,
-						CreatedAt:   time.Now().Format("2006-01-02T15:04:05.999Z"),
-					})
-
-					if err != nil {
-						return httpmock.NewStringResponse(500, ""), nil
-					}
-					return resp, nil
-				})
+			apiTokenLookup := types.NamespacedName{Name: apiTokenName, Namespace: ApiTokenNamespace}
 
 			By("By creating a new RemoteUnleash")
-			createdRemoteUnleashSecret := remoteUnleashSecretResource(apiTokenName, ApiTokenNamespace, apiTokenSecret)
-			Expect(k8sClient.Create(ctx, createdRemoteUnleashSecret)).Should(Succeed())
+			secretCreated := remoteUnleashSecretResource(apiTokenName, ApiTokenNamespace, ApiTokenSecret)
+			Expect(k8sClient.Create(ctx, secretCreated)).Should(Succeed())
 
-			remoteUnleashLookupKey, createdRemoteUnleash := remoteUnleashResource(apiTokenName, ApiTokenNamespace, ApiTokenServerURL, createdRemoteUnleashSecret)
-			Expect(k8sClient.Create(ctx, createdRemoteUnleash)).Should(Succeed())
-
-			Eventually(func() ([]metav1.Condition, error) {
-				err := k8sClient.Get(ctx, remoteUnleashLookupKey, createdRemoteUnleash)
-				if err != nil {
-					return nil, err
-				}
-
-				// unset condition.LastTransitionTime to make comparison easier
-				unsetConditionLastTransitionTime(createdRemoteUnleash.Status.Conditions)
-
-				return createdRemoteUnleash.Status.Conditions, nil
-			}, timeout, interval).Should(ContainElement(metav1.Condition{
-				Type:    unleashv1.UnleashStatusConditionTypeConnected,
-				Status:  metav1.ConditionTrue,
-				Reason:  "Reconciling",
-				Message: "Successfully connected to Unleash",
-			}))
+			unleashKey, unleashCreated := remoteUnleashResource(apiTokenName, ApiTokenNamespace, ApiTokenServerURL, secretCreated)
+			Expect(k8sClient.Create(ctx, unleashCreated)).Should(Succeed())
+			Eventually(remoteUnleashEventually(ctx, unleashKey, unleashCreated), timeout, interval).Should(ContainElement(remoteUnleashSuccessCondition()))
 
 			By("By creating a new ApiToken")
-			createdApiToken := remoteUnleashApiTokenResource(apiTokenName, ApiTokenNamespace, apiTokenName, createdRemoteUnleash)
-			Expect(k8sClient.Create(ctx, createdApiToken)).Should(Succeed())
-
-			Eventually(func() ([]metav1.Condition, error) {
-				err := k8sClient.Get(ctx, apiTokenLookupKey, createdApiToken)
-				if err != nil {
-					return nil, err
-				}
-
-				// unset condition.LastTransitionTime to make comparison easier
-				unsetConditionLastTransitionTime(createdApiToken.Status.Conditions)
-
-				return createdApiToken.Status.Conditions, nil
-			}, timeout, interval).Should(ContainElement(metav1.Condition{
-				Type:    unleashv1.ApiTokenStatusConditionTypeCreated,
-				Status:  metav1.ConditionTrue,
-				Reason:  "Reconciling",
-				Message: "API token successfully created",
-			}))
-
-			Expect(createdApiToken.Status.Created).Should(Equal(true))
-			Expect(createdApiToken.Status.Failed).Should(Equal(false))
+			apiTokenCreated := remoteUnleashApiTokenResource(apiTokenName, ApiTokenNamespace, apiTokenName, unleashCreated)
+			Expect(k8sClient.Create(ctx, apiTokenCreated)).Should(Succeed())
+			Eventually(apiTokenEventually(ctx, apiTokenLookup, apiTokenCreated), timeout, interval).Should(ContainElement(apiTokenSuccessCondition()))
+			Expect(apiTokenCreated.Status.Created).Should(Equal(true))
+			Expect(apiTokenCreated.Status.Failed).Should(Equal(false))
 
 			By("By checking that the ApiToken secret has been created")
-			createdApiTokenSecret := &corev1.Secret{}
-			Expect(k8sClient.Get(ctx, apiTokenLookupKey, createdApiTokenSecret)).Should(Succeed())
+			apiTokenSecretCreated := &corev1.Secret{}
+			Expect(k8sClient.Get(ctx, apiTokenLookup, apiTokenSecretCreated)).Should(Succeed())
 
-			Expect(createdApiTokenSecret.Data).Should(HaveKey(unleashv1.ApiTokenSecretTokenEnv))
-			Expect(createdApiTokenSecret.Data[unleashv1.ApiTokenSecretTokenEnv]).ShouldNot(BeEmpty())
-			Expect(createdApiTokenSecret.Data[unleashv1.ApiTokenSecretTokenEnv]).Should(Equal([]byte(apiTokenSecret)))
+			Expect(apiTokenSecretCreated.Data).Should(HaveKey(unleashv1.ApiTokenSecretTokenEnv))
+			Expect(apiTokenSecretCreated.Data[unleashv1.ApiTokenSecretTokenEnv]).ShouldNot(BeEmpty())
+			Expect(apiTokenSecretCreated.Data[unleashv1.ApiTokenSecretTokenEnv]).Should(Equal([]byte(ApiTokenSecret)))
 
-			Expect(createdApiTokenSecret.Data).Should(HaveKey(unleashv1.ApiTokenSecretServerEnv))
-			Expect(createdApiTokenSecret.Data[unleashv1.ApiTokenSecretServerEnv]).ShouldNot(BeEmpty())
-			Expect(createdApiTokenSecret.Data[unleashv1.ApiTokenSecretServerEnv]).Should(Equal([]byte(ApiTokenServerURL)))
+			Expect(apiTokenSecretCreated.Data).Should(HaveKey(unleashv1.ApiTokenSecretServerEnv))
+			Expect(apiTokenSecretCreated.Data[unleashv1.ApiTokenSecretServerEnv]).ShouldNot(BeEmpty())
+			Expect(apiTokenSecretCreated.Data[unleashv1.ApiTokenSecretServerEnv]).Should(Equal([]byte(ApiTokenServerURL)))
 
-			Expect(createdApiTokenSecret.Data).Should(HaveKey(unleashv1.ApiTokenSecretEnvEnv))
-			Expect(createdApiTokenSecret.Data[unleashv1.ApiTokenSecretEnvEnv]).ShouldNot(BeEmpty())
-			Expect(createdApiTokenSecret.Data[unleashv1.ApiTokenSecretEnvEnv]).Should(Equal([]byte("development")))
+			Expect(apiTokenSecretCreated.Data).Should(HaveKey(unleashv1.ApiTokenSecretEnvEnv))
+			Expect(apiTokenSecretCreated.Data[unleashv1.ApiTokenSecretEnvEnv]).ShouldNot(BeEmpty())
+			Expect(apiTokenSecretCreated.Data[unleashv1.ApiTokenSecretEnvEnv]).Should(Equal([]byte("development")))
 
 			Expect(promGaugeVecVal(apiTokenStatus, ApiTokenNamespace, apiTokenName, unleashv1.ApiTokenStatusConditionTypeCreated)).Should(Equal(1.0))
 			Expect(promGaugeVecVal(apiTokenStatus, ApiTokenNamespace, apiTokenName, unleashv1.ApiTokenStatusConditionTypeFailed)).Should(Equal(0.0))
 
 			By("By deleting the ApiToken")
-			deletePath := fmt.Sprintf("=~%s/.*", unleashclient.ApiTokensEndpoint)
-			httpmock.RegisterResponder("DELETE", deletePath, httpmock.NewStringResponder(200, ""))
-			Expect(k8sClient.Delete(ctx, createdApiToken)).Should(Succeed())
+			Expect(k8sClient.Delete(ctx, apiTokenCreated)).Should(Succeed())
 			Eventually(func() int {
 				info := httpmock.GetCallCountInfo()
-				return info[fmt.Sprintf("DELETE %s", deletePath)]
+				return info[fmt.Sprintf("DELETE %s", fmt.Sprintf("=~%s/.*", unleashclient.ApiTokensEndpoint))]
 			}, timeout, interval).ShouldNot(BeZero())
+			Expect(existingTokens.Tokens).Should(BeEmpty())
 		})
 
 		It("Should create secret when ApiToken exists in Unleash but not in Kubernetes", func() {
 			ctx := context.Background()
 
 			apiTokenName := "test-apitoken-exists"
-			apiTokenLookupKey := types.NamespacedName{Name: apiTokenName, Namespace: ApiTokenNamespace}
-			apiTokenSecret := "*:*.be44368985f7fb3237c584ef86f3d6bdada42ddbd63a019d26955178"
-
-			By("Mocking RemoteUnleash endpoints")
-			httpmock.Activate()
-			defer httpmock.DeactivateAndReset()
-			httpmock.RegisterResponder("GET", unleashclient.InstanceAdminStatsEndpoint,
-				httpmock.NewStringResponder(200, `{"versionOSS": "v4.0.0"}`))
-			httpmock.RegisterResponder("GET", unleashclient.ApiTokensEndpoint,
-				func(req *http.Request) (*http.Response, error) {
-					resp, err := httpmock.NewJsonResponse(200, unleashclient.ApiTokenResult{
-						Tokens: []unleashclient.ApiToken{
-							{
-								Secret:      apiTokenSecret,
-								Username:    fmt.Sprintf("%s-%s", apiTokenName, ApiTokenNameSuffix),
-								Type:        "client",
-								Environment: "development",
-								Project:     "*",
-								Projects:    []string{},
-								ExpiresAt:   time.Now().UTC().AddDate(0, 0, 1).Format(time.RFC3339),
-								CreatedAt:   time.Now().UTC().Format(time.RFC3339),
-							},
-						},
-					})
-					if err != nil {
-						return httpmock.NewStringResponse(500, ""), nil
-					}
-					return resp, nil
-				})
+			apiTokenLookup := types.NamespacedName{Name: apiTokenName, Namespace: ApiTokenNamespace}
 
 			By("By creating a new RemoteUnleash")
-			createdRemoteUnleashSecret := remoteUnleashSecretResource(apiTokenName, ApiTokenNamespace, apiTokenSecret)
-			Expect(k8sClient.Create(ctx, createdRemoteUnleashSecret)).Should(Succeed())
+			secretCreated := remoteUnleashSecretResource(apiTokenName, ApiTokenNamespace, ApiTokenSecret)
+			Expect(k8sClient.Create(ctx, secretCreated)).Should(Succeed())
 
-			remoteUnleashLookupKey, createdRemoteUnleash := remoteUnleashResource(apiTokenName, ApiTokenNamespace, ApiTokenServerURL, createdRemoteUnleashSecret)
-			Expect(k8sClient.Create(ctx, createdRemoteUnleash)).Should(Succeed())
-
-			Eventually(func() ([]metav1.Condition, error) {
-				err := k8sClient.Get(ctx, remoteUnleashLookupKey, createdRemoteUnleash)
-				if err != nil {
-					return nil, err
-				}
-
-				// unset condition.LastTransitionTime to make comparison easier
-				unsetConditionLastTransitionTime(createdRemoteUnleash.Status.Conditions)
-
-				return createdRemoteUnleash.Status.Conditions, nil
-			}, timeout, interval).Should(ContainElement(metav1.Condition{
-				Type:    unleashv1.UnleashStatusConditionTypeConnected,
-				Status:  metav1.ConditionTrue,
-				Reason:  "Reconciling",
-				Message: "Successfully connected to Unleash",
-			}))
+			unleashKey, unleashCreated := remoteUnleashResource(apiTokenName, ApiTokenNamespace, ApiTokenServerURL, secretCreated)
+			Expect(k8sClient.Create(ctx, unleashCreated)).Should(Succeed())
+			Eventually(remoteUnleashEventually(ctx, unleashKey, unleashCreated), timeout, interval).Should(ContainElement(remoteUnleashSuccessCondition()))
 
 			By("By creating a new ApiToken")
-			createdApiToken := remoteUnleashApiTokenResource(apiTokenName, ApiTokenNamespace, apiTokenName, createdRemoteUnleash)
-			Expect(k8sClient.Create(ctx, createdApiToken)).Should(Succeed())
-
-			Eventually(func() ([]metav1.Condition, error) {
-				err := k8sClient.Get(ctx, apiTokenLookupKey, createdApiToken)
-				if err != nil {
-					return nil, err
-				}
-
-				// unset condition.LastTransitionTime to make comparison easier
-				unsetConditionLastTransitionTime(createdApiToken.Status.Conditions)
-
-				return createdApiToken.Status.Conditions, nil
-			}, timeout, interval).Should(ContainElement(metav1.Condition{
-				Type:    unleashv1.ApiTokenStatusConditionTypeCreated,
-				Status:  metav1.ConditionTrue,
-				Reason:  "Reconciling",
-				Message: "API token successfully created",
-			}))
+			apiTokenCreated := remoteUnleashApiTokenResource(apiTokenName, ApiTokenNamespace, apiTokenName, unleashCreated)
+			existingTokens.Tokens = []unleashclient.ApiToken{
+				{
+					Secret:      ApiTokenSecret,
+					Username:    apiTokenCreated.ApiTokenName("unleasherator"),
+					Type:        apiTokenCreated.Spec.Type,
+					Environment: apiTokenCreated.Spec.Environment,
+					Projects:    apiTokenCreated.Spec.Projects,
+					ExpiresAt:   time.Now().AddDate(0, 0, 1).Format(time.RFC3339),
+					CreatedAt:   time.Now().Format(time.RFC3339),
+				},
+			}
+			Expect(k8sClient.Create(ctx, apiTokenCreated)).Should(Succeed())
+			Eventually(apiTokenEventually(ctx, apiTokenLookup, apiTokenCreated), timeout, interval).Should(ContainElement(apiTokenSuccessCondition()))
+			Expect(existingTokens.Tokens).Should(HaveLen(1))
+			Expect(httpmock.GetCallCountInfo()[fmt.Sprintf("POST %s", unleashclient.ApiTokensEndpoint)]).Should(Equal(0))
 
 			By("By checking that the ApiToken secret has been created")
-			createdApiTokenSecret := &corev1.Secret{}
-			Expect(k8sClient.Get(ctx, apiTokenLookupKey, createdApiTokenSecret)).Should(Succeed())
-
-			Expect(createdApiTokenSecret.Data).Should(HaveKey(unleashv1.ApiTokenSecretTokenEnv))
-			Expect(createdApiTokenSecret.Data[unleashv1.ApiTokenSecretTokenEnv]).ShouldNot(BeEmpty())
-			Expect(createdApiTokenSecret.Data[unleashv1.ApiTokenSecretTokenEnv]).Should(Equal([]byte(apiTokenSecret)))
-
-			Expect(createdApiTokenSecret.Data).Should(HaveKey(unleashv1.ApiTokenSecretServerEnv))
-			Expect(createdApiTokenSecret.Data[unleashv1.ApiTokenSecretServerEnv]).ShouldNot(BeEmpty())
-			Expect(createdApiTokenSecret.Data[unleashv1.ApiTokenSecretServerEnv]).Should(Equal([]byte(ApiTokenServerURL)))
-
-			Expect(createdApiTokenSecret.Data).Should(HaveKey(unleashv1.ApiTokenSecretEnvEnv))
-			Expect(createdApiTokenSecret.Data[unleashv1.ApiTokenSecretEnvEnv]).ShouldNot(BeEmpty())
-			Expect(createdApiTokenSecret.Data[unleashv1.ApiTokenSecretEnvEnv]).Should(Equal([]byte("development")))
-
-			Expect(promGaugeVecVal(apiTokenStatus, ApiTokenNamespace, apiTokenName, unleashv1.ApiTokenStatusConditionTypeCreated)).Should(Equal(1.0))
-			Expect(promGaugeVecVal(apiTokenStatus, ApiTokenNamespace, apiTokenName, unleashv1.ApiTokenStatusConditionTypeFailed)).Should(Equal(0.0))
+			apiTokenSecretCreated := &corev1.Secret{}
+			Expect(k8sClient.Get(ctx, apiTokenLookup, apiTokenSecretCreated)).Should(Succeed())
 
 			By("By deleting the ApiToken")
-			deletePath := fmt.Sprintf("=~%s/.*", unleashclient.ApiTokensEndpoint)
-			httpmock.RegisterResponder("DELETE", deletePath, httpmock.NewStringResponder(200, ""))
-			Expect(k8sClient.Delete(ctx, createdApiToken)).Should(Succeed())
-			Eventually(func() int {
-				info := httpmock.GetCallCountInfo()
-				return info[fmt.Sprintf("DELETE %s", deletePath)]
-			}, timeout, interval).ShouldNot(BeZero())
+			Expect(k8sClient.Delete(ctx, apiTokenCreated)).Should(Succeed())
+		})
+	})
+
+	Context("When updating an existing ApiToken", func() {
+		It("Should update ApiToken in Unleash when it differs from Kubernetes", func() {
+			ctx := context.Background()
+
+			apiTokenName := "test-apitoken-updated"
+			apiTokenLookup := types.NamespacedName{Name: apiTokenName, Namespace: ApiTokenNamespace}
+
+			By("By creating a new RemoteUnleash")
+			secretCreated := remoteUnleashSecretResource(apiTokenName, ApiTokenNamespace, ApiTokenSecret)
+			Expect(k8sClient.Create(ctx, secretCreated)).Should(Succeed())
+			unleashKey, unleashCreated := remoteUnleashResource(apiTokenName, ApiTokenNamespace, ApiTokenServerURL, secretCreated)
+			Expect(k8sClient.Create(ctx, unleashCreated)).Should(Succeed())
+			Eventually(remoteUnleashEventually(ctx, unleashKey, unleashCreated), timeout, interval).Should(ContainElement(remoteUnleashSuccessCondition()))
+
+			By("By creating a new ApiToken")
+			apiTokenCreated := remoteUnleashApiTokenResourceWithEnv(apiTokenName, ApiTokenNamespace, apiTokenName, "development", unleashCreated)
+			Expect(k8sClient.Create(ctx, apiTokenCreated)).Should(Succeed())
+			Eventually(apiTokenEventually(ctx, apiTokenLookup, apiTokenCreated), timeout, interval).Should(ContainElement(apiTokenSuccessCondition()))
+
+			By("By updating the ApiToken")
+			apiTokenCreated.Spec.Environment = "production"
+			Expect(k8sClient.Update(ctx, apiTokenCreated)).Should(Succeed())
+			Eventually(apiTokenEventually(ctx, apiTokenLookup, apiTokenCreated), timeout, interval).Should(ContainElement(apiTokenSuccessCondition()))
+
+			By("By checking that the ApiToken was updated in Unleash")
+			Expect(httpmock.GetCallCountInfo()[fmt.Sprintf("POST %s", unleashclient.ApiTokensEndpoint)]).Should(Equal(2))
+			Expect(existingTokens.Tokens[0].Environment).Should(Equal("production"))
+
+			By("By deleting the ApiToken")
+			Expect(k8sClient.Delete(ctx, apiTokenCreated)).Should(Succeed())
 		})
 	})
 })

--- a/controllers/remoteunleash_controller.go
+++ b/controllers/remoteunleash_controller.go
@@ -75,7 +75,6 @@ func (r *RemoteUnleashReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	log := log.FromContext(ctx)
 
 	log.Info("Starting reconciliation of RemoteUnleash")
-
 	remoteUnleash := &unleashv1.RemoteUnleash{}
 
 	err := r.Get(ctx, req.NamespacedName, remoteUnleash)
@@ -86,42 +85,6 @@ func (r *RemoteUnleashReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		}
 		log.Error(err, "Failed to get RemoteUnleash")
 		return ctrl.Result{}, err
-	}
-
-	// Set status to unknown if not set
-	if remoteUnleash.Status.Conditions == nil || len(remoteUnleash.Status.Conditions) == 0 {
-		if err := r.updateStatus(ctx, remoteUnleash, nil, metav1.Condition{
-			Type:    unleashv1.UnleashStatusConditionTypeReconciled,
-			Status:  metav1.ConditionUnknown,
-			Reason:  "Reconciling",
-			Message: "Starting reconciliation",
-		}); err != nil {
-			return ctrl.Result{}, err
-		}
-
-		if err := r.Get(ctx, req.NamespacedName, remoteUnleash); err != nil {
-			log.Error(err, "Failed to get RemoteUnleash")
-			return ctrl.Result{}, err
-		}
-	}
-
-	// Add finalizer if not present
-	if !controllerutil.ContainsFinalizer(remoteUnleash, tokenFinalizer) {
-		log.Info("Adding finalizer to RemoteUnleash")
-		if ok := controllerutil.AddFinalizer(remoteUnleash, tokenFinalizer); !ok {
-			log.Error(err, "Failed to add finalizer to RemoteUnleash")
-			return ctrl.Result{Requeue: true}, err
-		}
-
-		if err = r.Update(ctx, remoteUnleash); err != nil {
-			log.Error(err, "Failed to update RemoteUnleash to add finalizer")
-			return ctrl.Result{}, err
-		}
-
-		if err := r.Get(ctx, req.NamespacedName, remoteUnleash); err != nil {
-			log.Error(err, "Failed to get RemoteUnleash")
-			return ctrl.Result{}, err
-		}
 	}
 
 	// Check if marked for deletion
@@ -168,6 +131,45 @@ func (r *RemoteUnleashReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{}, nil
 	}
 
+	// Set status to unknown if not set
+	if remoteUnleash.Status.Conditions == nil || len(remoteUnleash.Status.Conditions) == 0 {
+		log.Info("Setting status to unknown for RemoteUnleash")
+
+		if err := r.updateStatus(ctx, remoteUnleash, nil, metav1.Condition{
+			Type:    unleashv1.UnleashStatusConditionTypeReconciled,
+			Status:  metav1.ConditionUnknown,
+			Reason:  "Reconciling",
+			Message: "Starting reconciliation",
+		}); err != nil {
+			return ctrl.Result{}, err
+		}
+
+		if err := r.Get(ctx, req.NamespacedName, remoteUnleash); err != nil {
+			log.Error(err, "Failed to get RemoteUnleash")
+			return ctrl.Result{}, err
+		}
+	}
+
+	// Add finalizer if not present
+	if !controllerutil.ContainsFinalizer(remoteUnleash, tokenFinalizer) {
+		log.Info("Adding finalizer to RemoteUnleash")
+
+		if ok := controllerutil.AddFinalizer(remoteUnleash, tokenFinalizer); !ok {
+			log.Error(err, "Failed to add finalizer to RemoteUnleash")
+			return ctrl.Result{Requeue: true}, err
+		}
+
+		if err = r.Update(ctx, remoteUnleash); err != nil {
+			log.Error(err, "Failed to update RemoteUnleash to add finalizer")
+			return ctrl.Result{}, err
+		}
+
+		if err := r.Get(ctx, req.NamespacedName, remoteUnleash); err != nil {
+			log.Error(err, "Failed to get RemoteUnleash")
+			return ctrl.Result{}, err
+		}
+	}
+
 	// Get admin token from secret
 	adminToken, err := remoteUnleash.AdminToken(ctx, r.Client, r.OperatorNamespace)
 	if err != nil {
@@ -205,6 +207,11 @@ func (r *RemoteUnleashReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{}, err
 	}
 
+	if err := r.Get(ctx, req.NamespacedName, remoteUnleash); err != nil {
+		log.Error(err, "Failed to get RemoteUnleash")
+		return ctrl.Result{}, err
+	}
+
 	stats, _, err := unleashClient.GetInstanceAdminStats()
 	if err != nil {
 		if err := r.updateStatusConnectionFailed(ctx, remoteUnleash, stats, err, fmt.Sprintf("Failed to connect to Unleash instance statistics endpoint on host %s", remoteUnleash.URL())); err != nil {
@@ -217,7 +224,11 @@ func (r *RemoteUnleashReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 	// Set RemoteUnleash status to connected
 	err = r.updateStatusConnectionSuccess(ctx, stats, remoteUnleash)
-	return ctrl.Result{RequeueAfter: 1 * time.Hour}, err
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	return ctrl.Result{RequeueAfter: 1 * time.Hour}, nil
 }
 
 func (r *RemoteUnleashReconciler) updateStatusConnectionSuccess(ctx context.Context, stats *unleashclient.InstanceAdminStatsResult, remoteUnleash *unleashv1.RemoteUnleash) error {
@@ -322,7 +333,7 @@ func (r *RemoteUnleashReconciler) FederationSubscribe(ctx context.Context) error
 		err := r.Federation.Subscriber.Subscribe(ctx, func(ctx context.Context, remoteUnleashes []*unleashv1.RemoteUnleash, adminSecret *corev1.Secret, clusters []string, status pb.Status) error {
 			log.Info("Received pubsub message", "status", status)
 
-			if !hasValue(r.Federation.ClusterName, clusters) {
+			if !utils.StringInSlice(r.Federation.ClusterName, clusters) {
 				log.Info("Ignoring message, not for this cluster", "cluster", r.Federation.ClusterName, "clusters", clusters)
 				return nil
 			}

--- a/controllers/remoteunleash_controller_test.go
+++ b/controllers/remoteunleash_controller_test.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/jarcoal/httpmock"
@@ -30,10 +31,23 @@ var _ = Describe("RemoteUnleash controller", func() {
 		RemoteUnleashNamespace = "default"
 		RemoteUnleashServerURL = "http://remoteunleash.nais.io"
 		RemoteUnleashToken     = "test"
+		RemoteUnleashVersion   = "v5.1.2"
 
 		timeout  = time.Second * 10
 		interval = time.Millisecond * 250
 	)
+
+	BeforeEach(func() {
+		promCounterVecFlush(remoteUnleashReceived)
+
+		httpmock.Activate()
+		httpmock.RegisterResponder("GET", unleashclient.InstanceAdminStatsEndpoint,
+			httpmock.NewStringResponder(200, fmt.Sprintf(`{"versionOSS": "%s"}`, RemoteUnleashVersion)))
+	})
+
+	AfterEach(func() {
+		httpmock.DeactivateAndReset()
+	})
 
 	Context("When creating a RemoteUnleash", func() {
 		It("Should fail if the secret does not exist", func() {
@@ -61,15 +75,12 @@ var _ = Describe("RemoteUnleash controller", func() {
 			Expect(k8sClient.Delete(ctx, createdRemoteUnleash)).Should(Succeed())
 		})
 
+		PIt("Should fail if the secret does not contain a token")
+		PIt("Should fail if it cannot connect to Unleash")
+
 		It("Should succeed when it can connect to Unleash", func() {
 			ctx := context.Background()
 			RemoteUnleashName := "test-unleash-success"
-
-			By("By mocking Unleash API")
-			httpmock.Activate()
-			defer httpmock.DeactivateAndReset()
-			httpmock.RegisterResponder("GET", unleashclient.InstanceAdminStatsEndpoint,
-				httpmock.NewStringResponder(200, `{"versionOSS": "v4.0.0"}`))
 
 			By("By creating a new Unleash secret")
 			secret := remoteUnleashSecretResource(RemoteUnleashName, RemoteUnleashNamespace, RemoteUnleashToken)
@@ -88,16 +99,19 @@ var _ = Describe("RemoteUnleash controller", func() {
 			}))
 
 			Expect(createdRemoteUnleash.IsReady()).To(BeTrue())
-			Expect(createdRemoteUnleash.Status.Version).To(Equal("v4.0.0"))
+			Expect(createdRemoteUnleash.Status.Version).To(Equal(RemoteUnleashVersion))
 			Expect(createdRemoteUnleash.Status.Reconciled).To(BeTrue())
 			Expect(createdRemoteUnleash.Status.Connected).To(BeTrue())
 
 			Expect(promGaugeVecVal(remoteUnleashStatus, RemoteUnleashNamespace, RemoteUnleashName, unleashv1.UnleashStatusConditionTypeReconciled)).To(Equal(1.0))
 			Expect(promGaugeVecVal(remoteUnleashStatus, RemoteUnleashNamespace, RemoteUnleashName, unleashv1.UnleashStatusConditionTypeConnected)).To(Equal(1.0))
+
+			Expect(httpmock.GetCallCountInfo()).To(HaveLen(1))
+			Expect(httpmock.GetCallCountInfo()[fmt.Sprintf("GET %s", unleashclient.InstanceAdminStatsEndpoint)]).To(Equal(1))
 		})
 	})
 
-	Describe("When subscribing to federated Unleash", func() {
+	Context("When subscribing to federated Unleash", func() {
 		It("Should create RemoteUnleash if cluster matches", func() {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
@@ -121,23 +135,14 @@ var _ = Describe("RemoteUnleash controller", func() {
 
 			handler := mockSubscriber.Calls[0].Arguments.Get(1).(federation.Handler)
 
-			By("By mocking Unleash API")
-			httpmock.Activate()
-			defer httpmock.DeactivateAndReset()
-			httpmock.RegisterResponder("GET", unleashclient.InstanceAdminStatsEndpoint,
-				httpmock.NewStringResponder(200, `{"versionOSS": "v4.0.0"}`))
-
-			By("Flushing prometheus metrics")
-			promCounterVecFlush(remoteUnleashReceived)
-
 			var remoteUnleashes []*unleashv1.RemoteUnleash
 
 			By("By creating a new RemoteUnleash that does not match cluster")
 			name := "test-unleash-other-cluster"
 			namespaces := []string{"some-namespace"}
 			clusters := []string{"some-cluster"}
-			secret := remoteUnleashSecretResource(name, namespaces[0], "test")
-			_, remoteUnleash := remoteUnleashResource(name, namespaces[0], "http://unleash-1.nais.io", secret)
+			secret := remoteUnleashSecretResource(name, namespaces[0], RemoteUnleashToken)
+			_, remoteUnleash := remoteUnleashResource(name, namespaces[0], RemoteUnleashServerURL, secret)
 			remoteUnleashes = []*unleashv1.RemoteUnleash{remoteUnleash}
 
 			err := handler(ctx, remoteUnleashes, secret, clusters, pb.Status_Provisioned)
@@ -149,8 +154,8 @@ var _ = Describe("RemoteUnleash controller", func() {
 			name = "test-unleash-same-cluster"
 			namespaces = []string{"default"}
 			clusters = []string{"test-cluster"}
-			secret = remoteUnleashSecretResource(name, namespaces[0], "test")
-			_, remoteUnleash = remoteUnleashResource(name, namespaces[0], "http://unleash-1.nais.io", secret)
+			secret = remoteUnleashSecretResource(name, namespaces[0], RemoteUnleashToken)
+			_, remoteUnleash = remoteUnleashResource(name, namespaces[0], RemoteUnleashServerURL, secret)
 			remoteUnleashes = []*unleashv1.RemoteUnleash{remoteUnleash}
 
 			err = handler(ctx, remoteUnleashes, secret, clusters, pb.Status_Provisioned)
@@ -163,8 +168,8 @@ var _ = Describe("RemoteUnleash controller", func() {
 			name = "test-unleash-same-cluster"
 			namespaces = []string{"default"}
 			clusters = []string{"test-cluster"}
-			secret = remoteUnleashSecretResource(name, namespaces[0], "test")
-			_, remoteUnleash = remoteUnleashResource(name, namespaces[0], "http://unleash-1.nais.io", secret)
+			secret = remoteUnleashSecretResource(name, namespaces[0], RemoteUnleashToken)
+			_, remoteUnleash = remoteUnleashResource(name, namespaces[0], RemoteUnleashServerURL, secret)
 			remoteUnleashes = []*unleashv1.RemoteUnleash{remoteUnleash}
 
 			Eventually(func() error {
@@ -198,23 +203,14 @@ var _ = Describe("RemoteUnleash controller", func() {
 
 			handler := mockSubscriber.Calls[0].Arguments.Get(1).(federation.Handler)
 
-			By("By mocking Unleash API")
-			httpmock.Activate()
-			defer httpmock.DeactivateAndReset()
-			httpmock.RegisterResponder("GET", unleashclient.InstanceAdminStatsEndpoint,
-				httpmock.NewStringResponder(200, `{"versionOSS": "v4.0.0"}`))
-
-			By("Flushing prometheus metrics")
-			promCounterVecFlush(remoteUnleashReceived)
-
 			var remoteUnleashes []*unleashv1.RemoteUnleash
 
 			By("By creating a new RemoteUnleash in a namespace that does not exist")
 			name := "test-unleash-namespaces-not-found"
 			namespaces := []string{"namespace-not-found"}
 			clusters := []string{"test-cluster"}
-			secret := remoteUnleashSecretResource(name, "default", "test")
-			_, remoteUnleash := remoteUnleashResource(name, namespaces[0], "http://unleash-1.nais.io", secret)
+			secret := remoteUnleashSecretResource(name, "default", RemoteUnleashToken)
+			_, remoteUnleash := remoteUnleashResource(name, namespaces[0], RemoteUnleashServerURL, secret)
 			remoteUnleashes = []*unleashv1.RemoteUnleash{remoteUnleash}
 
 			err := handler(ctx, remoteUnleashes, secret, clusters, pb.Status_Provisioned)

--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -14,13 +14,3 @@ func promGaugeValueForStatus(status metav1.ConditionStatus) float64 {
 	}
 	return 0
 }
-
-// hasValue returns true if s is in list, false otherwise.
-func hasValue(s string, list []string) bool {
-	for _, v := range list {
-		if v == s {
-			return true
-		}
-	}
-	return false
-}

--- a/docs/apitoken.md
+++ b/docs/apitoken.md
@@ -28,11 +28,15 @@ sequenceDiagram
     Unleasherator->>ApiToken: Update status
 ```
 
-The token will be stored in secret in the same namespace as the `ApiToken` resource. The name of the secret is specified in the `secretName` field and contains two keys:
+The token will be stored in secret in the same namespace as the `ApiToken` resource. The name of the secret is specified in the `secretName` field and contains the following data:
 
-- `UNLEASH_SERVER_API_TOKEN` - the token itself
-- `UNLEASH_SERVER_API_URL` - the URL of the Unleash instance (remember to add `/api` to the end when authenticating to the Unleash API)
-- `UNLEASH_SERVER_API_ENV` - the environment the token is valid for. Defaults to `development` if not specified.
+| Key                           | Default       | Description                                                                                                |
+| ----------------------------- | ------------- | ---------------------------------------------------------------------------------------------------------- |
+| `UNLEASH_SERVER_API_TOKEN`    |               | The token itself                                                                                           |
+| `UNLEASH_SERVER_API_URL`      |               | The URL of the Unleash instance (remember to add `/api` to the end when authenticating to the Unleash API) |
+| `UNLEASH_SERVER_API_ENV`      | `development` | The environment the token is valid for                                                                     |
+| `UNLEASH_SERVER_API_PROJECTS` | `default`     | The projects the token is valid for (as a comma-separated list)                                            |
+| `UNLEASH_SERVER_API_TYPE`     | `CLIENT`      | The type of the token (either `CLIENT` or `FRONTEND`)                                                      |
 
 ## Spec
 

--- a/pkg/resources/apitoken.go
+++ b/pkg/resources/apitoken.go
@@ -1,6 +1,8 @@
 package resources
 
 import (
+	"strings"
+
 	unleashv1 "github.com/nais/unleasherator/api/v1"
 	"github.com/nais/unleasherator/pkg/unleashclient"
 	corev1 "k8s.io/api/core/v1"
@@ -14,9 +16,11 @@ func ApiTokenSecret(unleash UnleashInstance, token *unleashv1.ApiToken, apiToken
 			Namespace: token.GetObjectMeta().GetNamespace(),
 		},
 		Data: map[string][]byte{
-			unleashv1.ApiTokenSecretTokenEnv:  []byte(apiToken.Secret),
-			unleashv1.ApiTokenSecretServerEnv: []byte(unleash.URL()),
-			unleashv1.ApiTokenSecretEnvEnv:    []byte(token.Spec.Environment),
+			unleashv1.ApiTokenSecretTokenEnv:    []byte(apiToken.Secret),
+			unleashv1.ApiTokenSecretServerEnv:   []byte(unleash.URL()),
+			unleashv1.ApiTokenSecretEnvEnv:      []byte(token.Spec.Environment),
+			unleashv1.ApiTokenSecretTypeEnv:     []byte(token.Spec.Type),
+			unleashv1.ApiTokenSecretProjectsEnv: []byte(strings.Join(token.Spec.Projects, ",")),
 		},
 	}
 }

--- a/pkg/resources/apitoken_test.go
+++ b/pkg/resources/apitoken_test.go
@@ -30,12 +30,18 @@ func TestApiTokenSecret(t *testing.T) {
 		},
 		Spec: unleashv1.ApiTokenSpec{
 			SecretName:  "test-secret",
+			Type:        "CLIENT",
 			Environment: "development",
+			Projects:    []string{"default"},
 		},
 	}
 
 	apiToken := &unleashclient.ApiToken{
-		Secret: "test-secret",
+		Secret:      "test-secret",
+		Username:    "test-apitoken-unleaasherator",
+		Type:        "CLIENT",
+		Environment: "development",
+		Projects:    []string{"default"},
 	}
 
 	expectedSecret := &corev1.Secret{
@@ -44,9 +50,11 @@ func TestApiTokenSecret(t *testing.T) {
 			Namespace: "default",
 		},
 		Data: map[string][]byte{
-			unleashv1.ApiTokenSecretTokenEnv:  []byte("test-secret"),
-			unleashv1.ApiTokenSecretServerEnv: []byte("http://api-token-unleash.nais.io"),
-			unleashv1.ApiTokenSecretEnvEnv:    []byte("development"),
+			unleashv1.ApiTokenSecretTokenEnv:    []byte("test-secret"),
+			unleashv1.ApiTokenSecretServerEnv:   []byte("http://api-token-unleash.nais.io"),
+			unleashv1.ApiTokenSecretEnvEnv:      []byte("development"),
+			unleashv1.ApiTokenSecretTypeEnv:     []byte("CLIENT"),
+			unleashv1.ApiTokenSecretProjectsEnv: []byte("default"),
 		},
 	}
 

--- a/pkg/unleashclient/admin_api.go
+++ b/pkg/unleashclient/admin_api.go
@@ -10,17 +10,36 @@ type InstanceAdminStatsResult struct {
 	VersionOSS        string  `json:"versionOSS"`
 	VersionEnterprise string  `json:"versionEnterprise"`
 	Users             float64 `json:"users"`
-	FeatureToggles    float64 `json:"featureToggles"`
-	Projects          float64 `json:"projects"`
-	ContextFields     float64 `json:"contextFields"`
-	Roles             float64 `json:"roles"`
-	Groups            float64 `json:"groups"`
-	Environments      float64 `json:"environments"`
-	Segments          float64 `json:"segments"`
-	Strategies        float64 `json:"strategies"`
-	SAMLenabled       bool    `json:"SAMLenabled"`
-	OIDCenabled       bool    `json:"OIDCenabled"`
-	Sum               string  `json:"sum"`
+	ActiveUsers       struct {
+		Last7  float64 `json:"last7"`
+		Last30 float64 `json:"last30"`
+		Last60 float64 `json:"last60"`
+		Last90 float64 `json:"last90"`
+	} `json:"activeUsers"`
+	FeatureToggles       float64 `json:"featureToggles"`
+	Projects             float64 `json:"projects"`
+	ContextFields        float64 `json:"contextFields"`
+	Roles                float64 `json:"roles"`
+	CustomRootRoles      float64 `json:"customRootRoles"`
+	CustomRootRolesInUse float64 `json:"customRootRolesInUse"`
+	Groups               float64 `json:"groups"`
+	Environments         float64 `json:"environments"`
+	Segments             float64 `json:"segments"`
+	Strategies           float64 `json:"strategies"`
+	SAMLenabled          bool    `json:"SAMLenabled"`
+	OIDCenabled          bool    `json:"OIDCenabled"`
+	ClientApps           []struct {
+		Range string  `json:"range"`
+		Count float64 `json:"count"`
+	} `json:"clientApps"`
+	FeatureExports    float64 `json:"featureExports"`
+	FeatureImports    float64 `json:"featureImports"`
+	ProductionChanges struct {
+		Last30 float64 `json:"last30"`
+		Last60 float64 `json:"last60"`
+		Last90 float64 `json:"last90"`
+	} `json:"productionChanges"`
+	Sum string `json:"sum"`
 }
 
 type HealthResult struct {
@@ -55,6 +74,7 @@ func (c *Client) GetInstanceAdminStats() (*InstanceAdminStatsResult, *http.Respo
 type ApiToken struct {
 	Secret      string   `json:"secret"`
 	Username    string   `json:"username"`
+	TokenName   string   `json:"tokenName"`
 	Type        string   `json:"type"` // Possible values: [client, admin, frontend]
 	Environment string   `json:"environment"`
 	Project     string   `json:"project"`

--- a/pkg/unleashclient/admin_api_test.go
+++ b/pkg/unleashclient/admin_api_test.go
@@ -13,3 +13,21 @@ func TestInstanceAdminStatsResult(t *testing.T) {
 		t.Errorf("Error unmarshalling json: %s", err)
 	}
 }
+
+func TestApiToken(t *testing.T) {
+	jsonString := `{"tokenName":"my-token","type":"client","environment":"development","projects":["default"],"secret":"default:development.0000000000000000000000000000000000000000000000000000000000000000","username":"my-token-2","alias":null,"project":"default","createdAt":"2023-12-08T11:36:52.035Z"}`
+	var result ApiToken
+	err := json.Unmarshal([]byte(jsonString), &result)
+	if err != nil {
+		t.Errorf("Error unmarshalling json: %s", err)
+	}
+}
+
+func TestApiTokenResult(t *testing.T) {
+	jsonString := `{"tokens":[{"secret":"default:development.0000000000000000000000000000000000000000000000000000000000000000","tokenName":"token-a","type":"client","project":"default","projects":["default"],"environment":"development","expiresAt":null,"createdAt":"2023-12-08T09:23:19.962Z","alias":null,"seenAt":null,"username":"token-a"},{"secret":"*:production.0000000000000000000000000000000000000000000000000000000000000000","tokenName":"token-b","type":"client","project":"*","projects":["*"],"environment":"production","expiresAt":null,"createdAt":"2023-12-07T08:58:25.547Z","alias":null,"seenAt":null,"username":"token-b"},{"secret":"*:*.0000000000000000000000000000000000000000000000000000000000000000","tokenName":"admin","type":"admin","project":"*","projects":["*"],"environment":"*","expiresAt":null,"createdAt":"2023-05-31T06:54:22.698Z","alias":null,"seenAt":"2023-12-08T12:35:14.627Z","username":"admin"}]}`
+	var result ApiTokenResult
+	err := json.Unmarshal([]byte(jsonString), &result)
+	if err != nil {
+		t.Errorf("Error unmarshalling json: %s", err)
+	}
+}

--- a/pkg/unleashclient/admin_api_test.go
+++ b/pkg/unleashclient/admin_api_test.go
@@ -3,24 +3,71 @@ package unleashclient
 import (
 	"encoding/json"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestInstanceAdminStatsResult(t *testing.T) {
-	jsonString := `{"timestamp":"2023-04-11T10:19:45.131Z","instanceId":"9bb58ff2-f295-4dd1-80a9-13e0c22de2fd","versionOSS":"4.19.3","versionEnterprise":"","users":3,"featureToggles":2,"projects":1,"contextFields":4,"roles":5,"groups":0,"environments":3,"segments":0,"strategies":8,"SAMLenabled":false,"OIDCenabled":false,"sum":"b9d48b54fad852075c0d5407acc35e79238f00b41d877196b9e37767588b8553"}`
+	jsonString := `{"timestamp":"2023-12-09T19:41:44.853Z","instanceId":"01e6339c-23a9-4a51-b1a8-664a46536c2b","versionOSS":"5.6.6","versionEnterprise":"","users":3,"activeUsers":{"last7":1,"last30":1,"last60":1,"last90":3},"featureToggles":5,"projects":1,"contextFields":5,"roles":5,"customRootRoles":0,"customRootRolesInUse":0,"groups":0,"environments":3,"segments":0,"strategies":5,"SAMLenabled":false,"OIDCenabled":false,"clientApps":[{"range":"allTime","count":0},{"range":"30d","count":0},{"range":"7d","count":0}],"featureExports":0,"featureImports":0,"productionChanges":{"last30":1,"last60":1,"last90":1},"sum":"402a4b9c214464d0346e02ee9d5ac4d19071888020bbafc70c900aa13edf49bf"}`
 	var result InstanceAdminStatsResult
 	err := json.Unmarshal([]byte(jsonString), &result)
 	if err != nil {
 		t.Errorf("Error unmarshalling json: %s", err)
 	}
+
+	assert.Equal(t, "2023-12-09T19:41:44.853Z", result.Timestamp)
+	assert.Equal(t, "01e6339c-23a9-4a51-b1a8-664a46536c2b", result.InstanceID)
+	assert.Equal(t, "5.6.6", result.VersionOSS)
+	assert.Equal(t, "", result.VersionEnterprise)
+	assert.Equal(t, float64(3), result.Users)
+	assert.Equal(t, float64(1), result.ActiveUsers.Last7)
+	assert.Equal(t, float64(1), result.ActiveUsers.Last30)
+	assert.Equal(t, float64(1), result.ActiveUsers.Last60)
+	assert.Equal(t, float64(3), result.ActiveUsers.Last90)
+	assert.Equal(t, float64(5), result.FeatureToggles)
+	assert.Equal(t, float64(1), result.Projects)
+	assert.Equal(t, float64(5), result.ContextFields)
+	assert.Equal(t, float64(5), result.Roles)
+	assert.Equal(t, float64(0), result.CustomRootRoles)
+	assert.Equal(t, float64(0), result.CustomRootRolesInUse)
+	assert.Equal(t, float64(0), result.Groups)
+	assert.Equal(t, float64(3), result.Environments)
+	assert.Equal(t, float64(0), result.Segments)
+	assert.Equal(t, float64(5), result.Strategies)
+	assert.Equal(t, false, result.SAMLenabled)
+	assert.Equal(t, false, result.OIDCenabled)
+	assert.Equal(t, 3, len(result.ClientApps))
+	assert.Equal(t, "allTime", result.ClientApps[0].Range)
+	assert.Equal(t, float64(0), result.ClientApps[0].Count)
+	assert.Equal(t, "30d", result.ClientApps[1].Range)
+	assert.Equal(t, float64(0), result.ClientApps[1].Count)
+	assert.Equal(t, "7d", result.ClientApps[2].Range)
+	assert.Equal(t, float64(0), result.ClientApps[2].Count)
+	assert.Equal(t, float64(0), result.FeatureExports)
+	assert.Equal(t, float64(0), result.FeatureImports)
+	assert.Equal(t, float64(1), result.ProductionChanges.Last30)
+	assert.Equal(t, float64(1), result.ProductionChanges.Last60)
+	assert.Equal(t, float64(1), result.ProductionChanges.Last90)
+	assert.Equal(t, "402a4b9c214464d0346e02ee9d5ac4d19071888020bbafc70c900aa13edf49bf", result.Sum)
 }
 
 func TestApiToken(t *testing.T) {
-	jsonString := `{"tokenName":"my-token","type":"client","environment":"development","projects":["default"],"secret":"default:development.0000000000000000000000000000000000000000000000000000000000000000","username":"my-token-2","alias":null,"project":"default","createdAt":"2023-12-08T11:36:52.035Z"}`
+	jsonString := `{"tokenName":"my-token","type":"client","environment":"development","projects":["default"],"secret":"default:development.0000000000000000000000000000000000000000000000000000000000000000","username":"my-token","alias":null,"project":"default","createdAt":"2023-12-08T11:36:52.035Z"}`
 	var result ApiToken
 	err := json.Unmarshal([]byte(jsonString), &result)
 	if err != nil {
 		t.Errorf("Error unmarshalling json: %s", err)
 	}
+
+	assert.Equal(t, "my-token", result.TokenName)
+	assert.Equal(t, "client", result.Type)
+	assert.Equal(t, "development", result.Environment)
+	assert.Equal(t, "default", result.Projects[0])
+	assert.Equal(t, "default:development.0000000000000000000000000000000000000000000000000000000000000000", result.Secret)
+	assert.Equal(t, "my-token", result.Username)
+	assert.Equal(t, "", result.Alias)
+	assert.Equal(t, "default", result.Project)
+	assert.Equal(t, "2023-12-08T11:36:52.035Z", result.CreatedAt)
 }
 
 func TestApiTokenResult(t *testing.T) {
@@ -30,4 +77,6 @@ func TestApiTokenResult(t *testing.T) {
 	if err != nil {
 		t.Errorf("Error unmarshalling json: %s", err)
 	}
+
+	assert.Equal(t, 3, len(result.Tokens))
 }

--- a/pkg/utils/k8s_test.go
+++ b/pkg/utils/k8s_test.go
@@ -1,0 +1,106 @@
+package utils
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestRemoveEmptyErrs(t *testing.T) {
+	tests := []struct {
+		name   string
+		slice  []error
+		result []error
+	}{
+		{
+			name:   "No empty errors",
+			slice:  []error{errors.New("error 1"), errors.New("error 2")},
+			result: []error{errors.New("error 1"), errors.New("error 2")},
+		},
+		{
+			name:   "Some empty errors",
+			slice:  []error{errors.New("error 1"), nil, errors.New("error 2"), nil},
+			result: []error{errors.New("error 1"), errors.New("error 2")},
+		},
+		{
+			name:   "All empty errors",
+			slice:  []error{nil, nil, nil},
+			result: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := removeEmptyErrs(tt.slice)
+			if !reflect.DeepEqual(got, tt.result) {
+				t.Errorf("removeEmptyErrs() = %v, want %v", got, tt.result)
+			}
+		})
+	}
+}
+func TestEnvVar(t *testing.T) {
+	tests := []struct {
+		name     string
+		nameArg  string
+		valueArg string
+		expected corev1.EnvVar
+	}{
+		{
+			name:     "Test case 1",
+			nameArg:  "testName",
+			valueArg: "testValue",
+			expected: corev1.EnvVar{
+				Name:  "testName",
+				Value: "testValue",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := EnvVar(tt.nameArg, tt.valueArg)
+			if !reflect.DeepEqual(got, tt.expected) {
+				t.Errorf("EnvVar() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestSecretEnvVar(t *testing.T) {
+	tests := []struct {
+		name       string
+		nameArg    string
+		secretName string
+		secretKey  string
+		expected   corev1.EnvVar
+	}{
+		{
+			name:       "Test case 1",
+			nameArg:    "testName",
+			secretName: "testSecret",
+			secretKey:  "testKey",
+			expected: corev1.EnvVar{
+				Name: "testName",
+				ValueFrom: &corev1.EnvVarSource{
+					SecretKeyRef: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: "testSecret",
+						},
+						Key: "testKey",
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := SecretEnvVar(tt.nameArg, tt.secretName, tt.secretKey)
+			if !reflect.DeepEqual(got, tt.expected) {
+				t.Errorf("SecretEnvVar() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}

--- a/pkg/utils/rand_test.go
+++ b/pkg/utils/rand_test.go
@@ -8,12 +8,30 @@ import (
 )
 
 func TestRandomString(t *testing.T) {
-	length := 32
-	randomString, err := RandomString(length)
-	assert.NoError(t, err)
+	tests := []struct {
+		name   string
+		length int
+	}{
+		{
+			name:   "Test with length 16",
+			length: 16,
+		},
+		{
+			name:   "Test with length 32",
+			length: 32,
+		},
+		// Add more test cases as needed
+	}
 
-	base64String, err := base64.StdEncoding.DecodeString(randomString)
-	assert.NoError(t, err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			randomString, err := RandomString(tt.length)
+			assert.NoError(t, err)
 
-	assert.Equal(t, length, len(base64String))
+			base64String, err := base64.StdEncoding.DecodeString(randomString)
+			assert.NoError(t, err)
+
+			assert.Equal(t, tt.length, len(base64String))
+		})
+	}
 }

--- a/pkg/utils/strings.go
+++ b/pkg/utils/strings.go
@@ -1,0 +1,25 @@
+package utils
+
+func StringSliceEquals(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	for _, item := range a {
+		if !StringInSlice(item, b) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func StringInSlice(item string, slice []string) bool {
+	for _, s := range slice {
+		if item == s {
+			return true
+		}
+	}
+
+	return false
+}

--- a/pkg/utils/strings_test.go
+++ b/pkg/utils/strings_test.go
@@ -1,0 +1,54 @@
+package utils
+
+import (
+	"testing"
+)
+
+func TestStringSliceEquals(t *testing.T) {
+	tests := []struct {
+		name string
+		a    []string
+		b    []string
+		want bool
+	}{
+		{
+			name: "Equal slices",
+			a:    []string{"apple", "banana", "cherry"},
+			b:    []string{"apple", "banana", "cherry"},
+			want: true,
+		},
+		{
+			name: "Equal slices, different order",
+			a:    []string{"apple", "banana", "cherry"},
+			b:    []string{"banana", "cherry", "apple"},
+			want: true,
+		},
+		{
+			name: "Different lengths",
+			a:    []string{"apple", "banana", "cherry"},
+			b:    []string{"apple", "banana"},
+			want: false,
+		},
+		{
+			name: "Different elements",
+			a:    []string{"apple", "banana", "cherry"},
+			b:    []string{"apple", "orange", "cherry"},
+			want: false,
+		},
+		{
+			name: "Empty slices",
+			a:    []string{},
+			b:    []string{},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := StringSliceEquals(tt.a, tt.b)
+			if got != tt.want {
+				t.Errorf("StringSliceEquals() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The primary goal of this Pull Request is to solve #131 by updating the api token in Unleash if either type, environment or projects is changed.

* update token in Unleash if it does not match Kuberntes
  * allow changing env, projects, and type
* rewritten test suite for apitoken controller
* hardned test suite for remoteunleash controller
* token.Spec.Projects is now `default` by default instead of `*`
* add more data to the resulting token secret
  * `UNLEASH_SERVER_API_PROJECTS`
  * `UNLEASH_SERVER_API_TYPE`