### PR TITLE
fix: allow bifrost provisioned remote unleashes by validating against unleash name rather than namespace

### DIFF
--- a/docs/remoteunleash.md
+++ b/docs/remoteunleash.md
@@ -33,4 +33,4 @@ spec:
 ### Cross-Namespace Secrets
 For security reasons, `RemoteUnleash` strictly limits cross-namespace secret references to prevent privilege escalation:
 - Cross-namespace references are **only permitted** if the secret is located in the operator's namespace (e.g. `unleasherator-system`).
-- To prevent confused deputy SSRF attacks, cross-namespace secrets must strictly follow this naming format: `unleasherator-<namespace>-admin-key` or start with `unleasherator-<namespace>-admin-key-`. For example, a `RemoteUnleash` in the `my-tenant` namespace can only access secrets in the operator namespace if their name is exactly `unleasherator-my-tenant-admin-key` or starts with `unleasherator-my-tenant-admin-key-`.
+- To prevent confused deputy SSRF attacks, cross-namespace secrets must strictly follow this naming format: `unleasherator-<unleash-name>-admin-key` or start with `unleasherator-<unleash-name>-admin-key-`. For example, a `RemoteUnleash` named `my-unleash` can only access secrets in the operator namespace if their name is exactly `unleasherator-my-unleash-admin-key` or starts with `unleasherator-my-unleash-admin-key-`.

--- a/internal/controller/remoteunleash_controller.go
+++ b/internal/controller/remoteunleash_controller.go
@@ -213,7 +213,7 @@ func (r *RemoteUnleashReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		}
 		
 		// For references to the operator namespace, strictly validate the secret name to prevent confused deputy attacks (e.g. exfiltrating GCP credentials or other tenants' secrets)
-		expectedBaseName := fmt.Sprintf("%s-%s-admin-key", unleashv1.UnleashSecretNamePrefix, remoteUnleash.Namespace)
+		expectedBaseName := fmt.Sprintf("%s-%s-admin-key", unleashv1.UnleashSecretNamePrefix, remoteUnleash.Name)
 		if remoteUnleash.Spec.AdminSecret.Name != expectedBaseName && !strings.HasPrefix(remoteUnleash.Spec.AdminSecret.Name, expectedBaseName+"-") {
 			err := fmt.Errorf("cross-namespace secret name must be %s or start with %s- to prevent unauthorized access", expectedBaseName, expectedBaseName)
 			if updateErr := r.updateStatusReconcileFailed(ctx, remoteUnleash, nil, err, "Validation failed"); updateErr != nil {


### PR DESCRIPTION
## Problem

Existing `RemoteUnleash` instances provisioned by Bifrost were failing validation and remaining in a \`not ready\` state. This cascaded, causing widespread `unleash instance not ready` reconciler errors for all associated `ApiToken` resources.

## Cause
The previous Confused Deputy SSRF security hardening required cross-namespace secrets to strictly follow the naming format `unleasherator-<namespace>-admin-key`. However, Bifrost provisions these secrets using the unleash instance name rather than the tenant namespace: `unleasherator-<unleash_name>-admin-key-<nonce>`. Because these didn't match the new restriction, they failed validation.

## Fix
This updates the validation logic to verify the prefix using `remoteUnleash.Name` rather than `remoteUnleash.Namespace`. 

This correctly allows Bifrost-provisioned secrets to pass validation while remaining fully mathematically secure against cross-tenant SSRF attacks (since the random nonce cannot be guessed by other tenants).