### PR TITLE
fix(federation): harden receive loop against poison messages and races

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -73,6 +73,7 @@ require (
 	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
 	github.com/jjti/go-spancheck v0.6.4 // indirect
 	github.com/karamaru-alpha/copyloopvar v1.2.1 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/lasiar/canonicalheader v1.1.2 // indirect
 	github.com/ldez/exptostd v0.4.2 // indirect
 	github.com/ldez/grignotin v0.9.0 // indirect

--- a/internal/controller/remoteunleash_controller.go
+++ b/internal/controller/remoteunleash_controller.go
@@ -457,6 +457,11 @@ func (r *RemoteUnleashReconciler) FederationSubscribe(ctx context.Context) error
 		// permanent handler error is recorded as the cancel cause; anything
 		// else from Receive is a transient subscription failure to retry.
 		started := time.Now()
+		// A run that stays up past the backoff cap counts as recovered; clear
+		// the gauge while healthy so alerts do not fire on a stale blip.
+		healthy := time.AfterFunc(federationReceiveBackoffMax, func() {
+			federationReceiveConsecutiveErrors.Set(0)
+		})
 		err := r.Federation.Subscriber.Subscribe(subCtx, func(ctx context.Context, remoteUnleashes []*unleashv1.RemoteUnleash, adminSecrets []*corev1.Secret, clusters []string, status pb.Status) error {
 			// failPermanently stops receiving so the operator restarts into a
 			// corrected configuration, but nacks the message: operator-side
@@ -733,9 +738,7 @@ func (r *RemoteUnleashReconciler) FederationSubscribe(ctx context.Context) error
 			}
 		})
 
-		// Subscribe returns when the subscription context is cancelled. A
-		// permanent handler error is recorded as the cancel cause; anything
-		// else from Receive is a transient subscription failure to retry.
+		healthy.Stop()
 		cancel(nil)
 
 		if ctx.Err() != nil {

--- a/internal/controller/remoteunleash_controller.go
+++ b/internal/controller/remoteunleash_controller.go
@@ -453,13 +453,18 @@ func (r *RemoteUnleashReconciler) FederationSubscribe(ctx context.Context) error
 		// receive loop exits deterministically.
 		subCtx, cancel := context.WithCancelCause(ctx)
 
+		// Subscribe returns when the subscription context is cancelled. A
+		// permanent handler error is recorded as the cancel cause; anything
+		// else from Receive is a transient subscription failure to retry.
+		started := time.Now()
 		err := r.Federation.Subscriber.Subscribe(subCtx, func(ctx context.Context, remoteUnleashes []*unleashv1.RemoteUnleash, adminSecrets []*corev1.Secret, clusters []string, status pb.Status) error {
-			// failPermanently stops receiving (operator must restart into a
-			// corrected configuration) and drops the message instead of
-			// redelivering it forever.
+			// failPermanently stops receiving so the operator restarts into a
+			// corrected configuration, but nacks the message: operator-side
+			// failures (e.g. RBAC) are recoverable, and the message must be
+			// redelivered once the operator is healthy again.
 			failPermanently := func(err error) error {
 				cancel(err)
-				return federation.Permanent(err)
+				return err
 			}
 			if len(remoteUnleashes) == 0 {
 				log.Info("Received pubsub message with no namespaces, ignoring", "status", status, "clusters", clusters)
@@ -624,6 +629,9 @@ func (r *RemoteUnleashReconciler) FederationSubscribe(ctx context.Context) error
 								client.ObjectKeyFromObject(existingRU),
 							)
 							if err != nil {
+								if !retriableError(err) {
+									return failPermanently(err)
+								}
 								return err
 							}
 							if !referencedByOther {
@@ -640,6 +648,9 @@ func (r *RemoteUnleashReconciler) FederationSubscribe(ctx context.Context) error
 						r.OperatorNamespace,
 					)
 					if err != nil {
+						if !retriableError(err) {
+							return failPermanently(err)
+						}
 						return err
 					}
 					for _, secret := range discoveredSecrets {
@@ -698,9 +709,17 @@ func (r *RemoteUnleashReconciler) FederationSubscribe(ctx context.Context) error
 					secretsToDelete = append(secretsToDelete, secret)
 				}
 				if errs := utils.DeleteAllObjects(cleanupCtx, r.Client, secretsToDelete); len(errs) > 0 {
+					var permanentErr error
 					for _, err := range errs {
 						remoteUnleashReceived.WithLabelValues("provisioned", "failed").Inc()
 						log.Error(err, "Failed to delete superseded federation admin secret")
+
+						if !retriableError(err) {
+							permanentErr = err
+						}
+					}
+					if permanentErr != nil {
+						return failPermanently(permanentErr)
 					}
 					return errs[0]
 				}
@@ -727,6 +746,15 @@ func (r *RemoteUnleashReconciler) FederationSubscribe(ctx context.Context) error
 		if cause := context.Cause(subCtx); cause != nil && !errors.Is(cause, context.Canceled) {
 			log.Error(cause, "Permanent federation handler error, stopping subscriber")
 			return cause
+		}
+
+		// A subscription that stayed up past the backoff cap counts as
+		// recovered; the next blip starts from a clean retry state instead of
+		// inheriting a pinned gauge and a five-minute delay.
+		if err == nil || time.Since(started) > federationReceiveBackoffMax {
+			consecutiveErrors = 0
+			backoff = federationReceiveBackoffBase
+			federationReceiveConsecutiveErrors.Set(0)
 		}
 
 		if err != nil {

--- a/internal/controller/remoteunleash_controller.go
+++ b/internal/controller/remoteunleash_controller.go
@@ -55,10 +55,23 @@ var (
 		},
 		[]string{"state", "status"},
 	)
+
+	federationReceiveConsecutiveErrors = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "unleasherator_federation_receive_consecutive_errors",
+			Help: "Consecutive Pub/Sub receive failures; non-zero sustained values indicate subscription instability",
+		},
+	)
+)
+
+const (
+	federationReceiveBackoffBase         = 1 * time.Second
+	federationReceiveBackoffMax          = 5 * time.Minute
+	federationReceiveEscalationThreshold = 10
 )
 
 func init() {
-	metrics.Registry.MustRegister(remoteUnleashStatus, remoteUnleashReceived)
+	metrics.Registry.MustRegister(remoteUnleashStatus, remoteUnleashReceived, federationReceiveConsecutiveErrors)
 }
 
 // RemoteUnleashReconciler reconciles a RemoteUnleash object
@@ -429,21 +442,37 @@ func (r *RemoteUnleashReconciler) FederationSubscribe(ctx context.Context) error
 		return nil
 	}
 
-	var permanentError error
+	backoff := federationReceiveBackoffBase
+	consecutiveErrors := 0
 
-	for ctx.Err() == nil && permanentError == nil {
+	for ctx.Err() == nil {
 		log.Info("Waiting for pubsub messages")
-		err := r.Federation.Subscriber.Subscribe(ctx, func(ctx context.Context, remoteUnleashes []*unleashv1.RemoteUnleash, adminSecrets []*corev1.Secret, clusters []string, status pb.Status) error {
+
+		// A permanent handler error cancels the subscription with the error as
+		// cause, so concurrent callbacks cannot race on shared state and the
+		// receive loop exits deterministically.
+		subCtx, cancel := context.WithCancelCause(ctx)
+
+		err := r.Federation.Subscriber.Subscribe(subCtx, func(ctx context.Context, remoteUnleashes []*unleashv1.RemoteUnleash, adminSecrets []*corev1.Secret, clusters []string, status pb.Status) error {
+			// failPermanently stops receiving (operator must restart into a
+			// corrected configuration) and drops the message instead of
+			// redelivering it forever.
+			failPermanently := func(err error) error {
+				cancel(err)
+				return federation.Permanent(err)
+			}
 			if len(remoteUnleashes) == 0 {
 				log.Info("Received pubsub message with no namespaces, ignoring", "status", status, "clusters", clusters)
 				return nil
 			}
 			if len(remoteUnleashes) != len(adminSecrets) {
-				return fmt.Errorf(
+				// Malformed payload can never be processed; drop it as poison
+				// without stopping the subscription.
+				return federation.Permanent(fmt.Errorf(
 					"federation payload produced %d RemoteUnleash resources and %d admin secrets",
 					len(remoteUnleashes),
 					len(adminSecrets),
-				)
+				))
 			}
 
 			log.Info("Received pubsub message", "status", status, "unleash", remoteUnleashes[0].GetName(), "clusters", clusters)
@@ -469,7 +498,7 @@ func (r *RemoteUnleashReconciler) FederationSubscribe(ctx context.Context) error
 					}
 					if err != nil {
 						if !retriableError(err) {
-							permanentError = err
+							return failPermanently(err)
 						}
 						return err
 					}
@@ -484,7 +513,7 @@ func (r *RemoteUnleashReconciler) FederationSubscribe(ctx context.Context) error
 					existingSecret, err := federationAdminSecret(ctx, r.APIReader, existingRU)
 					if err != nil {
 						if !retriableError(err) {
-							permanentError = err
+							return failPermanently(err)
 						}
 						return err
 					}
@@ -508,16 +537,17 @@ func (r *RemoteUnleashReconciler) FederationSubscribe(ctx context.Context) error
 				defer objectsCancel()
 
 				if errs := utils.DeleteAllObjects(objectsCtx, r.Client, safeRUs); len(errs) > 0 {
+					var permanentErr error
 					for _, err := range errs {
 						remoteUnleashReceived.WithLabelValues("removed", "failed").Inc()
 						log.Error(err, "Failed to delete RemoteUnleash")
 
 						if !retriableError(err) {
-							permanentError = err
+							permanentErr = err
 						}
 					}
-					if permanentError != nil {
-						return permanentError
+					if permanentErr != nil {
+						return failPermanently(permanentErr)
 					}
 					return errs[0]
 				}
@@ -527,16 +557,17 @@ func (r *RemoteUnleashReconciler) FederationSubscribe(ctx context.Context) error
 				defer secretCancel()
 
 				if errs := utils.DeleteAllObjects(secretCtx, r.Client, safeSecrets); len(errs) > 0 {
+					var permanentErr error
 					for _, err := range errs {
 						remoteUnleashReceived.WithLabelValues("removed", "failed").Inc()
 						log.Error(err, "Failed to delete admin secret")
 
 						if !retriableError(err) {
-							permanentError = err
+							permanentErr = err
 						}
 					}
-					if permanentError != nil {
-						return permanentError
+					if permanentErr != nil {
+						return failPermanently(permanentErr)
 					}
 					return errs[0]
 				}
@@ -558,7 +589,7 @@ func (r *RemoteUnleashReconciler) FederationSubscribe(ctx context.Context) error
 					err := r.APIReader.Get(ctx, client.ObjectKeyFromObject(ru), existingRU)
 					if err != nil && !apierrors.IsNotFound(err) {
 						if !retriableError(err) {
-							permanentError = err
+							return failPermanently(err)
 						}
 						return err
 					}
@@ -574,7 +605,7 @@ func (r *RemoteUnleashReconciler) FederationSubscribe(ctx context.Context) error
 						existingSecret, err := federationAdminSecret(ctx, r.APIReader, existingRU)
 						if err != nil {
 							if !retriableError(err) {
-								permanentError = err
+								return failPermanently(err)
 							}
 							return err
 						}
@@ -627,15 +658,16 @@ func (r *RemoteUnleashReconciler) FederationSubscribe(ctx context.Context) error
 				defer secretCancel()
 
 				if errs := utils.UpsertAllObjects(secretCtx, r.Client, safeSecrets); len(errs) > 0 {
+					var permanentErr error
 					for _, err := range errs {
 						remoteUnleashReceived.WithLabelValues("provisioned", "failed").Inc()
 
 						if !retriableError(err) {
-							permanentError = err
+							permanentErr = err
 						}
 					}
-					if permanentError != nil {
-						return permanentError
+					if permanentErr != nil {
+						return failPermanently(permanentErr)
 					}
 					return errs[0]
 				}
@@ -652,7 +684,7 @@ func (r *RemoteUnleashReconciler) FederationSubscribe(ctx context.Context) error
 							continue
 						} else {
 							if !retriableError(err) {
-								permanentError = err
+								return failPermanently(err)
 							}
 							return err
 						}
@@ -682,12 +714,53 @@ func (r *RemoteUnleashReconciler) FederationSubscribe(ctx context.Context) error
 			}
 		})
 
-		if err != nil {
-			return err
+		// Subscribe returns when the subscription context is cancelled. A
+		// permanent handler error is recorded as the cancel cause; anything
+		// else from Receive is a transient subscription failure to retry.
+		cancel(nil)
+
+		if ctx.Err() != nil {
+			federationReceiveConsecutiveErrors.Set(0)
+			return nil
 		}
+
+		if cause := context.Cause(subCtx); cause != nil && !errors.Is(cause, context.Canceled) {
+			log.Error(cause, "Permanent federation handler error, stopping subscriber")
+			return cause
+		}
+
+		if err != nil {
+			consecutiveErrors++
+			federationReceiveConsecutiveErrors.Set(float64(consecutiveErrors))
+			log.Error(err, "Federation subscription failed, reconnecting with backoff",
+				"attempt", consecutiveErrors, "backoff", backoff)
+			if consecutiveErrors >= federationReceiveEscalationThreshold {
+				log.Error(err, "Federation subscription has failed repeatedly",
+					"consecutiveErrors", consecutiveErrors)
+			}
+
+			timer := time.NewTimer(backoff)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				federationReceiveConsecutiveErrors.Set(0)
+				return nil
+			case <-timer.C:
+			}
+			backoff *= 2
+			if backoff > federationReceiveBackoffMax {
+				backoff = federationReceiveBackoffMax
+			}
+			continue
+		}
+
+		// Receive exited without an error or permanent cause; nothing more to do.
+		federationReceiveConsecutiveErrors.Set(0)
+		return nil
 	}
 
-	return permanentError
+	federationReceiveConsecutiveErrors.Set(0)
+	return nil
 }
 
 // retriableError returns true if the error is not a forbidden or unauthorized error.

--- a/internal/controller/remoteunleash_controller_test.go
+++ b/internal/controller/remoteunleash_controller_test.go
@@ -679,13 +679,19 @@ var _ = Describe("RemoteUnleash Controller", func() {
 			)
 			replacementRU.Spec.AdminSecret.Namespace = remoteUnleashReconciler.OperatorNamespace
 
-			Expect(handler(
-				ctx,
-				[]*unleashv1.RemoteUnleash{replacementRU},
-				[]*corev1.Secret{replacementSecret},
-				clusters,
-				pb.Status_Provisioned,
-			)).To(Succeed())
+			// The handler upserts the RemoteUnleash while the controller may
+			// concurrently update its status; conflicts are transient (in
+			// production the message would be nacked and redelivered), so
+			// retry until the idempotent handler converges.
+			Eventually(func() error {
+				return handler(
+					ctx,
+					[]*unleashv1.RemoteUnleash{replacementRU},
+					[]*corev1.Secret{replacementSecret},
+					clusters,
+					pb.Status_Provisioned,
+				)
+			}, timeout, interval).Should(Succeed())
 
 			Expect(k8sClient.Get(
 				ctx,

--- a/internal/controller/remoteunleash_federation_unit_test.go
+++ b/internal/controller/remoteunleash_federation_unit_test.go
@@ -1,0 +1,146 @@
+package controller
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	unleashv1 "github.com/nais/unleasherator/api/v1"
+	"github.com/nais/unleasherator/internal/federation"
+	mockfederation "github.com/nais/unleasherator/internal/federation/mockfediration"
+	"github.com/nais/unleasherator/internal/pb"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+)
+
+func federationTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, unleashv1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+	return scheme
+}
+
+func TestFederationSubscribeRetriesTransientErrors(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var subscribeCalls atomic.Int32
+	mockSubscriber := &mockfederation.MockSubscriber{}
+	mockSubscriber.On("Subscribe", mock.Anything, mock.Anything).
+		Run(func(mock.Arguments) { subscribeCalls.Add(1) }).
+		Return(errors.New("pubsub connection reset"))
+
+	scheme := federationTestScheme(t)
+	reconciler := &RemoteUnleashReconciler{
+		Client:    fake.NewClientBuilder().WithScheme(scheme).Build(),
+		APIReader: fake.NewClientBuilder().WithScheme(scheme).Build(),
+		Scheme:    scheme,
+		Federation: RemoteUnleashFederation{
+			Enabled:     true,
+			ClusterName: "test",
+			Subscriber:  mockSubscriber,
+		},
+	}
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- reconciler.FederationSubscribe(ctx) }()
+
+	require.Eventually(t, func() bool { return subscribeCalls.Load() >= 2 }, 5*time.Second, 10*time.Millisecond,
+		"transient receive errors must trigger a reconnect")
+	assert.GreaterOrEqual(t, testutil.ToFloat64(federationReceiveConsecutiveErrors), float64(2))
+
+	cancel()
+	require.NoError(t, <-errCh, "parent cancellation must shut down cleanly")
+	assert.Zero(t, testutil.ToFloat64(federationReceiveConsecutiveErrors))
+}
+
+func TestFederationSubscribeReturnsPermanentHandlerError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	forbidden := apierrors.NewForbidden(schema.GroupResource{Group: "unleash.nais.io", Resource: "remoteunleashes"}, "test", errors.New("rbac denied"))
+	scheme := federationTestScheme(t)
+	forbiddenClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(context.Context, client.WithWatch, client.ObjectKey, client.Object, ...client.GetOption) error {
+				return forbidden
+			},
+		}).
+		Build()
+
+	handlerCh := make(chan federation.Handler, 1)
+	mockSubscriber := &mockfederation.MockSubscriber{}
+	mockSubscriber.On("Subscribe", mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			handlerCh <- args.Get(1).(federation.Handler)
+			<-args.Get(0).(context.Context).Done()
+		}).
+		Return(nil)
+
+	reconciler := &RemoteUnleashReconciler{
+		Client:    forbiddenClient,
+		APIReader: forbiddenClient,
+		Scheme:    scheme,
+		Federation: RemoteUnleashFederation{
+			Enabled:     true,
+			ClusterName: "test",
+			Subscriber:  mockSubscriber,
+		},
+	}
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- reconciler.FederationSubscribe(ctx) }()
+
+	var handler federation.Handler
+	select {
+	case handler = <-handlerCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Subscribe was not called")
+	}
+
+	remoteUnleash := &unleashv1.RemoteUnleash{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "tenant"},
+	}
+	secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "secret", Namespace: "nais-system"}}
+
+	// Concurrent callbacks hitting the same permanent failure must not race on
+	// shared subscriber state; the first cancellation decides the cause.
+	done := make(chan struct{})
+	for range 4 {
+		go func() {
+			defer func() { done <- struct{}{} }()
+			err := handler(ctx, []*unleashv1.RemoteUnleash{remoteUnleash}, []*corev1.Secret{secret}, []string{"test"}, pb.Status_Removed)
+			var permanent *federation.PermanentError
+			assert.ErrorAs(t, err, &permanent)
+		}()
+	}
+	for range 4 {
+		<-done
+	}
+
+	select {
+	case err := <-errCh:
+		require.ErrorIs(t, err, forbidden, "permanent handler error must terminate the subscription")
+	case <-time.After(5 * time.Second):
+		t.Fatal("permanent handler error did not stop the subscription")
+	}
+}
+
+func TestFederationSubscribeDisabled(t *testing.T) {
+	reconciler := &RemoteUnleashReconciler{}
+	require.NoError(t, reconciler.FederationSubscribe(context.Background()))
+}

--- a/internal/controller/remoteunleash_federation_unit_test.go
+++ b/internal/controller/remoteunleash_federation_unit_test.go
@@ -60,7 +60,9 @@ func TestFederationSubscribeRetriesTransientErrors(t *testing.T) {
 
 	require.Eventually(t, func() bool { return subscribeCalls.Load() >= 2 }, 5*time.Second, 10*time.Millisecond,
 		"transient receive errors must trigger a reconnect")
-	assert.GreaterOrEqual(t, testutil.ToFloat64(federationReceiveConsecutiveErrors), float64(2))
+	require.Eventually(t, func() bool {
+		return testutil.ToFloat64(federationReceiveConsecutiveErrors) >= 2
+	}, 5*time.Second, 10*time.Millisecond)
 
 	cancel()
 	require.NoError(t, <-errCh, "parent cancellation must shut down cleanly")
@@ -124,8 +126,9 @@ func TestFederationSubscribeReturnsPermanentHandlerError(t *testing.T) {
 		go func() {
 			defer func() { done <- struct{}{} }()
 			err := handler(ctx, []*unleashv1.RemoteUnleash{remoteUnleash}, []*corev1.Secret{secret}, []string{"test"}, pb.Status_Removed)
-			var permanent *federation.PermanentError
-			assert.ErrorAs(t, err, &permanent)
+			// Recoverable operator-side failures (RBAC) nack the message so it
+			// is redelivered once the operator restarts healthy.
+			assert.ErrorIs(t, err, forbidden)
 		}()
 	}
 	for range 4 {

--- a/internal/controller/remoteunleash_federation_unit_test.go
+++ b/internal/controller/remoteunleash_federation_unit_test.go
@@ -126,9 +126,9 @@ func TestFederationSubscribeReturnsPermanentHandlerError(t *testing.T) {
 		go func() {
 			defer func() { done <- struct{}{} }()
 			err := handler(ctx, []*unleashv1.RemoteUnleash{remoteUnleash}, []*corev1.Secret{secret}, []string{"test"}, pb.Status_Removed)
-			// Recoverable operator-side failures (RBAC) nack the message so it
-			// is redelivered once the operator restarts healthy.
 			assert.ErrorIs(t, err, forbidden)
+			var permanent *federation.PermanentError
+			assert.NotErrorAs(t, err, &permanent, "RBAC failures must be nacked, not dropped")
 		}()
 	}
 	for range 4 {

--- a/internal/controller/remoteunleash_federation_unit_test.go
+++ b/internal/controller/remoteunleash_federation_unit_test.go
@@ -121,18 +121,17 @@ func TestFederationSubscribeReturnsPermanentHandlerError(t *testing.T) {
 
 	// Concurrent callbacks hitting the same permanent failure must not race on
 	// shared subscriber state; the first cancellation decides the cause.
-	done := make(chan struct{})
+	errs := make(chan error, 4)
 	for range 4 {
 		go func() {
-			defer func() { done <- struct{}{} }()
-			err := handler(ctx, []*unleashv1.RemoteUnleash{remoteUnleash}, []*corev1.Secret{secret}, []string{"test"}, pb.Status_Removed)
-			assert.ErrorIs(t, err, forbidden)
-			var permanent *federation.PermanentError
-			assert.NotErrorAs(t, err, &permanent, "RBAC failures must be nacked, not dropped")
+			errs <- handler(ctx, []*unleashv1.RemoteUnleash{remoteUnleash}, []*corev1.Secret{secret}, []string{"test"}, pb.Status_Removed)
 		}()
 	}
 	for range 4 {
-		<-done
+		err := <-errs
+		assert.ErrorIs(t, err, forbidden)
+		var permanent *federation.PermanentError
+		assert.NotErrorAs(t, err, &permanent, "RBAC failures must be nacked, not dropped")
 	}
 
 	select {

--- a/internal/federation/subscriber.go
+++ b/internal/federation/subscriber.go
@@ -25,9 +25,13 @@ import (
 )
 
 // PermanentError marks a message that can never be processed successfully
-// (unparseable payload, authorization failure). Such messages are poison:
-// redelivering them only blocks the subscription ordering key, so they are
-// acknowledged and dropped with an observable metric instead of nacked.
+// because its payload is malformed. Such messages are poison: redelivering
+// them only blocks the subscription ordering key, so they are acknowledged
+// and dropped with an observable metric instead of nacked.
+//
+// Recoverable operator-side failures (RBAC, API errors) must NOT use this:
+// they cancel the subscription to force a restart, but the message is nacked
+// so it is redelivered once the operator is healthy again.
 type PermanentError struct {
 	Err error
 }

--- a/internal/federation/subscriber.go
+++ b/internal/federation/subscriber.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 
 	"cloud.google.com/go/pubsub"
 	"github.com/nais/unleasherator/internal/pb"
 	"github.com/nais/unleasherator/internal/resources"
+	"github.com/prometheus/client_golang/prometheus"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/propagation"
@@ -17,9 +19,38 @@ import (
 	"google.golang.org/protobuf/proto"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
 
 	unleashv1 "github.com/nais/unleasherator/api/v1"
 )
+
+// PermanentError marks a message that can never be processed successfully
+// (unparseable payload, authorization failure). Such messages are poison:
+// redelivering them only blocks the subscription ordering key, so they are
+// acknowledged and dropped with an observable metric instead of nacked.
+type PermanentError struct {
+	Err error
+}
+
+func (e *PermanentError) Error() string { return e.Err.Error() }
+func (e *PermanentError) Unwrap() error { return e.Err }
+
+// Permanent wraps err so the subscriber acknowledges and drops the message.
+func Permanent(err error) *PermanentError {
+	return &PermanentError{Err: err}
+}
+
+var federationPoisonMessages = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "unleasherator_federation_poison_messages_total",
+		Help: "Number of federation Pub/Sub messages dropped after permanent failure",
+	},
+	[]string{"subscription"},
+)
+
+func init() {
+	metrics.Registry.MustRegister(federationPoisonMessages)
+}
 
 type Subscriber interface {
 	Subscribe(ctx context.Context, handler Handler) error
@@ -83,8 +114,22 @@ func (s *subscriber) Subscribe(ctx context.Context, handler Handler) error {
 		if err := s.handleMessage(ctx, msg, handler); err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
-			log.Error(err, "nack message")
-			msg.Nack()
+
+			var permanent *PermanentError
+			if errors.As(err, &permanent) {
+				// Count before acking so a dropped message is observable even
+				// if the log line is lost.
+				subID := ""
+				if s.subscription != nil {
+					subID = s.subscription.ID()
+				}
+				federationPoisonMessages.WithLabelValues(subID).Inc()
+				log.Error(err, "dropping poison message")
+				msg.Ack()
+			} else {
+				log.Error(err, "nack message")
+				msg.Nack()
+			}
 		} else {
 			log.Info("ack message")
 			msg.Ack()
@@ -105,7 +150,9 @@ func (s *subscriber) handleMessage(ctx context.Context, msg *pubsub.Message, han
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
 		log.Error(err, "unmarshal message")
-		return err
+		// An unparseable payload can never succeed; drop it instead of
+		// redelivering forever.
+		return Permanent(fmt.Errorf("unmarshal federation message: %w", err))
 	}
 
 	if instance.GetStatus() == pb.Status_Removed && instance.GetSecretToken() == "" {

--- a/internal/federation/subscriber_test.go
+++ b/internal/federation/subscriber_test.go
@@ -2,7 +2,9 @@ package federation
 
 import (
 	"context"
+	"errors"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -10,6 +12,7 @@ import (
 	"github.com/google/uuid"
 	unleashv1 "github.com/nais/unleasherator/api/v1"
 	"github.com/nais/unleasherator/internal/pb"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/protobuf/proto"
 	corev1 "k8s.io/api/core/v1"
@@ -258,4 +261,162 @@ func TestSubscriberIgnoresUnauthenticatedLegacyRemoval(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.False(t, handlerCalled)
+}
+
+func TestSubscriberDropsPoisonMessage(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	srv, conn, c, topic, subscription, err := newPubSub(ctx, "poison-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer srv.Close()
+	defer conn.Close()
+	defer c.Close()
+
+	subscriber := NewSubscriber(c, subscription, "unleasherator-system", true)
+
+	handlerCalls := make(chan struct{}, 10)
+	go func() {
+		_ = subscriber.Subscribe(ctx, func(context.Context, []*unleashv1.RemoteUnleash, []*corev1.Secret, []string, pb.Status) error {
+			handlerCalls <- struct{}{}
+			return nil
+		})
+	}()
+
+	// Poison message: bytes that can never unmarshal into pb.Instance.
+	res := topic.Publish(ctx, &pubsub.Message{
+		ID:          uuid.New().String(),
+		Data:        []byte("not-a-protobuf"),
+		PublishTime: time.Now(),
+		OrderingKey: "poison-ordering",
+	})
+	_, err = res.Get(ctx)
+	assert.NoError(t, err)
+
+	// A valid message with the same ordering key must not be blocked by the
+	// poison message: if the poison were nacked, redelivery would starve it.
+	instance := &pb.Instance{
+		Name:        "after-poison",
+		Url:         "https://after.example.com",
+		SecretToken: "token",
+		Namespaces:  []string{"namespace-a"},
+		Clusters:    []string{"cluster-a"},
+		Status:      pb.Status_Provisioned,
+	}
+	payload, err := proto.Marshal(instance)
+	assert.NoError(t, err)
+	res = topic.Publish(ctx, &pubsub.Message{
+		ID:          uuid.New().String(),
+		Data:        payload,
+		PublishTime: time.Now(),
+		OrderingKey: "poison-ordering",
+	})
+	_, err = res.Get(ctx)
+	assert.NoError(t, err)
+
+	select {
+	case <-handlerCalls:
+	case <-time.After(10 * time.Second):
+		t.Fatal("valid message was not processed; poison message blocked the ordering key")
+	}
+
+	assert.Eventually(t, func() bool {
+		return testutil.ToFloat64(federationPoisonMessages.WithLabelValues(subscription.ID())) >= 1
+	}, 5*time.Second, 10*time.Millisecond, "poison message must be counted before being dropped")
+}
+
+func TestSubscriberAcksPermanentHandlerError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	srv, conn, c, topic, subscription, err := newPubSub(ctx, "permanent-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer srv.Close()
+	defer conn.Close()
+	defer c.Close()
+
+	subscriber := NewSubscriber(c, subscription, "unleasherator-system", true)
+
+	var calls atomic.Int32
+	go func() {
+		_ = subscriber.Subscribe(ctx, func(context.Context, []*unleashv1.RemoteUnleash, []*corev1.Secret, []string, pb.Status) error {
+			calls.Add(1)
+			return Permanent(errors.New("authorization denied"))
+		})
+	}()
+
+	instance := &pb.Instance{
+		Name:        "permanent-instance",
+		Url:         "https://permanent.example.com",
+		SecretToken: "token",
+		Namespaces:  []string{"namespace-a"},
+		Clusters:    []string{"cluster-a"},
+		Status:      pb.Status_Provisioned,
+	}
+	payload, err := proto.Marshal(instance)
+	assert.NoError(t, err)
+	res := topic.Publish(ctx, &pubsub.Message{
+		ID:          uuid.New().String(),
+		Data:        payload,
+		PublishTime: time.Now(),
+		OrderingKey: "permanent-ordering",
+	})
+	_, err = res.Get(ctx)
+	assert.NoError(t, err)
+
+	assert.Eventually(t, func() bool { return calls.Load() == 1 }, 10*time.Second, 10*time.Millisecond)
+	// A nacked message would be redelivered promptly; an acked poison message
+	// must not be handled again.
+	time.Sleep(500 * time.Millisecond)
+	assert.Equal(t, int32(1), calls.Load(), "permanent error must be acked, not redelivered")
+	assert.GreaterOrEqual(t, testutil.ToFloat64(federationPoisonMessages.WithLabelValues(subscription.ID())), float64(1))
+}
+
+func TestSubscriberRedeliversTransientHandlerError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	srv, conn, c, topic, subscription, err := newPubSub(ctx, "transient-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer srv.Close()
+	defer conn.Close()
+	defer c.Close()
+
+	subscriber := NewSubscriber(c, subscription, "unleasherator-system", true)
+
+	var calls atomic.Int32
+	go func() {
+		_ = subscriber.Subscribe(ctx, func(context.Context, []*unleashv1.RemoteUnleash, []*corev1.Secret, []string, pb.Status) error {
+			calls.Add(1)
+			return errors.New("temporary API server failure")
+		})
+	}()
+
+	instance := &pb.Instance{
+		Name:        "transient-instance",
+		Url:         "https://transient.example.com",
+		SecretToken: "token",
+		Namespaces:  []string{"namespace-a"},
+		Clusters:    []string{"cluster-a"},
+		Status:      pb.Status_Provisioned,
+	}
+	payload, err := proto.Marshal(instance)
+	assert.NoError(t, err)
+	res := topic.Publish(ctx, &pubsub.Message{
+		ID:          uuid.New().String(),
+		Data:        payload,
+		PublishTime: time.Now(),
+		OrderingKey: "transient-ordering",
+	})
+	_, err = res.Get(ctx)
+	assert.NoError(t, err)
+
+	assert.Eventually(t, func() bool { return calls.Load() >= 2 }, 10*time.Second, 10*time.Millisecond,
+		"transient errors must be nacked and redelivered")
 }

--- a/internal/federation/subscriber_test.go
+++ b/internal/federation/subscriber_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"cloud.google.com/go/pubsub"
+	"cloud.google.com/go/pubsub/pstest"
 	"github.com/google/uuid"
 	unleashv1 "github.com/nais/unleasherator/api/v1"
 	"github.com/nais/unleasherator/internal/pb"
@@ -265,12 +266,13 @@ func TestSubscriberIgnoresUnauthenticatedLegacyRemoval(t *testing.T) {
 
 func TestSubscriberDropsPoisonMessage(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
 
 	srv, conn, c, topic, subscription, err := newPubSub(ctx, "poison-test")
 	if err != nil {
 		t.Fatal(err)
 	}
+	// Cancel Receive before tearing down the test server.
+	defer cancel()
 	defer srv.Close()
 	defer conn.Close()
 	defer c.Close()
@@ -329,12 +331,13 @@ func TestSubscriberDropsPoisonMessage(t *testing.T) {
 
 func TestSubscriberAcksPermanentHandlerError(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
 
 	srv, conn, c, topic, subscription, err := newPubSub(ctx, "permanent-test")
 	if err != nil {
 		t.Fatal(err)
 	}
+	// Cancel Receive before tearing down the test server.
+	defer cancel()
 	defer srv.Close()
 	defer conn.Close()
 	defer c.Close()
@@ -377,18 +380,27 @@ func TestSubscriberAcksPermanentHandlerError(t *testing.T) {
 }
 
 func TestSubscriberRedeliversTransientHandlerError(t *testing.T) {
+	// pstest redelivers nacked messages only after the subscription ack
+	// deadline; the default 10s makes this test slow and flaky.
+	pstest.SetMinAckDeadline(2 * time.Second)
+	defer pstest.ResetMinAckDeadline()
+
 	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
 
 	srv, conn, c, topic, subscription, err := newPubSub(ctx, "transient-test")
 	if err != nil {
 		t.Fatal(err)
 	}
+	// Cancel Receive before tearing down the test server.
+	defer cancel()
 	defer srv.Close()
 	defer conn.Close()
 	defer c.Close()
 
 	subscriber := NewSubscriber(c, subscription, "unleasherator-system", true)
+
+	_, err = subscription.Update(ctx, pubsub.SubscriptionConfigToUpdate{AckDeadline: 2 * time.Second})
+	assert.NoError(t, err)
 
 	var calls atomic.Int32
 	go func() {
@@ -417,6 +429,6 @@ func TestSubscriberRedeliversTransientHandlerError(t *testing.T) {
 	_, err = res.Get(ctx)
 	assert.NoError(t, err)
 
-	assert.Eventually(t, func() bool { return calls.Load() >= 2 }, 10*time.Second, 10*time.Millisecond,
+	assert.Eventually(t, func() bool { return calls.Load() >= 2 }, 30*time.Second, 50*time.Millisecond,
 		"transient errors must be nacked and redelivered")
 }

--- a/internal/federation/subscriber_test.go
+++ b/internal/federation/subscriber_test.go
@@ -271,11 +271,11 @@ func TestSubscriberDropsPoisonMessage(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	// Cancel Receive before tearing down the test server.
-	defer cancel()
 	defer srv.Close()
 	defer conn.Close()
 	defer c.Close()
+	// LIFO: Receive is cancelled before the test server is torn down.
+	defer cancel()
 
 	subscriber := NewSubscriber(c, subscription, "unleasherator-system", true)
 
@@ -336,11 +336,11 @@ func TestSubscriberAcksPermanentHandlerError(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	// Cancel Receive before tearing down the test server.
-	defer cancel()
 	defer srv.Close()
 	defer conn.Close()
 	defer c.Close()
+	// LIFO: Receive is cancelled before the test server is torn down.
+	defer cancel()
 
 	subscriber := NewSubscriber(c, subscription, "unleasherator-system", true)
 
@@ -391,11 +391,11 @@ func TestSubscriberRedeliversTransientHandlerError(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	// Cancel Receive before tearing down the test server.
-	defer cancel()
 	defer srv.Close()
 	defer conn.Close()
 	defer c.Close()
+	// LIFO: Receive is cancelled before the test server is torn down.
+	defer cancel()
 
 	subscriber := NewSubscriber(c, subscription, "unleasherator-system", true)
 


### PR DESCRIPTION
## Summary

Fixes three coupled defects in the federation Pub/Sub receive path.

- Poison messages (unparseable protobuf, malformed RemoteUnleash/admin-secret counts) are acknowledged with a `unleasherator_federation_poison_messages_total` metric instead of being nacked into infinite redelivery that blocks the ordering key.
- Recoverable operator-side failures (RBAC, API errors) cancel the subscription with cause so the operator restarts loudly, but nack the message so it is redelivered after recovery — no silent message loss.
- Transient `Receive` failures reconnect with exponential backoff (1s → 5m cap); `unleasherator_federation_receive_consecutive_errors` exposes consecutive failures for alerting and resets on healthy runs.
- Permanent-error handling is race-free via `context.WithCancelCause`; the shared `permanentError` variable is gone.

## Validation

- New tests prove: poison messages do not block the ordering key; permanent errors ack without redelivery; transient handler errors redeliver; transient receive errors reconnect; concurrent permanent failures terminate the subscription without data races; RBAC failures are nacked, never dropped.
- `go test -race -count=3` on affected packages, `make all`, and `make test` pass.
- Adversarial review (2 rounds): all blockers resolved.

Closes #752