### PR TITLE
Fix redundant re-reconcile of Deployment resources

### DIFF
--- a/controllers/unleash_controller.go
+++ b/controllers/unleash_controller.go
@@ -664,10 +664,12 @@ func (r *UnleashReconciler) reconcileDeployment(ctx context.Context, unleash *un
 			log.Error(err, "Failed to update Deployment", "Deployment.Namespace", found.Namespace, "Deployment.Name", found.Name)
 			return ctrl.Result{}, err
 		}
-	}
 
-	log.Info("Skip reconcile: Deployment already up to date", "Deployment.Namespace", found.Namespace, "Deployment.Name", found.Name)
-	return ctrl.Result{}, nil
+		return ctrl.Result{}, nil
+	} else {
+		log.Info("Skip reconcile: Deployment already up to date", "Deployment.Namespace", found.Namespace, "Deployment.Name", found.Name)
+		return ctrl.Result{}, nil
+	}
 }
 
 // reconcileService will ensure that the Service for the Unleash instance is created


### PR DESCRIPTION
Due to some fields not being set Deployment resources are always re-reconciled during reconciliation of Unleash resources.