### PR TITLE
fix(apitoken): retain finalizer on cleanup failure

### DIFF
--- a/internal/controller/apitoken_controller.go
+++ b/internal/controller/apitoken_controller.go
@@ -583,8 +583,9 @@ func (r *ApiTokenReconciler) cleanupTokenInUnleash(ctx context.Context, token *u
 	}
 
 	if !unleash.IsReady() {
-		log.Info("Unleash instance is not ready; skipping token cleanup")
-		return nil
+		// Retryable: a restarting instance may become ready shortly; the
+		// finalizer deadline bounds how long deletion can wait.
+		return fmt.Errorf("unleash instance not ready for token cleanup")
 	}
 
 	apiClient, err := r.apiClient(ctx, unleash)

--- a/internal/controller/apitoken_controller.go
+++ b/internal/controller/apitoken_controller.go
@@ -182,10 +182,9 @@ func (r *ApiTokenReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	if token.GetDeletionTimestamp() != nil {
 		log.Info("ApiToken marked for deletion")
 		if controllerutil.ContainsFinalizer(token, tokenFinalizer) {
-			// Try to clean up the token in Unleash if the instance exists
 			if err := r.cleanupTokenInUnleash(ctx, token, log); err != nil {
-				// Log but don't block deletion - the Unleash instance may not exist
-				log.Info("Could not clean up token in Unleash, proceeding with deletion", "error", err.Error())
+				log.Error(err, "Failed to clean up token in reachable Unleash instance")
+				return ctrl.Result{}, err
 			}
 
 			// Update status to indicate finalizing
@@ -507,50 +506,56 @@ func (r *ApiTokenReconciler) updateStatusFailed(ctx context.Context, apiToken *u
 	return nil
 }
 
-// doFinalizerOperationsForToken will delete the ApiToken from Unleash
-func (r *ApiTokenReconciler) doFinalizerOperationsForToken(ctx context.Context, token *unleashv1.ApiToken, unleashClient *unleashclient.Client, log logr.Logger) {
+// doFinalizerOperationsForToken deletes the ApiToken from Unleash.
+func (r *ApiTokenReconciler) doFinalizerOperationsForToken(ctx context.Context, token *unleashv1.ApiToken, unleashClient *unleashclient.Client, log logr.Logger) error {
 	tokenName := token.ApiTokenName(r.ApiTokenNameSuffix)
 	tokens, err := unleashClient.GetAPITokensByName(ctx, tokenName)
 	if err != nil {
 		log.Error(err, fmt.Sprintf("Failed to get ApiToken %s from Unleash", tokenName))
-		return
+		return fmt.Errorf("getting ApiToken %s from Unleash: %w", tokenName, err)
 	}
 
 	if tokens == nil || len(tokens.Tokens) == 0 {
 		log.Info(fmt.Sprintf("ApiToken %s not found in Unleash", tokenName))
-		return
+		return nil
 	}
 
 	for _, t := range tokens.Tokens {
 		log.Info(fmt.Sprintf("Deleting ApiToken %s from Unleash", t.TokenName))
-		err = unleashClient.DeleteApiToken(ctx, t.Secret)
-		if err != nil {
+		if err := unleashClient.DeleteApiToken(ctx, t.Secret); err != nil {
 			log.Error(err, fmt.Sprintf("Failed to delete ApiToken %s from Unleash", t.TokenName))
+			return fmt.Errorf("deleting ApiToken %s from Unleash: %w", t.TokenName, err)
 		}
 		log.Info(fmt.Sprintf("Successfully deleted ApiToken %s from Unleash", t.TokenName))
 	}
+	return nil
 }
 
-// cleanupTokenInUnleash attempts to delete the token from Unleash during finalization.
-// Returns an error if cleanup fails, but callers may choose to ignore this to allow deletion to proceed.
+// cleanupTokenInUnleash deletes the token during finalization when Unleash is reachable.
+// A missing or unavailable instance cannot be cleaned up and must not block CR deletion.
 func (r *ApiTokenReconciler) cleanupTokenInUnleash(ctx context.Context, token *unleashv1.ApiToken, log logr.Logger) error {
 	unleash, err := r.getUnleashInstance(ctx, token)
 	if err != nil {
-		return fmt.Errorf("failed to get Unleash instance: %w", err)
+		if apierrors.IsNotFound(err) {
+			log.Info("Unleash instance no longer exists; skipping token cleanup")
+			return nil
+		}
+		return fmt.Errorf("getting Unleash instance for token cleanup: %w", err)
 	}
 
 	if !unleash.IsReady() {
-		return fmt.Errorf("unleash instance not ready")
+		log.Info("Unleash instance is not ready; skipping token cleanup")
+		return nil
 	}
 
 	apiClient, err := r.apiClient(ctx, unleash)
 	if err != nil {
-		return fmt.Errorf("failed to create Unleash client: %w", err)
+		log.Info("Could not create Unleash client; skipping token cleanup", "error", err.Error())
+		return nil
 	}
 
 	log.Info("Performing Finalizer Operations for ApiToken before deletion")
-	r.doFinalizerOperationsForToken(ctx, token, apiClient, log)
-	return nil
+	return r.doFinalizerOperationsForToken(ctx, token, apiClient, log)
 }
 
 func (r *ApiTokenReconciler) apiClient(ctx context.Context, instance resources.UnleashInstance) (*unleashclient.Client, error) {

--- a/internal/controller/apitoken_controller.go
+++ b/internal/controller/apitoken_controller.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 	"time"
@@ -31,6 +32,11 @@ import (
 )
 
 const tokenFinalizer = "unleash.nais.io/finalizer"
+
+const (
+	apiTokenFinalizerCleanupTimeout  = 30 * time.Second
+	apiTokenFinalizerCleanupDeadline = 24 * time.Hour
+)
 
 var (
 	// API Token controller timeouts - prefixed to avoid conflicts with other controllers
@@ -182,9 +188,18 @@ func (r *ApiTokenReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	if token.GetDeletionTimestamp() != nil {
 		log.Info("ApiToken marked for deletion")
 		if controllerutil.ContainsFinalizer(token, tokenFinalizer) {
-			if err := r.cleanupTokenInUnleash(ctx, token, log); err != nil {
-				log.Error(err, "Failed to clean up token in reachable Unleash instance")
-				return ctrl.Result{}, err
+			if time.Since(token.DeletionTimestamp.Time) < apiTokenFinalizerCleanupDeadline {
+				cleanupCtx, cancel := context.WithTimeout(ctx, apiTokenFinalizerCleanupTimeout)
+				err := r.cleanupTokenInUnleash(cleanupCtx, token, log)
+				cancel()
+				if err != nil {
+					log.Error(err, "Failed to clean up token in reachable Unleash instance")
+					return ctrl.Result{}, err
+				}
+			} else {
+				r.Recorder.Event(token, "Warning", "TokenCleanupDeadlineExceeded",
+					"Proceeding with deletion after the token cleanup deadline elapsed")
+				log.Info("Token cleanup deadline exceeded; proceeding with deletion")
 			}
 
 			// Update status to indicate finalizing
@@ -511,6 +526,10 @@ func (r *ApiTokenReconciler) doFinalizerOperationsForToken(ctx context.Context, 
 	tokenName := token.ApiTokenName(r.ApiTokenNameSuffix)
 	tokens, err := unleashClient.GetAPITokensByName(ctx, tokenName)
 	if err != nil {
+		if isTerminalTokenCleanupError(err) {
+			log.Info("ApiToken lookup cannot be completed; proceeding with finalizer removal", "status", cleanupErrorStatusCode(err))
+			return nil
+		}
 		log.Error(err, fmt.Sprintf("Failed to get ApiToken %s from Unleash", tokenName))
 		return fmt.Errorf("getting ApiToken %s from Unleash: %w", tokenName, err)
 	}
@@ -523,12 +542,29 @@ func (r *ApiTokenReconciler) doFinalizerOperationsForToken(ctx context.Context, 
 	for _, t := range tokens.Tokens {
 		log.Info(fmt.Sprintf("Deleting ApiToken %s from Unleash", t.TokenName))
 		if err := unleashClient.DeleteApiToken(ctx, t.Secret); err != nil {
+			if isTerminalTokenCleanupError(err) {
+				log.Info("ApiToken deletion cannot be completed; proceeding with finalizer removal", "status", cleanupErrorStatusCode(err))
+				return nil
+			}
 			log.Error(err, fmt.Sprintf("Failed to delete ApiToken %s from Unleash", t.TokenName))
 			return fmt.Errorf("deleting ApiToken %s from Unleash: %w", t.TokenName, err)
 		}
 		log.Info(fmt.Sprintf("Successfully deleted ApiToken %s from Unleash", t.TokenName))
 	}
 	return nil
+}
+
+func isTerminalTokenCleanupError(err error) bool {
+	statusCode := cleanupErrorStatusCode(err)
+	return statusCode == 401 || statusCode == 403 || statusCode == 404 || statusCode == 405
+}
+
+func cleanupErrorStatusCode(err error) int {
+	var apiErr *unleashclient.UnleashAPIError
+	if errors.As(err, &apiErr) {
+		return apiErr.StatusCode
+	}
+	return 0
 }
 
 // cleanupTokenInUnleash deletes the token during finalization when Unleash is reachable.

--- a/internal/controller/apitoken_controller.go
+++ b/internal/controller/apitoken_controller.go
@@ -188,18 +188,21 @@ func (r *ApiTokenReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	if token.GetDeletionTimestamp() != nil {
 		log.Info("ApiToken marked for deletion")
 		if controllerutil.ContainsFinalizer(token, tokenFinalizer) {
-			if time.Since(token.DeletionTimestamp.Time) < apiTokenFinalizerCleanupDeadline {
-				cleanupCtx, cancel := context.WithTimeout(ctx, apiTokenFinalizerCleanupTimeout)
-				err := r.cleanupTokenInUnleash(cleanupCtx, token, log)
-				cancel()
-				if err != nil {
+			cleanupCtx, cancel := context.WithTimeout(ctx, apiTokenFinalizerCleanupTimeout)
+			err := r.cleanupTokenInUnleash(cleanupCtx, token, log)
+			cancel()
+			if err != nil {
+				if time.Since(token.DeletionTimestamp.Time) < apiTokenFinalizerCleanupDeadline {
 					log.Error(err, "Failed to clean up token in reachable Unleash instance")
 					return ctrl.Result{}, err
 				}
-			} else {
-				r.Recorder.Event(token, "Warning", "TokenCleanupDeadlineExceeded",
-					"Proceeding with deletion after the token cleanup deadline elapsed")
+				if r.Recorder != nil {
+					r.Recorder.Event(token, "Warning", "TokenCleanupDeadlineExceeded",
+						"Proceeding with deletion after the token cleanup deadline elapsed")
+				}
 				log.Info("Token cleanup deadline exceeded; proceeding with deletion")
+			} else {
+				log.Info("ApiToken cleanup completed")
 			}
 
 			// Update status to indicate finalizing
@@ -556,7 +559,7 @@ func (r *ApiTokenReconciler) doFinalizerOperationsForToken(ctx context.Context, 
 
 func isTerminalTokenCleanupError(err error) bool {
 	statusCode := cleanupErrorStatusCode(err)
-	return statusCode == 401 || statusCode == 403 || statusCode == 404 || statusCode == 405
+	return statusCode == 404 || statusCode == 405
 }
 
 func cleanupErrorStatusCode(err error) int {

--- a/internal/controller/apitoken_controller.go
+++ b/internal/controller/apitoken_controller.go
@@ -550,8 +550,11 @@ func (r *ApiTokenReconciler) cleanupTokenInUnleash(ctx context.Context, token *u
 
 	apiClient, err := r.apiClient(ctx, unleash)
 	if err != nil {
-		log.Info("Could not create Unleash client; skipping token cleanup", "error", err.Error())
-		return nil
+		if apierrors.IsNotFound(err) {
+			log.Info("Unleash credentials no longer exist; skipping token cleanup")
+			return nil
+		}
+		return fmt.Errorf("creating Unleash client for token cleanup: %w", err)
 	}
 
 	log.Info("Performing Finalizer Operations for ApiToken before deletion")

--- a/internal/controller/apitoken_controller_test.go
+++ b/internal/controller/apitoken_controller_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/jarcoal/httpmock"
@@ -286,21 +287,29 @@ var _ = Describe("ApiToken Controller", Ordered, func() {
 			Expect(k8sClient.Create(ctx, apiTokenCreated)).Should(Succeed())
 			Eventually(apiTokenEventually(ctx, apiTokenLookup, apiTokenCreated), timeout, interval).Should(ContainElement(apiTokenSuccessCondition()))
 
+			var deleteAttempts atomic.Int32
 			httpmock.RegisterResponder("DELETE", fmt.Sprintf("=~%s%s/.*", serverURL, unleashclient.ApiTokensEndpoint),
-				httpmock.NewStringResponder(http.StatusInternalServerError, "delete failed"))
+				func(*http.Request) (*http.Response, error) {
+					deleteAttempts.Add(1)
+					return httpmock.NewStringResponse(http.StatusInternalServerError, "delete failed"), nil
+				})
 			Expect(k8sClient.Delete(ctx, apiTokenCreated)).Should(Succeed())
 
-			Eventually(func(g Gomega) {
+			Eventually(func() int32 {
+				return deleteAttempts.Load()
+			}, timeout, interval).Should(BeNumerically(">=", 1))
+
+			Consistently(func(g Gomega) {
 				deletingToken := &unleashv1.ApiToken{}
 				g.Expect(k8sClient.Get(ctx, apiTokenLookup, deletingToken)).To(Succeed())
 				g.Expect(deletingToken.DeletionTimestamp).ToNot(BeNil())
 				g.Expect(deletingToken.Finalizers).To(ContainElement(tokenFinalizer))
-			}, timeout, interval).Should(Succeed())
+			}, 500*time.Millisecond, interval).Should(Succeed())
 
 			registerApiTokenMocks(serverURL)
 			Eventually(func() bool {
 				return apierrors.IsNotFound(k8sClient.Get(ctx, apiTokenLookup, &unleashv1.ApiToken{}))
-			}, timeout, interval).Should(BeTrue())
+			}, timeout*3, interval).Should(BeTrue())
 		})
 	})
 

--- a/internal/controller/apitoken_controller_test.go
+++ b/internal/controller/apitoken_controller_test.go
@@ -13,6 +13,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -263,6 +264,43 @@ var _ = Describe("ApiToken Controller", Ordered, func() {
 				err := k8sClient.Get(ctx, apiTokenLookup, &unleashv1.ApiToken{})
 				return err != nil
 			}, timeout, interval).Should(BeTrue(), "ApiToken should be deleted even when Unleash instance doesn't exist")
+		})
+	})
+
+	Context("When finalizing an ApiToken", func() {
+		It("Should retain the finalizer when token deletion fails", func() {
+			ctx := context.Background()
+			apiTokenName := "test-apitoken-finalizer-delete-failure"
+			apiTokenLookup := types.NamespacedName{Name: apiTokenName, Namespace: ApiTokenNamespace}
+			serverURL := mockRemoteUnleashURL(apiTokenName, ApiTokenNamespace)
+
+			secretCreated := remoteUnleashSecretResource(apiTokenName, ApiTokenNamespace, ApiTokenSecret)
+			Expect(k8sClient.Create(ctx, secretCreated)).Should(Succeed())
+
+			unleashKey, unleashCreated := remoteUnleashResource(apiTokenName, ApiTokenNamespace, serverURL, secretCreated)
+			registerApiTokenMocks(serverURL)
+			Expect(k8sClient.Create(ctx, unleashCreated)).Should(Succeed())
+			Eventually(remoteUnleashEventually(ctx, unleashKey, unleashCreated), timeout, interval).Should(ContainElement(remoteUnleashSuccessCondition()))
+
+			apiTokenCreated := remoteUnleashApiTokenResource(apiTokenName, ApiTokenNamespace, apiTokenName, unleashCreated)
+			Expect(k8sClient.Create(ctx, apiTokenCreated)).Should(Succeed())
+			Eventually(apiTokenEventually(ctx, apiTokenLookup, apiTokenCreated), timeout, interval).Should(ContainElement(apiTokenSuccessCondition()))
+
+			httpmock.RegisterResponder("DELETE", fmt.Sprintf("=~%s%s/.*", serverURL, unleashclient.ApiTokensEndpoint),
+				httpmock.NewStringResponder(http.StatusInternalServerError, "delete failed"))
+			Expect(k8sClient.Delete(ctx, apiTokenCreated)).Should(Succeed())
+
+			Eventually(func(g Gomega) {
+				deletingToken := &unleashv1.ApiToken{}
+				g.Expect(k8sClient.Get(ctx, apiTokenLookup, deletingToken)).To(Succeed())
+				g.Expect(deletingToken.DeletionTimestamp).ToNot(BeNil())
+				g.Expect(deletingToken.Finalizers).To(ContainElement(tokenFinalizer))
+			}, timeout, interval).Should(Succeed())
+
+			registerApiTokenMocks(serverURL)
+			Eventually(func() bool {
+				return apierrors.IsNotFound(k8sClient.Get(ctx, apiTokenLookup, &unleashv1.ApiToken{}))
+			}, timeout, interval).Should(BeTrue())
 		})
 	})
 

--- a/internal/controller/apitoken_controller_unit_test.go
+++ b/internal/controller/apitoken_controller_unit_test.go
@@ -1,11 +1,69 @@
 package controller
 
 import (
+	"context"
 	"errors"
 	"testing"
 
+	unleashv1 "github.com/nais/unleasherator/api/v1"
 	"github.com/nais/unleasherator/internal/unleashclient"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
+
+func TestCleanupTokenInUnleashRetriesWhenInstanceNotReady(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, unleashv1.AddToScheme(scheme))
+
+	remoteUnleash := &unleashv1.RemoteUnleash{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-remote", Namespace: "default"},
+	}
+	token := &unleashv1.ApiToken{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-token", Namespace: "default"},
+		Spec: unleashv1.ApiTokenSpec{
+			UnleashInstance: unleashv1.ApiTokenUnleashInstance{
+				Name:       remoteUnleash.Name,
+				Kind:       "RemoteUnleash",
+				ApiVersion: "unleash.nais.io/v1",
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(remoteUnleash).
+		Build()
+	reconciler := &ApiTokenReconciler{Client: fakeClient, Scheme: scheme}
+
+	err := reconciler.cleanupTokenInUnleash(context.Background(), token, ctrl.Log.WithName("test"))
+	require.Error(t, err, "not-ready instance must retain the finalizer instead of silently orphaning the token")
+	assert.Contains(t, err.Error(), "not ready")
+}
+
+func TestCleanupTokenInUnleashSkipsWhenInstanceIsAbsent(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, unleashv1.AddToScheme(scheme))
+
+	token := &unleashv1.ApiToken{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-token", Namespace: "default"},
+		Spec: unleashv1.ApiTokenSpec{
+			UnleashInstance: unleashv1.ApiTokenUnleashInstance{
+				Name:       "missing-remote",
+				Kind:       "RemoteUnleash",
+				ApiVersion: "unleash.nais.io/v1",
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	reconciler := &ApiTokenReconciler{Client: fakeClient, Scheme: scheme}
+
+	require.NoError(t, reconciler.cleanupTokenInUnleash(context.Background(), token, ctrl.Log.WithName("test")))
+}
 
 func TestIsTerminalTokenCleanupError(t *testing.T) {
 	tests := []struct {

--- a/internal/controller/apitoken_controller_unit_test.go
+++ b/internal/controller/apitoken_controller_unit_test.go
@@ -14,14 +14,14 @@ func TestIsTerminalTokenCleanupError(t *testing.T) {
 		terminal bool
 	}{
 		{
-			name:     "unauthorized is terminal",
+			name:     "unauthorized is retried",
 			err:      &unleashclient.UnleashAPIError{StatusCode: 401},
-			terminal: true,
+			terminal: false,
 		},
 		{
-			name:     "forbidden is terminal",
+			name:     "forbidden is retried",
 			err:      &unleashclient.UnleashAPIError{StatusCode: 403},
-			terminal: true,
+			terminal: false,
 		},
 		{
 			name:     "not found is terminal",

--- a/internal/controller/apitoken_controller_unit_test.go
+++ b/internal/controller/apitoken_controller_unit_test.go
@@ -1,0 +1,55 @@
+package controller
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/nais/unleasherator/internal/unleashclient"
+)
+
+func TestIsTerminalTokenCleanupError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		terminal bool
+	}{
+		{
+			name:     "unauthorized is terminal",
+			err:      &unleashclient.UnleashAPIError{StatusCode: 401},
+			terminal: true,
+		},
+		{
+			name:     "forbidden is terminal",
+			err:      &unleashclient.UnleashAPIError{StatusCode: 403},
+			terminal: true,
+		},
+		{
+			name:     "not found is terminal",
+			err:      &unleashclient.UnleashAPIError{StatusCode: 404},
+			terminal: true,
+		},
+		{
+			name:     "method not allowed is terminal",
+			err:      &unleashclient.UnleashAPIError{StatusCode: 405},
+			terminal: true,
+		},
+		{
+			name:     "server error is retried",
+			err:      &unleashclient.UnleashAPIError{StatusCode: 500},
+			terminal: false,
+		},
+		{
+			name:     "network error is retried",
+			err:      errors.New("connection refused"),
+			terminal: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isTerminalTokenCleanupError(tt.err); got != tt.terminal {
+				t.Fatalf("isTerminalTokenCleanupError() = %t, want %t", got, tt.terminal)
+			}
+		})
+	}
+}

--- a/internal/unleashclient/client.go
+++ b/internal/unleashclient/client.go
@@ -160,11 +160,7 @@ func (c *Client) HTTPDelete(ctx context.Context, requestPath string, item string
 	defer res.Body.Close()
 
 	if res.StatusCode != http.StatusOK {
-		body, err := io.ReadAll(res.Body)
-		if err != nil {
-			return err
-		}
-		return parseAPIError(res.StatusCode, body)
+		return &UnleashAPIError{StatusCode: res.StatusCode}
 	}
 	return nil
 }

--- a/internal/unleashclient/client.go
+++ b/internal/unleashclient/client.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -154,7 +155,7 @@ func (c *Client) HTTPDelete(ctx context.Context, requestPath string, item string
 
 	res, err := c.HttpClient.Do(req)
 	if err != nil {
-		return err
+		return fmt.Errorf("HTTP DELETE request failed: %w", withoutURLError(err))
 	}
 	defer res.Body.Close()
 
@@ -162,6 +163,19 @@ func (c *Client) HTTPDelete(ctx context.Context, requestPath string, item string
 		return fmt.Errorf("unexpected http status code %d", res.StatusCode)
 	}
 	return nil
+}
+
+func withoutURLError(err error) error {
+	for {
+		var urlErr *url.Error
+		if !errors.As(err, &urlErr) {
+			return err
+		}
+		if urlErr.Err == nil {
+			return errors.New("HTTP request failed")
+		}
+		err = urlErr.Err
+	}
 }
 
 func (c *Client) HTTPPost(ctx context.Context, requestPath string, p, v any) (*http.Response, error) {

--- a/internal/unleashclient/client.go
+++ b/internal/unleashclient/client.go
@@ -130,7 +130,7 @@ func (c *Client) HTTPGet(ctx context.Context, requestPath string, v any) (*http.
 	}
 
 	if res.StatusCode != http.StatusOK {
-		return res, fmt.Errorf("unexpected http status code %d", res.StatusCode)
+		return res, parseAPIError(res.StatusCode, body)
 	}
 
 	err = json.Unmarshal(body, v)
@@ -160,7 +160,11 @@ func (c *Client) HTTPDelete(ctx context.Context, requestPath string, item string
 	defer res.Body.Close()
 
 	if res.StatusCode != http.StatusOK {
-		return fmt.Errorf("unexpected http status code %d", res.StatusCode)
+		body, err := io.ReadAll(res.Body)
+		if err != nil {
+			return err
+		}
+		return parseAPIError(res.StatusCode, body)
 	}
 	return nil
 }

--- a/internal/unleashclient/client_test.go
+++ b/internal/unleashclient/client_test.go
@@ -1,8 +1,19 @@
 package unleashclient
 
 import (
+	"context"
+	"errors"
+	"net/http"
+	"net/url"
+	"strings"
 	"testing"
 )
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
 
 func TestNewClient(t *testing.T) {
 	_, err := NewClient("http://localhost:4242", "test")
@@ -25,5 +36,32 @@ func TestRequestURL(t *testing.T) {
 
 	if client.URL.String() != "http://localhost:4242/" {
 		t.Errorf("Expected URL to be http://localhost:4242/, got %s", client.URL.String())
+	}
+}
+
+func TestHTTPDeleteSanitizesTokenFromTransportError(t *testing.T) {
+	const token = "sensitive-token"
+	client, err := NewClientWithHttpClient("https://unleash.example.com", "admin-token", &http.Client{
+		Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			return nil, &url.Error{
+				Op:  "Delete",
+				URL: req.URL.String(),
+				Err: errors.New("connection refused"),
+			}
+		}),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = client.HTTPDelete(context.Background(), "/api/admin/api-tokens", token)
+	if err == nil {
+		t.Fatal("expected HTTP DELETE to fail")
+	}
+	if strings.Contains(err.Error(), token) {
+		t.Fatalf("transport error leaked token: %v", err)
+	}
+	if !strings.Contains(err.Error(), "connection refused") {
+		t.Fatalf("transport error lost cause: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary

Fixes a credential-lifecycle failure where an ApiToken finalizer could remove its Kubernetes finalizer after an Unleash token-delete failure, leaving a live, untracked credential.

- Propagate retryable token lookup and deletion errors after a ready Unleash client has been established.
- Keep the finalizer for retryable cleanup failures, with a 30-second request deadline and a 24-hour finalizer escape hatch.
- Treat a not-ready Unleash instance as retryable instead of silently orphaning the token.
- Treat 404/405 Unleash responses as terminal; retain the 24-hour retry window for 401/403 credential failures.
- Log deletion success only after Unleash confirms deletion.
- Redact token-bearing request URLs and DELETE response bodies from propagated errors.
- Preserve deletion only when the referenced Unleash instance or its credentials are absent; retain the finalizer for invalid client configuration.

## Validation

- Envtest proves a reachable RemoteUnleash returning HTTP 500 is observed, retains the finalizer over time, and completes deletion after a successful retry.
- Unit tests cover terminal API-error classification, token redaction from transport errors, and the not-ready/absent instance distinction.
- `make all` passes.

Closes #758