### PR TITLE
More specific selector in servicemonitor

### DIFF
--- a/charts/unleasherator/templates/controller-manager-metrics-monitor.yaml
+++ b/charts/unleasherator/templates/controller-manager-metrics-monitor.yaml
@@ -20,4 +20,6 @@ spec:
       insecureSkipVerify: true
   selector:
     matchLabels:
+      app.kubernetes.io/instance: unleasherator
+      app.kubernets.io/name: unleasherator
       control-plane: controller-manager

--- a/config/prometheus/kustomization.yaml
+++ b/config/prometheus/kustomization.yaml
@@ -1,2 +1,9 @@
 resources:
 - monitor.yaml
+
+configurations:
+  - servicemonitor-matchlabels.yaml
+
+commonLabels:
+  app.kubernetes.io/name: prometheus
+  app.kubernetes.io/instance: system

--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -24,3 +24,5 @@ spec:
   selector:
     matchLabels:
       control-plane: controller-manager
+      app.kubernets.io/name: unleasherator
+      app.kubernetes.io/instance: unleasherator

--- a/config/prometheus/servicemonitor-matchlabels.yaml
+++ b/config/prometheus/servicemonitor-matchlabels.yaml
@@ -1,0 +1,5 @@
+labels:
+  - path: spec/selector/matchLabels
+    create: true
+    group: monitoring.coreos.com
+    kind: ServiceMonitor


### PR DESCRIPTION
Existing selector matches other services resulting in prometheus scrape errors