### PR TITLE
fix(federation): grant required secret operations

### DIFF
--- a/charts/unleasherator/templates/manager-rbac.yaml
+++ b/charts/unleasherator/templates/manager-rbac.yaml
@@ -21,6 +21,8 @@ rules:
   - create
   - delete
   - get
+  - list
+  - patch
   - update
 - apiGroups:
   - ""

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -19,6 +19,8 @@ rules:
   - create
   - delete
   - get
+  - list
+  - patch
   - update
 - apiGroups:
   - ""

--- a/internal/controller/remoteunleash_controller.go
+++ b/internal/controller/remoteunleash_controller.go
@@ -83,7 +83,7 @@ type RemoteUnleashFederation struct {
 //+kubebuilder:rbac:groups=unleash.nais.io,resources=remoteunleashes,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=unleash.nais.io,resources=remoteunleashes/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=unleash.nais.io,resources=remoteunleashes/finalizers,verbs=update
-//+kubebuilder:rbac:groups=core,resources=secrets,verbs=get;create;update;delete
+//+kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;create;update;delete
 
 func (r *RemoteUnleashReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	spanOpts := o11y.ReconcilerAttributes(ctx, req)

--- a/internal/controller/unleash_controller.go
+++ b/internal/controller/unleash_controller.go
@@ -102,7 +102,7 @@ type UnleashFederation struct {
 //+kubebuilder:rbac:groups=unleash.nais.io,resources=unleashes/finalizers,verbs=update
 //+kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=core,resources=secrets,verbs=get;create;update;delete
+//+kubebuilder:rbac:groups=core,resources=secrets,verbs=get;create;update;patch;delete
 //+kubebuilder:rbac:groups=core,resources=services/finalizers,verbs=update
 //+kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 //+kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses,verbs=get;list;watch;create;update;patch;delete


### PR DESCRIPTION
## Summary

Fix the RBAC regression discovered during the first test-environment rollout of #746.

- Add `patch` for Secrets. `UnleashReconciler` patches stale URLs in operator Secrets; without this verb the new pod loops on `forbidden`.
- Add `list` for Secrets. Federation migration cleanup lists managed Secrets within the tenant and operator namespaces using strict managed labels, then validates namespace authorization and credentials before deletion.

## Rollout evidence

The `20260805-6e3d1ae` management pod reported:

```text
cannot patch resource "secrets" in API group "" in the namespace "nais-system"
```

The initial deploy remained federation-inert, but further rollout and the step-2 canary must wait for this fix.

## Security review

This changes the existing cluster-scoped Secret permission from:

```text
create, delete, get, update
```

to:

```text
create, delete, get, list, patch, update
```

`list` is security-sensitive. The migration code narrows each request to one of two namespaces and managed labels, and revalidates the authorized namespace and credential before deletion. The operator already has cluster-scoped Secret read/write access; this PR adds only operations exercised by the merged code.

## Validation

- `make test` with race detection
- `make all`
- Generated Helm and controller RBAC contain only the two required additional verbs
