### PR TITLE
Escape selector lables in Feature.yaml

### DIFF
--- a/charts/unleasherator/Feature.yaml
+++ b/charts/unleasherator/Feature.yaml
@@ -105,12 +105,12 @@ values:
       template: |
         - to:
           - namespaceSelector:
-              "kubernetes.io/metadata.name": nais-system
+              "kubernetes\.io/metadata\.name": nais-system
             podSelector:
               matchLabels:
-                "app.kubernetes.io/component": distributor
-                "app.kubernetes.io/instance": tempo
-                "app.kubernetes.io/name": tempo
+                "app\.kubernetes\.io/component": distributor
+                "app\.kubernetes\.io/instance": tempo
+                "app\.kubernetes\t s.io/name": tempo
           ports:
             - port: 4317
               protocol: TCP


### PR DESCRIPTION
```
14:45:05
W0128 13:45:05.130511     880 warnings.go:70] unknown field "spec.egress[2].to[0].namespaceSelector.kubernetes.io/metadata.name"
```