### PR TITLE
Add more attributes to Otel config

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -1,2 +1,2 @@
 LEADER_ELECTION_ENABLED=false
-OPERATOR_NAMESPACE=unleasherator-system
+POD_NAMESPACE=unleasherator-system

--- a/api/v1/remoteunleash_types.go
+++ b/api/v1/remoteunleash_types.go
@@ -132,9 +132,9 @@ func (u *RemoteUnleash) AdminSecretNamespacedName() types.NamespacedName {
 }
 
 // AdminToken returns the admin API token for the Unleash instance.
-func (u *RemoteUnleash) AdminToken(ctx context.Context, client client.Client, operatorNamespace string) ([]byte, error) {
-	// operatorNamespace is not used, and is only here to satisfy the interface of UnleashInstance.
-	_ = operatorNamespace
+func (u *RemoteUnleash) AdminToken(ctx context.Context, client client.Client, podNamespace string) ([]byte, error) {
+	// podNamespace is not used, and is only here to satisfy the interface of UnleashInstance.
+	_ = podNamespace
 
 	secret := &v1.Secret{}
 	if err := client.Get(ctx, u.AdminSecretNamespacedName(), secret); err != nil {
@@ -145,8 +145,8 @@ func (u *RemoteUnleash) AdminToken(ctx context.Context, client client.Client, op
 }
 
 // ApiClient returns an Unleash API client for the Unleash instance.
-func (u *RemoteUnleash) ApiClient(ctx context.Context, client client.Client, operatorNamespace string) (*unleashclient.Client, error) {
-	token, err := u.AdminToken(ctx, client, operatorNamespace)
+func (u *RemoteUnleash) ApiClient(ctx context.Context, client client.Client, podNamespace string) (*unleashclient.Client, error) {
+	token, err := u.AdminToken(ctx, client, podNamespace)
 	if err != nil {
 		return nil, err
 	}

--- a/api/v1/remoteunleash_types.go
+++ b/api/v1/remoteunleash_types.go
@@ -132,9 +132,9 @@ func (u *RemoteUnleash) AdminSecretNamespacedName() types.NamespacedName {
 }
 
 // AdminToken returns the admin API token for the Unleash instance.
-func (u *RemoteUnleash) AdminToken(ctx context.Context, client client.Client, podNamespace string) ([]byte, error) {
-	// podNamespace is not used, and is only here to satisfy the interface of UnleashInstance.
-	_ = podNamespace
+func (u *RemoteUnleash) AdminToken(ctx context.Context, client client.Client, namespace string) ([]byte, error) {
+	// namespace is not used, and is only here to satisfy the interface of UnleashInstance.
+	_ = namespace
 
 	secret := &v1.Secret{}
 	if err := client.Get(ctx, u.AdminSecretNamespacedName(), secret); err != nil {
@@ -145,8 +145,8 @@ func (u *RemoteUnleash) AdminToken(ctx context.Context, client client.Client, po
 }
 
 // ApiClient returns an Unleash API client for the Unleash instance.
-func (u *RemoteUnleash) ApiClient(ctx context.Context, client client.Client, podNamespace string) (*unleashclient.Client, error) {
-	token, err := u.AdminToken(ctx, client, podNamespace)
+func (u *RemoteUnleash) ApiClient(ctx context.Context, client client.Client, namespace string) (*unleashclient.Client, error) {
+	token, err := u.AdminToken(ctx, client, namespace)
 	if err != nil {
 		return nil, err
 	}

--- a/api/v1/unleash_types.go
+++ b/api/v1/unleash_types.go
@@ -290,9 +290,9 @@ func (u *Unleash) NamespacedNameWithSuffix(suffix string) types.NamespacedName {
 	}
 }
 
-func (u *Unleash) NamespacedOperatorSecretName(operatorNamespace string) types.NamespacedName {
+func (u *Unleash) NamespacedOperatorSecretName(podNamespace string) types.NamespacedName {
 	return types.NamespacedName{
-		Namespace: operatorNamespace,
+		Namespace: podNamespace,
 		Name:      u.GetOperatorSecretName(),
 	}
 }
@@ -324,10 +324,10 @@ func (u *Unleash) PublicWebURL() string {
 	return fmt.Sprintf("https://%s", u.Spec.WebIngress.Host)
 }
 
-func (u *Unleash) AdminToken(ctx context.Context, client client.Client, operatorNamespace string) ([]byte, error) {
+func (u *Unleash) AdminToken(ctx context.Context, client client.Client, podNamespace string) ([]byte, error) {
 	secret := &corev1.Secret{}
 
-	err := client.Get(ctx, u.NamespacedOperatorSecretName(operatorNamespace), secret)
+	err := client.Get(ctx, u.NamespacedOperatorSecretName(podNamespace), secret)
 	if err != nil {
 		return nil, err
 	}
@@ -335,8 +335,8 @@ func (u *Unleash) AdminToken(ctx context.Context, client client.Client, operator
 	return secret.Data[UnleashSecretTokenKey], nil
 }
 
-func (u *Unleash) ApiClient(ctx context.Context, client client.Client, operatorNamespace string) (*unleashclient.Client, error) {
-	token, err := u.AdminToken(ctx, client, operatorNamespace)
+func (u *Unleash) ApiClient(ctx context.Context, client client.Client, podNamespace string) (*unleashclient.Client, error) {
+	token, err := u.AdminToken(ctx, client, podNamespace)
 	if err != nil {
 		return nil, err
 	}

--- a/api/v1/unleash_types.go
+++ b/api/v1/unleash_types.go
@@ -290,9 +290,9 @@ func (u *Unleash) NamespacedNameWithSuffix(suffix string) types.NamespacedName {
 	}
 }
 
-func (u *Unleash) NamespacedOperatorSecretName(podNamespace string) types.NamespacedName {
+func (u *Unleash) NamespacedOperatorSecretName(namespace string) types.NamespacedName {
 	return types.NamespacedName{
-		Namespace: podNamespace,
+		Namespace: namespace,
 		Name:      u.GetOperatorSecretName(),
 	}
 }
@@ -324,10 +324,10 @@ func (u *Unleash) PublicWebURL() string {
 	return fmt.Sprintf("https://%s", u.Spec.WebIngress.Host)
 }
 
-func (u *Unleash) AdminToken(ctx context.Context, client client.Client, podNamespace string) ([]byte, error) {
+func (u *Unleash) AdminToken(ctx context.Context, client client.Client, namespace string) ([]byte, error) {
 	secret := &corev1.Secret{}
 
-	err := client.Get(ctx, u.NamespacedOperatorSecretName(podNamespace), secret)
+	err := client.Get(ctx, u.NamespacedOperatorSecretName(namespace), secret)
 	if err != nil {
 		return nil, err
 	}
@@ -335,8 +335,8 @@ func (u *Unleash) AdminToken(ctx context.Context, client client.Client, podNames
 	return secret.Data[UnleashSecretTokenKey], nil
 }
 
-func (u *Unleash) ApiClient(ctx context.Context, client client.Client, podNamespace string) (*unleashclient.Client, error) {
-	token, err := u.AdminToken(ctx, client, podNamespace)
+func (u *Unleash) ApiClient(ctx context.Context, client client.Client, namespace string) (*unleashclient.Client, error) {
+	token, err := u.AdminToken(ctx, client, namespace)
 	if err != nil {
 		return nil, err
 	}

--- a/api/v1/unleash_types_test.go
+++ b/api/v1/unleash_types_test.go
@@ -76,13 +76,13 @@ func TestUnleashNamespacedOperatorSecretName(t *testing.T) {
 		},
 	}
 
-	operatorNamespace := "operator-namespace"
+	podNamespace := "operator-namespace"
 	expected := types.NamespacedName{
-		Namespace: operatorNamespace,
+		Namespace: podNamespace,
 		Name:      unleash.GetOperatorSecretName(),
 	}
 
-	assert.Equal(t, unleash.NamespacedOperatorSecretName(operatorNamespace), expected, "Unexpected NamespacedName for operator secret")
+	assert.Equal(t, unleash.NamespacedOperatorSecretName(podNamespace), expected, "Unexpected NamespacedName for operator secret")
 }
 
 func TestUnleashNamespacedInstanceSecretName(t *testing.T) {

--- a/api/v1/unleash_types_test.go
+++ b/api/v1/unleash_types_test.go
@@ -76,13 +76,13 @@ func TestUnleashNamespacedOperatorSecretName(t *testing.T) {
 		},
 	}
 
-	podNamespace := "operator-namespace"
+	namespace := "operator-namespace"
 	expected := types.NamespacedName{
-		Namespace: podNamespace,
+		Namespace: namespace,
 		Name:      unleash.GetOperatorSecretName(),
 	}
 
-	assert.Equal(t, unleash.NamespacedOperatorSecretName(podNamespace), expected, "Unexpected NamespacedName for operator secret")
+	assert.Equal(t, unleash.NamespacedOperatorSecretName(namespace), expected, "Unexpected NamespacedName for operator secret")
 }
 
 func TestUnleashNamespacedInstanceSecretName(t *testing.T) {

--- a/charts/unleasherator/Feature.yaml
+++ b/charts/unleasherator/Feature.yaml
@@ -11,7 +11,7 @@ values:
     computed:
       template: '"{{ .Env.name }}"'
   # Federation
-  controllerManager.manager.env.federationClusterName:
+  controllerManager.manager.env.clusterName:
     computed:
       template: '"{{ .Env.name }}"'
   controllerManager.manager.env.federationPubsubGcpProjectId:

--- a/charts/unleasherator/templates/deployment.yaml
+++ b/charts/unleasherator/templates/deployment.yaml
@@ -46,8 +46,8 @@ spec:
         env:
         - name: API_TOKEN_NAME_SUFFIX
           value: {{ quote .Values.controllerManager.manager.env.apiTokenNameSuffix }}
-        - name: FEDERATION_CLUSTER_NAME
-          value: {{ quote .Values.controllerManager.manager.env.federationClusterName }}
+        - name: CLUSTER_NAME
+          value: {{ quote .Values.controllerManager.manager.env.clusterName }}
         - name: FEDERATION_PUBSUB_MODE
           value: {{ quote .Values.controllerManager.manager.env.federationPubsubMode }}
         - name: FEDERATION_PUBSUB_GCP_PROJECT_ID
@@ -65,7 +65,7 @@ spec:
           value: {{ quote .Values.controllerManager.manager.env.httpsProxy }}
         - name: NO_PROXY
           value: {{ quote .Values.controllerManager.manager.env.noProxy }}
-        - name: OPERATOR_NAMESPACE
+        - name: POD_NAMESPACE
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace

--- a/charts/unleasherator/templates/deployment.yaml
+++ b/charts/unleasherator/templates/deployment.yaml
@@ -69,6 +69,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: {{ quote .Values.controllerManager.manager.env.googleApplicationCredentials
             }}

--- a/charts/unleasherator/values.yaml
+++ b/charts/unleasherator/values.yaml
@@ -33,7 +33,7 @@ controllerManager:
     env:
       apiTokenNameSuffix: unleasherator
       featureApiTokenUpdateEnabled: "false"
-      federationClusterName: ""
+      clusterName: ""
       federationPubsubGcpProjectId: ""
       federationPubsubMode: ""
       federationPubsubSubscription: ""

--- a/charts/unleasherator/values.yaml
+++ b/charts/unleasherator/values.yaml
@@ -32,8 +32,8 @@ controllerManager:
         type: RuntimeDefault
     env:
       apiTokenNameSuffix: unleasherator
-      featureApiTokenUpdateEnabled: "false"
       clusterName: ""
+      featureApiTokenUpdateEnabled: "false"
       federationPubsubGcpProjectId: ""
       federationPubsubMode: ""
       federationPubsubSubscription: ""

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -102,7 +102,7 @@ func main() {
 		Client:            mgr.GetClient(),
 		Scheme:            mgr.GetScheme(),
 		Recorder:          mgr.GetEventRecorderFor("unleash-controller"),
-		OperatorNamespace: cfg.OperatorNamespace,
+		OperatorNamespace: cfg.PodNamespace,
 		Federation: controllers.UnleashFederation{
 			Enabled:   cfg.Federation.IsEnabled() && publisher != nil,
 			Publisher: publisher,
@@ -116,11 +116,11 @@ func main() {
 		Client:            mgr.GetClient(),
 		Scheme:            mgr.GetScheme(),
 		Recorder:          mgr.GetEventRecorderFor("remote-unleash-controller"),
-		OperatorNamespace: cfg.OperatorNamespace,
+		OperatorNamespace: cfg.PodNamespace,
 		Timeout:           cfg.Timeout,
 		Federation: controllers.RemoteUnleashFederation{
 			Enabled:     cfg.Federation.IsEnabled() && subscriber != nil,
-			ClusterName: cfg.Federation.ClusterName,
+			ClusterName: cfg.ClusterName,
 			Subscriber:  subscriber,
 		},
 	}
@@ -132,7 +132,7 @@ func main() {
 		Client:                mgr.GetClient(),
 		Scheme:                mgr.GetScheme(),
 		Recorder:              mgr.GetEventRecorderFor("api-token-controller"),
-		OperatorNamespace:     cfg.OperatorNamespace,
+		OperatorNamespace:     cfg.PodNamespace,
 		ApiTokenNameSuffix:    cfg.ApiTokenNameSuffix,
 		ApiTokenUpdateEnabled: cfg.Features.ApiTokenUpdateEnabled,
 	}).SetupWithManager(mgr); err != nil {

--- a/config/default/manager_config_patch.yaml
+++ b/config/default/manager_config_patch.yaml
@@ -13,7 +13,7 @@ spec:
         env:
         - name: API_TOKEN_NAME_SUFFIX
           value: "unleasherator"
-        - name: FEDERATION_CLUSTER_NAME
+        - name: CLUSTER_NAME
           value: ""
         - name: FEDERATION_PUBSUB_MODE
           value: ""
@@ -29,10 +29,14 @@ spec:
           value: ""
         - name: NO_PROXY
           value: ""
-        - name: OPERATOR_NAMESPACE
+        - name: POD_NAMESPACE
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: ""
         - name: HEALTH_PROBE_BIND_ADDRESS

--- a/controllers/remoteunleash_controller.go
+++ b/controllers/remoteunleash_controller.go
@@ -343,8 +343,8 @@ func (r *RemoteUnleashReconciler) FederationSubscribe(ctx context.Context) error
 		err := r.Federation.Subscriber.Subscribe(ctx, func(ctx context.Context, remoteUnleashes []*unleashv1.RemoteUnleash, adminSecret *corev1.Secret, clusters []string, status pb.Status) error {
 			log.Info("Received pubsub message", "status", status, "unleash", remoteUnleashes[0].GetName(), "clusters", clusters)
 
-			if !utils.StringInSlice(r.ClusterName, clusters) {
-				log.Info("Ignoring message, not for this cluster", "cluster", r.ClusterName, "clusters", clusters)
+			if !utils.StringInSlice(r.Federation.ClusterName, clusters) {
+				log.Info("Ignoring message, not for this cluster", "cluster", r.Federation.ClusterName, "clusters", clusters)
 				return nil
 			}
 

--- a/controllers/remoteunleash_controller.go
+++ b/controllers/remoteunleash_controller.go
@@ -343,8 +343,8 @@ func (r *RemoteUnleashReconciler) FederationSubscribe(ctx context.Context) error
 		err := r.Federation.Subscriber.Subscribe(ctx, func(ctx context.Context, remoteUnleashes []*unleashv1.RemoteUnleash, adminSecret *corev1.Secret, clusters []string, status pb.Status) error {
 			log.Info("Received pubsub message", "status", status, "unleash", remoteUnleashes[0].GetName(), "clusters", clusters)
 
-			if !utils.StringInSlice(r.Federation.ClusterName, clusters) {
-				log.Info("Ignoring message, not for this cluster", "cluster", r.Federation.ClusterName, "clusters", clusters)
+			if !utils.StringInSlice(r.ClusterName, clusters) {
+				log.Info("Ignoring message, not for this cluster", "cluster", r.ClusterName, "clusters", clusters)
 				return nil
 			}
 

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -29,7 +29,7 @@ import (
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
-const operatorNamespace = "default"
+const podNamespace = "default"
 
 var (
 	cfg                     *rest.Config
@@ -96,7 +96,7 @@ var _ = BeforeSuite(func() {
 	err = (&UnleashReconciler{
 		Client:            k8sManager.GetClient(),
 		Scheme:            k8sManager.GetScheme(),
-		OperatorNamespace: operatorNamespace,
+		OperatorNamespace: podNamespace,
 		Recorder:          k8sManager.GetEventRecorderFor("unleash-controller"),
 		Federation: UnleashFederation{
 			Enabled:   true,
@@ -109,7 +109,7 @@ var _ = BeforeSuite(func() {
 	remoteUnleashReconciler = &RemoteUnleashReconciler{
 		Client:            k8sManager.GetClient(),
 		Scheme:            k8sManager.GetScheme(),
-		OperatorNamespace: operatorNamespace,
+		OperatorNamespace: podNamespace,
 		Timeout:           timeout,
 		Federation: RemoteUnleashFederation{
 			Enabled:     true,
@@ -123,7 +123,7 @@ var _ = BeforeSuite(func() {
 	err = (&ApiTokenReconciler{
 		Client:                k8sManager.GetClient(),
 		Scheme:                k8sManager.GetScheme(),
-		OperatorNamespace:     operatorNamespace,
+		OperatorNamespace:     podNamespace,
 		ApiTokenNameSuffix:    ApiTokenNameSuffix,
 		ApiTokenUpdateEnabled: true,
 	}).SetupWithManager(k8sManager)

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -29,7 +29,7 @@ import (
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
-const podNamespace = "default"
+const namespace = "default"
 
 var (
 	cfg                     *rest.Config
@@ -96,7 +96,7 @@ var _ = BeforeSuite(func() {
 	err = (&UnleashReconciler{
 		Client:            k8sManager.GetClient(),
 		Scheme:            k8sManager.GetScheme(),
-		OperatorNamespace: podNamespace,
+		OperatorNamespace: namespace,
 		Recorder:          k8sManager.GetEventRecorderFor("unleash-controller"),
 		Federation: UnleashFederation{
 			Enabled:   true,
@@ -109,7 +109,7 @@ var _ = BeforeSuite(func() {
 	remoteUnleashReconciler = &RemoteUnleashReconciler{
 		Client:            k8sManager.GetClient(),
 		Scheme:            k8sManager.GetScheme(),
-		OperatorNamespace: podNamespace,
+		OperatorNamespace: namespace,
 		Timeout:           timeout,
 		Federation: RemoteUnleashFederation{
 			Enabled:     true,
@@ -123,7 +123,7 @@ var _ = BeforeSuite(func() {
 	err = (&ApiTokenReconciler{
 		Client:                k8sManager.GetClient(),
 		Scheme:                k8sManager.GetScheme(),
-		OperatorNamespace:     podNamespace,
+		OperatorNamespace:     namespace,
 		ApiTokenNameSuffix:    ApiTokenNameSuffix,
 		ApiTokenUpdateEnabled: true,
 	}).SetupWithManager(k8sManager)

--- a/controllers/unleash_controller_test.go
+++ b/controllers/unleash_controller_test.go
@@ -115,7 +115,7 @@ var _ = Describe("Unleash controller", func() {
 			Expect(k8sClient.Get(ctx, createdUnleash.NamespacedInstanceSecretName(), instanceSecret)).Should(Succeed())
 
 			operatorSecret := &corev1.Secret{}
-			Expect(k8sClient.Get(ctx, createdUnleash.NamespacedOperatorSecretName(operatorNamespace), operatorSecret)).Should(Succeed())
+			Expect(k8sClient.Get(ctx, createdUnleash.NamespacedOperatorSecretName(podNamespace), operatorSecret)).Should(Succeed())
 
 			networkPolicy := &networkingv1.NetworkPolicy{}
 			Expect(k8sClient.Get(ctx, createdUnleash.NamespacedName(), networkPolicy)).Should(Succeed())

--- a/controllers/unleash_controller_test.go
+++ b/controllers/unleash_controller_test.go
@@ -115,7 +115,7 @@ var _ = Describe("Unleash controller", func() {
 			Expect(k8sClient.Get(ctx, createdUnleash.NamespacedInstanceSecretName(), instanceSecret)).Should(Succeed())
 
 			operatorSecret := &corev1.Secret{}
-			Expect(k8sClient.Get(ctx, createdUnleash.NamespacedOperatorSecretName(podNamespace), operatorSecret)).Should(Succeed())
+			Expect(k8sClient.Get(ctx, createdUnleash.NamespacedOperatorSecretName(namespace), operatorSecret)).Should(Succeed())
 
 			networkPolicy := &networkingv1.NetworkPolicy{}
 			Expect(k8sClient.Get(ctx, createdUnleash.NamespacedName(), networkPolicy)).Should(Succeed())

--- a/docs/federation.md
+++ b/docs/federation.md
@@ -42,7 +42,7 @@ For Unleasherator to be able to create the Unleash instance, it needs to be conf
 
 | Name                                                         | Description                                                           | Default |
 | ------------------------------------------------------------ | --------------------------------------------------------------------- | ------- |
-| `controllerManager.manager.env.federationClusterName`        | Cluster name                                                          | `""`    |
+| `controllerManager.manager.env.clusterName`                  | Cluster name                                                          | `""`    |
 | `controllerManager.manager.env.federationPubsubMode`         | Federation mode, either `"publish"`, `"subscribe"` or `""` (disabled) | `""`    |
 | `controllerManager.manager.env.federationPubsubGcpProjectId` | GCP project ID for PubSub topic                                       | `""`    |
 | `controllerManager.manager.env.federationPubsubSubscription` | PubSub subscription ID                                                | `""`    |

--- a/docs/federation.md
+++ b/docs/federation.md
@@ -42,7 +42,7 @@ For Unleasherator to be able to create the Unleash instance, it needs to be conf
 
 | Name                                                         | Description                                                           | Default |
 | ------------------------------------------------------------ | --------------------------------------------------------------------- | ------- |
-| `controllerManager.manager.env.clusterName`                  | Cluster name                                                          | `""`    |
+| `controllerManager.manager.clusterName`                      | Cluster name                                                          | `""`    |
 | `controllerManager.manager.env.federationPubsubMode`         | Federation mode, either `"publish"`, `"subscribe"` or `""` (disabled) | `""`    |
 | `controllerManager.manager.env.federationPubsubGcpProjectId` | GCP project ID for PubSub topic                                       | `""`    |
 | `controllerManager.manager.env.federationPubsubSubscription` | PubSub subscription ID                                                | `""`    |

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -41,7 +41,9 @@ type Config struct {
 	LeaderElectionEnabled      bool   `envconfig:"LEADER_ELECTION_ENABLED" default:"true"`
 	LeaderElectionResourceName string `envconfig:"LEADER_ELECTION_RESOURCE_NAME" default:"509984d3.nais.io"`
 	MetricsBindAddress         string `envconfig:"METRICS_BIND_ADDRESS" default:"127.0.0.1:8080"`
-	OperatorNamespace          string `envconfig:"OPERATOR_NAMESPACE" required:"true"`
+	ClusterName                string `envconfig:"CLUSTER_NAME" required:"true"`
+	PodName                    string `envconfig:"POD_NAME" required:"true"`
+	PodNamespace               string `envconfig:"POD_NAMESPACE" required:"true"`
 	Log                        LogConfig
 	Timeout                    TimeoutConfig
 	WebhookPort                int `envconfig:"WEBHOOK_PORT" default:"9443"`
@@ -68,7 +70,7 @@ func (c *Config) ManagerOptions(scheme *runtime.Scheme) manager.Options {
 	return manager.Options{
 		Scheme:                  scheme,
 		LeaderElection:          c.LeaderElectionEnabled,
-		LeaderElectionNamespace: c.OperatorNamespace,
+		LeaderElectionNamespace: c.PodNamespace,
 		LeaderElectionID:        c.LeaderElectionResourceName,
 		Metrics: server.Options{
 			BindAddress: c.MetricsBindAddress,
@@ -87,7 +89,6 @@ func (t *TimeoutConfig) WriteContext(ctx context.Context) (context.Context, cont
 }
 
 type FederationConfig struct {
-	ClusterName        string         `envconfig:"FEDERATION_CLUSTER_NAME"`
 	Mode               FederationMode `envconfig:"FEDERATION_PUBSUB_MODE"`
 	PubsubProjectID    string         `envconfig:"FEDERATION_PUBSUB_GCP_PROJECT_ID"`
 	PubsubTopic        string         `envconfig:"FEDERATION_PUBSUB_TOPIC"`
@@ -116,7 +117,7 @@ func (c *Config) PubsubSubscriber(ctx context.Context) (federation.Subscriber, e
 
 	subscription := c.pubsubSubscription(ctx, client)
 
-	return federation.NewSubscriber(client, subscription, c.OperatorNamespace), nil
+	return federation.NewSubscriber(client, subscription, c.PodNamespace), nil
 }
 
 func (c *Config) PubsubPublisher(ctx context.Context) (federation.Publisher, error) {

--- a/pkg/federation/subscriber.go
+++ b/pkg/federation/subscriber.go
@@ -24,7 +24,7 @@ type Handler func(ctx context.Context, remoteUnleash []*unleashv1.RemoteUnleash,
 type subscriber struct {
 	client       *pubsub.Client
 	subscription *pubsub.Subscription
-	podNamespace string
+	namespace    string
 }
 
 // Close the pubsub client.
@@ -71,16 +71,16 @@ func (s *subscriber) handleMessage(ctx context.Context, msg *pubsub.Message, han
 	}
 
 	secretName := fmt.Sprintf("unleasherator-%s-%s", instance.GetName(), secretNonce)
-	adminSecret := resources.OperatorSecretForUnleash(instance.GetName(), secretName, s.podNamespace, instance.SecretToken)
+	adminSecret := resources.OperatorSecretForUnleash(instance.GetName(), secretName, s.namespace, instance.SecretToken)
 	remoteUnleashes := resources.RemoteunleashInstances(instance.GetName(), instance.GetUrl(), instance.GetNamespaces(), adminSecret.GetName(), adminSecret.GetNamespace())
 
 	return handler(ctx, remoteUnleashes, adminSecret, instance.Clusters, instance.Status)
 }
 
-func NewSubscriber(client *pubsub.Client, subscription *pubsub.Subscription, podNamespace string) Subscriber {
+func NewSubscriber(client *pubsub.Client, subscription *pubsub.Subscription, namespace string) Subscriber {
 	return &subscriber{
 		client:       client,
 		subscription: subscription,
-		podNamespace: podNamespace,
+		namespace:    namespace,
 	}
 }

--- a/pkg/federation/subscriber.go
+++ b/pkg/federation/subscriber.go
@@ -22,9 +22,9 @@ type Subscriber interface {
 type Handler func(ctx context.Context, remoteUnleash []*unleashv1.RemoteUnleash, adminSecret *corev1.Secret, clusters []string, status pb.Status) error
 
 type subscriber struct {
-	client            *pubsub.Client
-	subscription      *pubsub.Subscription
-	operatorNamespace string
+	client       *pubsub.Client
+	subscription *pubsub.Subscription
+	podNamespace string
 }
 
 // Close the pubsub client.
@@ -71,16 +71,16 @@ func (s *subscriber) handleMessage(ctx context.Context, msg *pubsub.Message, han
 	}
 
 	secretName := fmt.Sprintf("unleasherator-%s-%s", instance.GetName(), secretNonce)
-	adminSecret := resources.OperatorSecretForUnleash(instance.GetName(), secretName, s.operatorNamespace, instance.SecretToken)
+	adminSecret := resources.OperatorSecretForUnleash(instance.GetName(), secretName, s.podNamespace, instance.SecretToken)
 	remoteUnleashes := resources.RemoteunleashInstances(instance.GetName(), instance.GetUrl(), instance.GetNamespaces(), adminSecret.GetName(), adminSecret.GetNamespace())
 
 	return handler(ctx, remoteUnleashes, adminSecret, instance.Clusters, instance.Status)
 }
 
-func NewSubscriber(client *pubsub.Client, subscription *pubsub.Subscription, operatorNamespace string) Subscriber {
+func NewSubscriber(client *pubsub.Client, subscription *pubsub.Subscription, podNamespace string) Subscriber {
 	return &subscriber{
-		client:            client,
-		subscription:      subscription,
-		operatorNamespace: operatorNamespace,
+		client:       client,
+		subscription: subscription,
+		podNamespace: podNamespace,
 	}
 }

--- a/pkg/federation/subscriber_test.go
+++ b/pkg/federation/subscriber_test.go
@@ -18,7 +18,7 @@ import (
 
 func TestSubscriber_Subscribe(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-	operatorNamespace := "my-ns"
+	podNamespace := "my-ns"
 	apiToken := "test"
 	unleashName := "test"
 
@@ -31,7 +31,7 @@ func TestSubscriber_Subscribe(t *testing.T) {
 	defer c.Close()
 
 	// Create a new subscriber.
-	subscriber := NewSubscriber(c, subscription, operatorNamespace)
+	subscriber := NewSubscriber(c, subscription, podNamespace)
 
 	received := make(chan bool)
 	finished := false
@@ -68,7 +68,7 @@ func TestSubscriber_Subscribe(t *testing.T) {
 	// Start a goroutine to consume messages from the subscription.
 	go func() {
 		err = subscriber.Subscribe(ctx, func(ctx context.Context, remoteUnleashes []*unleashv1.RemoteUnleash, adminSecret *corev1.Secret, clusters []string, status pb.Status) error {
-			assert.Equal(t, operatorNamespace, adminSecret.GetNamespace())
+			assert.Equal(t, podNamespace, adminSecret.GetNamespace())
 			assert.Equal(t, "unleasherator-test-not-a-real-nonce", adminSecret.GetName())
 			assert.Equal(t, apiToken, adminSecret.StringData["token"])
 			assert.Equal(t, clusters, []string{"cluster-1", "cluster-2"})
@@ -96,7 +96,7 @@ func TestSubscriber_Subscribe(t *testing.T) {
 }
 
 func TestSubscriber_handleMessage(t *testing.T) {
-	var operatorNamespace = "unleasherator-system"
+	var podNamespace = "unleasherator-system"
 
 	instance := &pb.Instance{
 		Name:       "test-instance",
@@ -128,7 +128,7 @@ func TestSubscriber_handleMessage(t *testing.T) {
 		return nil
 	}
 
-	subscriber := &subscriber{operatorNamespace: operatorNamespace}
+	subscriber := &subscriber{podNamespace: podNamespace}
 	err = subscriber.handleMessage(context.Background(), msg, mockHandler)
 
 	assert.NoError(t, err)
@@ -145,7 +145,7 @@ func TestSubscriber_handleMessage(t *testing.T) {
 
 	assert.NotNil(t, capturedAdminSecret)
 	assert.True(t, strings.HasPrefix(capturedAdminSecret.Name, "unleasherator-"+instance.Name+"-"))
-	assert.Equal(t, operatorNamespace, capturedAdminSecret.Namespace)
+	assert.Equal(t, podNamespace, capturedAdminSecret.Namespace)
 	assert.Equal(t, instance.SecretToken, capturedAdminSecret.StringData["admin"])
 	assert.Equal(t, instance.Clusters, capturedClusters)
 	assert.Equal(t, instance.Status, capturedStatus)

--- a/pkg/o11y/tracing.go
+++ b/pkg/o11y/tracing.go
@@ -30,6 +30,9 @@ func InitTracing(ctx context.Context, config *config.Config) (*sdktrace.TracerPr
 		resource.NewWithAttributes(
 			semconv.SchemaURL,
 			semconv.ServiceName("Unleasherator"),
+			semconv.ServiceInstanceID(config.PodName),
+			semconv.ServiceNamespace(config.PodNamespace),
+			semconv.K8SClusterName(config.ClusterName),
 		),
 	)
 

--- a/pkg/resources/unleash.go
+++ b/pkg/resources/unleash.go
@@ -350,7 +350,7 @@ func IngressForUnleash(unleash *unleashv1.Unleash, config *unleashv1.UnleashIngr
 }
 
 // NetworkPolicyForUnleash returns the NetworkPolicy for the Unleash Deployment
-func NetworkPolicyForUnleash(unleash *unleashv1.Unleash, scheme *runtime.Scheme, operatorNamespace string) (*networkingv1.NetworkPolicy, error) {
+func NetworkPolicyForUnleash(unleash *unleashv1.Unleash, scheme *runtime.Scheme, podNamespace string) (*networkingv1.NetworkPolicy, error) {
 	labels := labelsForUnleash(unleash.GetName())
 
 	np := &networkingv1.NetworkPolicy{
@@ -374,7 +374,7 @@ func NetworkPolicyForUnleash(unleash *unleashv1.Unleash, scheme *runtime.Scheme,
 						{
 							NamespaceSelector: &metav1.LabelSelector{
 								MatchLabels: map[string]string{
-									"kubernetes.io/metadata.name": operatorNamespace,
+									"kubernetes.io/metadata.name": podNamespace,
 								},
 							},
 						},

--- a/pkg/resources/unleash.go
+++ b/pkg/resources/unleash.go
@@ -350,7 +350,7 @@ func IngressForUnleash(unleash *unleashv1.Unleash, config *unleashv1.UnleashIngr
 }
 
 // NetworkPolicyForUnleash returns the NetworkPolicy for the Unleash Deployment
-func NetworkPolicyForUnleash(unleash *unleashv1.Unleash, scheme *runtime.Scheme, podNamespace string) (*networkingv1.NetworkPolicy, error) {
+func NetworkPolicyForUnleash(unleash *unleashv1.Unleash, scheme *runtime.Scheme, namespace string) (*networkingv1.NetworkPolicy, error) {
 	labels := labelsForUnleash(unleash.GetName())
 
 	np := &networkingv1.NetworkPolicy{
@@ -374,7 +374,7 @@ func NetworkPolicyForUnleash(unleash *unleashv1.Unleash, scheme *runtime.Scheme,
 						{
 							NamespaceSelector: &metav1.LabelSelector{
 								MatchLabels: map[string]string{
-									"kubernetes.io/metadata.name": podNamespace,
+									"kubernetes.io/metadata.name": namespace,
 								},
 							},
 						},


### PR DESCRIPTION
New attributes:

* `semconv.ServiceInstanceID(config.PodName)`
* `semconv.ServiceNamespace(config.PodNamespace)`
* `semconv.K8SClusterName(config.ClusterName)`

Reference:

* https://opentelemetry.io/docs/specs/semconv/attributes-registry/k8s/
* https://opentelemetry.io/docs/specs/semconv/general/attributes/