### PR TITLE
Ignore casing for token type when comparing

### DIFF
--- a/api/v1/apitoken_types.go
+++ b/api/v1/apitoken_types.go
@@ -1,6 +1,8 @@
 package unleash_nais_io_v1
 
 import (
+	"strings"
+
 	"github.com/nais/unleasherator/pkg/unleashclient"
 	"github.com/nais/unleasherator/pkg/utils"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -123,7 +125,7 @@ func (t *ApiToken) ApiTokenRequest(suffix string) unleashclient.ApiTokenRequest 
 }
 
 func (t *ApiToken) ApiTokenIsEqual(token *unleashclient.ApiToken) bool {
-	return t.Spec.Type == token.Type &&
+	return strings.EqualFold(t.Spec.Type, token.Type) &&
 		t.Spec.Environment == token.Environment &&
 		utils.StringSliceEquals(t.Spec.Projects, token.Projects)
 }

--- a/api/v1/apitoken_types_test.go
+++ b/api/v1/apitoken_types_test.go
@@ -65,7 +65,7 @@ func TestApiToken_NamespacedName(t *testing.T) {
 func TestApiToken_IsEqual(t *testing.T) {
 	apiToken := &ApiToken{
 		Spec: ApiTokenSpec{
-			Type:        "client",
+			Type:        "CLIENT",
 			Environment: "development",
 			Projects:    []string{"project1", "project2"},
 		},
@@ -77,15 +77,19 @@ func TestApiToken_IsEqual(t *testing.T) {
 		Projects:    []string{"project1", "project2"},
 	}
 
+	// Test when the token types are case different
+	apiToken.Spec.Type = "ClIeNt"
+	assert.True(t, apiToken.ApiTokenIsEqual(unleashToken))
+
 	// Test when the tokens are equal
 	assert.True(t, apiToken.ApiTokenIsEqual(unleashToken))
 
 	// Test when the tokens have different types
-	unleashToken.Type = "server"
+	unleashToken.Type = "FRONTEND"
 	assert.False(t, apiToken.ApiTokenIsEqual(unleashToken))
 
 	// Test when the tokens have different environments
-	unleashToken.Type = "client"
+	unleashToken.Type = "CLIENT"
 	unleashToken.Environment = "production"
 	assert.False(t, apiToken.ApiTokenIsEqual(unleashToken))
 


### PR DESCRIPTION
This ensures that we are not constantly updating the tokens in Unleash when they
are in reallity not changed. Unleash will lower case token types after creation.
