### PR TITLE
Build linux/arm64 container images

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -148,4 +148,4 @@ jobs:
           labels: ${{ steps.metadata.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
This pull request includes a change to the `.github/workflows/chart.yaml` file to expand the supported platforms for the build process.

Platform support update:

* [`.github/workflows/chart.yaml`](diffhunk://#diff-b4e327c49c11f0d80b3a8c30f79ccc0a972f3cf626b872a8775c9395e840aca6L143-R143): Added support for the `linux/arm64` platform alongside `linux/amd64` in the build configuration.