### PR TITLE
Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,7 +29,7 @@ updates:
       build-test:
         patterns:
           - "github.com/arttor/helmify/cmd/helmify"
-          - "github.com/golangci/golangci-lint/cmd/golangci-lint"
+          - "github.com/golangci/golangci-lint*"
           - "github.com/onsi/ginkgo/v2"
           - "github.com/jarcoal/httpmock"
           - "github.com/onsi/gomega"


### PR DESCRIPTION
This pull request includes a change to the `.github/dependabot.yml` file to improve the pattern matching for dependency updates.

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L32-R32): Updated the pattern for `golangci-lint` to use a wildcard, ensuring that all sub-packages are included in the updates.