### PR TITLE
feat(federation): migrate legacy admin secrets in reconcile

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -132,6 +132,7 @@ func main() {
 			Subscriber:  subscriber,
 		},
 		AllowLegacyNameBoundSecrets: cfg.Features.AllowLegacyNameBoundSecrets,
+		NamespaceBoundSecrets:       cfg.Features.FederationNamespaceBoundSecrets,
 		Tracer:                      tp.Tracer("remoteunleash-controller"),
 	}
 	if err = remoteUnleashReconciler.SetupWithManager(mgr); err != nil {

--- a/internal/controller/remoteunleash_controller.go
+++ b/internal/controller/remoteunleash_controller.go
@@ -268,13 +268,13 @@ func (r *RemoteUnleashReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		migrated, err := r.migrateLegacyAdminSecret(ctx, remoteUnleash, log)
 		if err != nil {
 			log.Error(err, "Failed to migrate legacy admin secret")
-			federationSecretMigrations.WithLabelValues("failed").Inc()
 			return ctrl.Result{}, err
 		}
 		if migrated {
 			// The spec change triggers the next reconcile via the generation
-			// predicate; it will validate the new reference end-to-end.
-			return ctrl.Result{}, nil
+			// predicate; the jittered requeue is belt-and-braces in case a
+			// future change makes the update a no-op.
+			return ctrl.Result{RequeueAfter: utils.RequeueAfterWithJitter(remoteUnleashRequeueAfter, remoteUnleashRequeueJitter)}, nil
 		}
 	}
 

--- a/internal/controller/remoteunleash_controller.go
+++ b/internal/controller/remoteunleash_controller.go
@@ -84,7 +84,11 @@ type RemoteUnleashReconciler struct {
 	Timeout                     config.TimeoutConfig
 	Federation                  RemoteUnleashFederation
 	AllowLegacyNameBoundSecrets bool
-	Tracer                      trace.Tracer
+	// NamespaceBoundSecrets enables reconcile-driven migration of legacy
+	// admin secrets to the namespace-bound layout when combined with
+	// AllowLegacyNameBoundSecrets.
+	NamespaceBoundSecrets bool
+	Tracer                trace.Tracer
 }
 
 type RemoteUnleashFederation struct {
@@ -256,6 +260,22 @@ func (r *RemoteUnleashReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	err = r.updateStatusSuccess(ctx, stats, remoteUnleash)
 	if err != nil {
 		return ctrl.Result{}, err
+	}
+
+	// The credential is verified by the stats call above; this is the safe
+	// point to move a legacy admin secret to the namespace-bound layout.
+	if r.NamespaceBoundSecrets && r.AllowLegacyNameBoundSecrets {
+		migrated, err := r.migrateLegacyAdminSecret(ctx, remoteUnleash, log)
+		if err != nil {
+			log.Error(err, "Failed to migrate legacy admin secret")
+			federationSecretMigrations.WithLabelValues("failed").Inc()
+			return ctrl.Result{}, err
+		}
+		if migrated {
+			// The spec change triggers the next reconcile via the generation
+			// predicate; it will validate the new reference end-to-end.
+			return ctrl.Result{}, nil
+		}
 	}
 
 	return ctrl.Result{RequeueAfter: utils.RequeueAfterWithJitter(remoteUnleashRequeueAfter, remoteUnleashRequeueJitter)}, nil

--- a/internal/controller/remoteunleash_migration.go
+++ b/internal/controller/remoteunleash_migration.go
@@ -1,0 +1,129 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/prometheus/client_golang/prometheus"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/util/retry"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/go-logr/logr"
+	unleashv1 "github.com/nais/unleasherator/api/v1"
+	"github.com/nais/unleasherator/internal/federation"
+	"github.com/nais/unleasherator/internal/resources"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+var federationSecretMigrations = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "unleasherator_federation_secret_migrations_total",
+		Help: "Number of RemoteUnleash admin secrets migrated from legacy to namespace-bound layout",
+	},
+	[]string{"result"},
+)
+
+func init() {
+	metrics.Registry.MustRegister(federationSecretMigrations)
+}
+
+// migrateLegacyAdminSecret moves a legacy (tenant-namespace or name-bound)
+// admin secret reference to the namespace-bound layout: the secret lives in
+// the operator namespace and carries the authoritative authorized-namespace
+// annotation. The credential is copied verbatim; it was already verified
+// against the Unleash server earlier in the reconcile.
+//
+// Ordering is deliberate: create the replacement first, repoint the
+// RemoteUnleash, then delete the legacy secret only when no other RemoteUnleash
+// still references it.
+func (r *RemoteUnleashReconciler) migrateLegacyAdminSecret(ctx context.Context, remoteUnleash *unleashv1.RemoteUnleash, log logr.Logger) (bool, error) {
+	legacyKey := remoteUnleash.AdminSecretNamespacedName()
+
+	legacySecret := &corev1.Secret{}
+	if err := r.Get(ctx, legacyKey, legacySecret); err != nil {
+		return false, fmt.Errorf("getting legacy admin secret: %w", err)
+	}
+
+	// Already namespace-bound: operator namespace secret carrying the
+	// authoritative annotation for this tenant namespace.
+	if legacyKey.Namespace == r.OperatorNamespace &&
+		legacySecret.Annotations[unleashv1.UnleashSecretAuthorizedNamespaceAnnotation] == remoteUnleash.Namespace {
+		return false, nil
+	}
+
+	token := legacySecret.Data[remoteUnleash.Spec.AdminSecret.Key]
+	if len(token) == 0 {
+		return false, fmt.Errorf("legacy admin secret %s is missing key %q", legacyKey, remoteUnleash.Spec.AdminSecret.Key)
+	}
+
+	// Same derivation as the federation subscriber, so a later republication
+	// with the same credential converges on the same secret name.
+	nonce, err := federation.StableSecretNonce(remoteUnleash.Name, remoteUnleash.Spec.Server.URL, string(token))
+	if err != nil {
+		return false, err
+	}
+	secretName := fmt.Sprintf("unleasherator-%s-%s-admin-key-%s", remoteUnleash.Name, remoteUnleash.Namespace, nonce)
+
+	newSecret := resources.OperatorSecretForUnleash(remoteUnleash.Name, secretName, r.OperatorNamespace, string(token), remoteUnleash.Spec.Server.URL)
+	if newSecret.Annotations == nil {
+		newSecret.Annotations = map[string]string{}
+	}
+	newSecret.Annotations[unleashv1.UnleashSecretAuthorizedNamespaceAnnotation] = remoteUnleash.Namespace
+
+	existing := &corev1.Secret{}
+	err = r.Get(ctx, client.ObjectKeyFromObject(newSecret), existing)
+	switch {
+	case apierrors.IsNotFound(err):
+		if err := r.Create(ctx, newSecret); err != nil {
+			return false, fmt.Errorf("creating namespace-bound admin secret: %w", err)
+		}
+	case err != nil:
+		return false, fmt.Errorf("getting namespace-bound admin secret: %w", err)
+	default:
+		if existing.Annotations[unleashv1.UnleashSecretAuthorizedNamespaceAnnotation] != remoteUnleash.Namespace ||
+			string(existing.Data[unleashv1.UnleashSecretServerURLKey]) != remoteUnleash.Spec.Server.URL ||
+			string(existing.Data[unleashv1.UnleashSecretTokenKey]) != string(token) {
+			return false, fmt.Errorf("namespace-bound admin secret %s already exists with conflicting content", client.ObjectKeyFromObject(newSecret))
+		}
+	}
+
+	// Repoint the RemoteUnleash before touching the legacy secret so a failure
+	// here leaves the working reference intact.
+	if err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		if err := r.Get(ctx, remoteUnleash.NamespacedName(), remoteUnleash); err != nil {
+			return err
+		}
+		remoteUnleash.Spec.AdminSecret.Name = secretName
+		remoteUnleash.Spec.AdminSecret.Namespace = r.OperatorNamespace
+		remoteUnleash.Spec.AdminSecret.Key = unleashv1.UnleashSecretTokenKey
+		return r.Update(ctx, remoteUnleash)
+	}); err != nil {
+		return false, fmt.Errorf("repointing RemoteUnleash to namespace-bound admin secret: %w", err)
+	}
+
+	shared, err := federationAdminSecretReferencedByOtherRemoteUnleash(
+		ctx, r.APIReader, legacyKey, client.ObjectKeyFromObject(remoteUnleash))
+	if err != nil {
+		return true, fmt.Errorf("checking legacy admin secret references: %w", err)
+	}
+	if shared {
+		log.Info("Preserving legacy admin secret referenced by another RemoteUnleash", "secret", legacyKey)
+		federationSecretMigrations.WithLabelValues("migrated").Inc()
+		return true, nil
+	}
+
+	if err := r.Delete(ctx, legacySecret); err != nil && !apierrors.IsNotFound(err) {
+		return true, fmt.Errorf("deleting legacy admin secret: %w", err)
+	}
+
+	log.Info("Migrated RemoteUnleash admin secret to namespace-bound layout",
+		"remoteUnleash", remoteUnleash.NamespacedName(), "secret", secretName)
+	if r.Recorder != nil {
+		r.Recorder.Event(remoteUnleash, "Normal", "FederationSecretMigrated",
+			"Admin secret migrated to the namespace-bound layout")
+	}
+	federationSecretMigrations.WithLabelValues("migrated").Inc()
+	return true, nil
+}

--- a/internal/controller/remoteunleash_migration.go
+++ b/internal/controller/remoteunleash_migration.go
@@ -83,15 +83,22 @@ func (r *RemoteUnleashReconciler) migrateLegacyAdminSecret(ctx context.Context, 
 	// Never derive the authoritative URL binding from tenant-controlled spec:
 	// pre-#746 legacy secrets carry no URL, and a tenant could otherwise point
 	// the spec at an attacker server and have the grant survive the legacy
-	// enforcement flip. Such secrets require one operator-driven republication
-	// (which writes the url key) before they can migrate.
-	if string(legacySecret.Data[unleashv1.UnleashSecretServerURLKey]) != remoteUnleash.Spec.Server.URL {
+	// enforcement flip.
+	recordedURL := string(legacySecret.Data[unleashv1.UnleashSecretServerURLKey])
+	if recordedURL != remoteUnleash.Spec.Server.URL {
 		if r.Recorder != nil {
 			r.Recorder.Event(remoteUnleash, "Warning", "FederationSecretMigrationRefused",
 				"Legacy admin secret does not assert its URL; republication is required before migration")
 		}
+		if recordedURL == "" {
+			// The documented, expected state before republication — not an
+			// error; the resource stays healthy on its normal requeue.
+			log.Info("Refusing to migrate legacy admin secret that does not assert its URL; republication required", "secret", legacyKey)
+			federationSecretMigrations.WithLabelValues("refused").Inc()
+			return false, nil
+		}
 		federationSecretMigrations.WithLabelValues("failed").Inc()
-		return false, fmt.Errorf("legacy admin secret %s does not assert spec.server.url; republication required", legacyKey)
+		return false, fmt.Errorf("legacy admin secret %s URL %q does not match spec.server.url %q", legacyKey, recordedURL, remoteUnleash.Spec.Server.URL)
 	}
 
 	// Refuse shared legacy secrets before minting anything: each referencing

--- a/internal/controller/remoteunleash_migration.go
+++ b/internal/controller/remoteunleash_migration.go
@@ -2,11 +2,14 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/prometheus/client_golang/prometheus"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -25,6 +28,10 @@ var federationSecretMigrations = prometheus.NewCounterVec(
 	[]string{"result"},
 )
 
+// errMigrationSuperseded aborts a repoint when the RemoteUnleash spec changed
+// while the migration was in flight (e.g. a concurrent federation rotation).
+var errMigrationSuperseded = errors.New("migration superseded by spec change")
+
 func init() {
 	metrics.Registry.MustRegister(federationSecretMigrations)
 }
@@ -41,8 +48,10 @@ func init() {
 func (r *RemoteUnleashReconciler) migrateLegacyAdminSecret(ctx context.Context, remoteUnleash *unleashv1.RemoteUnleash, log logr.Logger) (bool, error) {
 	legacyKey := remoteUnleash.AdminSecretNamespacedName()
 
+	// Read through the API directly: the migration must not act on stale
+	// cached state after a restart or cache lag.
 	legacySecret := &corev1.Secret{}
-	if err := r.Get(ctx, legacyKey, legacySecret); err != nil {
+	if err := r.APIReader.Get(ctx, legacyKey, legacySecret); err != nil {
 		return false, fmt.Errorf("getting legacy admin secret: %w", err)
 	}
 
@@ -53,13 +62,35 @@ func (r *RemoteUnleashReconciler) migrateLegacyAdminSecret(ctx context.Context, 
 		return false, nil
 	}
 
+	// Only ever touch operator-managed federation secrets. A tenant-authored
+	// same-namespace secret does not cross a privilege boundary and must never
+	// be rewritten or deleted by the operator.
+	legacyLabels := legacySecret.Labels
+	if legacyLabels["app.kubernetes.io/part-of"] != "unleasherator" ||
+		legacyLabels["app.kubernetes.io/created-by"] != "controller-manager" ||
+		legacyLabels["app.kubernetes.io/instance"] != remoteUnleash.Name ||
+		!strings.HasPrefix(legacySecret.Name, unleashv1.UnleashSecretNamePrefix+"-") {
+		log.V(1).Info("Admin secret is not operator-managed; skipping migration", "secret", legacyKey)
+		return false, nil
+	}
+
 	token := legacySecret.Data[remoteUnleash.Spec.AdminSecret.Key]
 	if len(token) == 0 {
+		federationSecretMigrations.WithLabelValues("failed").Inc()
 		return false, fmt.Errorf("legacy admin secret %s is missing key %q", legacyKey, remoteUnleash.Spec.AdminSecret.Key)
 	}
 
-	// Same derivation as the federation subscriber, so a later republication
-	// with the same credential converges on the same secret name.
+	// Refuse to launder a stale URL binding into the durable namespace-bound
+	// grant: a recorded URL that disagrees with the spec indicates drift.
+	if recordedURL := string(legacySecret.Data[unleashv1.UnleashSecretServerURLKey]); recordedURL != "" &&
+		recordedURL != remoteUnleash.Spec.Server.URL {
+		federationSecretMigrations.WithLabelValues("failed").Inc()
+		return false, fmt.Errorf("legacy admin secret %s URL does not match spec.server.url", legacyKey)
+	}
+
+	// Same derivation as the federation subscriber fallback, so a later
+	// republication of an instance without an explicit secret nonce converges
+	// on the same secret name.
 	nonce, err := federation.StableSecretNonce(remoteUnleash.Name, remoteUnleash.Spec.Server.URL, string(token))
 	if err != nil {
 		return false, err
@@ -71,12 +102,20 @@ func (r *RemoteUnleashReconciler) migrateLegacyAdminSecret(ctx context.Context, 
 		newSecret.Annotations = map[string]string{}
 	}
 	newSecret.Annotations[unleashv1.UnleashSecretAuthorizedNamespaceAnnotation] = remoteUnleash.Namespace
+	// Write Data directly so retries and conflict checks read back the same
+	// content; StringData is only converted by the API server on write.
+	newSecret.Data = map[string][]byte{
+		unleashv1.UnleashSecretTokenKey:     token,
+		unleashv1.UnleashSecretServerURLKey: []byte(remoteUnleash.Spec.Server.URL),
+	}
+	newSecret.StringData = nil
 
 	existing := &corev1.Secret{}
-	err = r.Get(ctx, client.ObjectKeyFromObject(newSecret), existing)
+	err = r.APIReader.Get(ctx, client.ObjectKeyFromObject(newSecret), existing)
 	switch {
 	case apierrors.IsNotFound(err):
-		if err := r.Create(ctx, newSecret); err != nil {
+		if err := r.Create(ctx, newSecret); err != nil && !apierrors.IsAlreadyExists(err) {
+			federationSecretMigrations.WithLabelValues("failed").Inc()
 			return false, fmt.Errorf("creating namespace-bound admin secret: %w", err)
 		}
 	case err != nil:
@@ -85,36 +124,59 @@ func (r *RemoteUnleashReconciler) migrateLegacyAdminSecret(ctx context.Context, 
 		if existing.Annotations[unleashv1.UnleashSecretAuthorizedNamespaceAnnotation] != remoteUnleash.Namespace ||
 			string(existing.Data[unleashv1.UnleashSecretServerURLKey]) != remoteUnleash.Spec.Server.URL ||
 			string(existing.Data[unleashv1.UnleashSecretTokenKey]) != string(token) {
+			if r.Recorder != nil {
+				r.Recorder.Event(remoteUnleash, "Warning", "FederationSecretMigrationConflict",
+					"Namespace-bound admin secret already exists with conflicting content; manual resolution required")
+			}
+			federationSecretMigrations.WithLabelValues("failed").Inc()
 			return false, fmt.Errorf("namespace-bound admin secret %s already exists with conflicting content", client.ObjectKeyFromObject(newSecret))
 		}
 	}
 
 	// Repoint the RemoteUnleash before touching the legacy secret so a failure
-	// here leaves the working reference intact.
+	// here leaves the working reference intact. Re-check the premise inside the
+	// retry: a concurrent federation update (e.g. rotation) must win.
 	if err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 		if err := r.Get(ctx, remoteUnleash.NamespacedName(), remoteUnleash); err != nil {
 			return err
+		}
+		if remoteUnleash.AdminSecretNamespacedName() != legacyKey {
+			return errMigrationSuperseded
 		}
 		remoteUnleash.Spec.AdminSecret.Name = secretName
 		remoteUnleash.Spec.AdminSecret.Namespace = r.OperatorNamespace
 		remoteUnleash.Spec.AdminSecret.Key = unleashv1.UnleashSecretTokenKey
 		return r.Update(ctx, remoteUnleash)
 	}); err != nil {
+		if errors.Is(err, errMigrationSuperseded) {
+			log.Info("Migration superseded by concurrent spec change", "remoteUnleash", remoteUnleash.NamespacedName())
+			return false, nil
+		}
+		federationSecretMigrations.WithLabelValues("failed").Inc()
 		return false, fmt.Errorf("repointing RemoteUnleash to namespace-bound admin secret: %w", err)
 	}
 
 	shared, err := federationAdminSecretReferencedByOtherRemoteUnleash(
 		ctx, r.APIReader, legacyKey, client.ObjectKeyFromObject(remoteUnleash))
 	if err != nil {
+		federationSecretMigrations.WithLabelValues("cleanup_failed").Inc()
 		return true, fmt.Errorf("checking legacy admin secret references: %w", err)
 	}
 	if shared {
 		log.Info("Preserving legacy admin secret referenced by another RemoteUnleash", "secret", legacyKey)
-		federationSecretMigrations.WithLabelValues("migrated").Inc()
+		federationSecretMigrations.WithLabelValues("preserved").Inc()
 		return true, nil
 	}
 
-	if err := r.Delete(ctx, legacySecret); err != nil && !apierrors.IsNotFound(err) {
+	// Delete with preconditions so a secret recreated after our read is never
+	// removed underneath its new owner.
+	if err := r.Delete(ctx, legacySecret, &client.DeleteOptions{
+		Preconditions: &metav1.Preconditions{
+			UID:             &legacySecret.UID,
+			ResourceVersion: &legacySecret.ResourceVersion,
+		},
+	}); err != nil && !apierrors.IsNotFound(err) && !apierrors.IsConflict(err) {
+		federationSecretMigrations.WithLabelValues("cleanup_failed").Inc()
 		return true, fmt.Errorf("deleting legacy admin secret: %w", err)
 	}
 

--- a/internal/controller/remoteunleash_migration.go
+++ b/internal/controller/remoteunleash_migration.go
@@ -80,12 +80,36 @@ func (r *RemoteUnleashReconciler) migrateLegacyAdminSecret(ctx context.Context, 
 		return false, fmt.Errorf("legacy admin secret %s is missing key %q", legacyKey, remoteUnleash.Spec.AdminSecret.Key)
 	}
 
-	// Refuse to launder a stale URL binding into the durable namespace-bound
-	// grant: a recorded URL that disagrees with the spec indicates drift.
-	if recordedURL := string(legacySecret.Data[unleashv1.UnleashSecretServerURLKey]); recordedURL != "" &&
-		recordedURL != remoteUnleash.Spec.Server.URL {
+	// Never derive the authoritative URL binding from tenant-controlled spec:
+	// pre-#746 legacy secrets carry no URL, and a tenant could otherwise point
+	// the spec at an attacker server and have the grant survive the legacy
+	// enforcement flip. Such secrets require one operator-driven republication
+	// (which writes the url key) before they can migrate.
+	if string(legacySecret.Data[unleashv1.UnleashSecretServerURLKey]) != remoteUnleash.Spec.Server.URL {
+		if r.Recorder != nil {
+			r.Recorder.Event(remoteUnleash, "Warning", "FederationSecretMigrationRefused",
+				"Legacy admin secret does not assert its URL; republication is required before migration")
+		}
 		federationSecretMigrations.WithLabelValues("failed").Inc()
-		return false, fmt.Errorf("legacy admin secret %s URL does not match spec.server.url", legacyKey)
+		return false, fmt.Errorf("legacy admin secret %s does not assert spec.server.url; republication required", legacyKey)
+	}
+
+	// Refuse shared legacy secrets before minting anything: each referencing
+	// RemoteUnleash would otherwise receive its own annotated grant, and the
+	// canary tooling already treats shared secrets as manual-review cases.
+	shared, err := federationAdminSecretReferencedByOtherRemoteUnleash(
+		ctx, r.APIReader, legacyKey, client.ObjectKeyFromObject(remoteUnleash))
+	if err != nil {
+		return false, fmt.Errorf("checking legacy admin secret references: %w", err)
+	}
+	if shared {
+		log.Info("Refusing to migrate shared legacy admin secret; migrate referencing resources manually", "secret", legacyKey)
+		if r.Recorder != nil {
+			r.Recorder.Event(remoteUnleash, "Warning", "FederationSecretMigrationRefused",
+				"Legacy admin secret is shared with another RemoteUnleash; manual migration required")
+		}
+		federationSecretMigrations.WithLabelValues("refused").Inc()
+		return false, nil
 	}
 
 	// Same derivation as the federation subscriber fallback, so a later
@@ -140,7 +164,8 @@ func (r *RemoteUnleashReconciler) migrateLegacyAdminSecret(ctx context.Context, 
 		if err := r.Get(ctx, remoteUnleash.NamespacedName(), remoteUnleash); err != nil {
 			return err
 		}
-		if remoteUnleash.AdminSecretNamespacedName() != legacyKey {
+		if remoteUnleash.AdminSecretNamespacedName() != legacyKey ||
+			remoteUnleash.Spec.Server.URL != string(newSecret.Data[unleashv1.UnleashSecretServerURLKey]) {
 			return errMigrationSuperseded
 		}
 		remoteUnleash.Spec.AdminSecret.Name = secretName
@@ -156,20 +181,8 @@ func (r *RemoteUnleashReconciler) migrateLegacyAdminSecret(ctx context.Context, 
 		return false, fmt.Errorf("repointing RemoteUnleash to namespace-bound admin secret: %w", err)
 	}
 
-	shared, err := federationAdminSecretReferencedByOtherRemoteUnleash(
-		ctx, r.APIReader, legacyKey, client.ObjectKeyFromObject(remoteUnleash))
-	if err != nil {
-		federationSecretMigrations.WithLabelValues("cleanup_failed").Inc()
-		return true, fmt.Errorf("checking legacy admin secret references: %w", err)
-	}
-	if shared {
-		log.Info("Preserving legacy admin secret referenced by another RemoteUnleash", "secret", legacyKey)
-		federationSecretMigrations.WithLabelValues("preserved").Inc()
-		return true, nil
-	}
-
-	// Delete with preconditions so a secret recreated after our read is never
-	// removed underneath its new owner.
+	// By this point the shared-secret check already refused migration, so the
+	// legacy secret is solely owned and can be deleted with preconditions.
 	if err := r.Delete(ctx, legacySecret, &client.DeleteOptions{
 		Preconditions: &metav1.Preconditions{
 			UID:             &legacySecret.UID,

--- a/internal/controller/remoteunleash_migration_test.go
+++ b/internal/controller/remoteunleash_migration_test.go
@@ -275,9 +275,26 @@ func TestMigrateLegacyAdminSecretRefusesURLDrift(t *testing.T) {
 	reconciler := migrationTestSetup(t, remoteUnleash, secret)
 
 	migrated, err := reconciler.migrateLegacyAdminSecret(context.Background(), remoteUnleash, ctrl.Log.WithName("test"))
-	require.Error(t, err)
+	require.Error(t, err, "a recorded URL that mismatches the spec is genuine drift and must fail")
 	assert.False(t, migrated)
-	assert.Contains(t, err.Error(), "republication required")
+	assert.Contains(t, err.Error(), "does not match")
+}
+
+func TestMigrateLegacyAdminSecretRefusesUnassertedURL(t *testing.T) {
+	remoteUnleash := legacyRemoteUnleash()
+	secret := legacySecret()
+	delete(secret.Data, unleashv1.UnleashSecretServerURLKey)
+	reconciler := migrationTestSetup(t, remoteUnleash, secret)
+
+	migrated, err := reconciler.migrateLegacyAdminSecret(context.Background(), remoteUnleash, ctrl.Log.WithName("test"))
+	require.NoError(t, err, "a missing URL is the expected pre-republication state, not an error")
+	assert.False(t, migrated)
+
+	updated := &unleashv1.RemoteUnleash{}
+	require.NoError(t, reconciler.Get(context.Background(), remoteUnleash.NamespacedName(), updated))
+	assert.Equal(t, "unleasherator-test-unleash-abc123", updated.Spec.AdminSecret.Name)
+	require.True(t, apierrors.IsNotFound(reconciler.Get(context.Background(), namespaceBoundSecretKey(t), &corev1.Secret{})),
+		"no grant may be minted without a secret-asserted URL")
 }
 
 func TestMigrateLegacyAdminSecretIsIdempotentOnRetry(t *testing.T) {

--- a/internal/controller/remoteunleash_migration_test.go
+++ b/internal/controller/remoteunleash_migration_test.go
@@ -58,6 +58,11 @@ func legacySecret() *corev1.Secret {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "unleasherator-test-unleash-abc123",
 			Namespace: migrationTenantNamespace,
+			Labels: map[string]string{
+				"app.kubernetes.io/instance":   "test-unleash",
+				"app.kubernetes.io/part-of":    "unleasherator",
+				"app.kubernetes.io/created-by": "controller-manager",
+			},
 		},
 		Data: map[string][]byte{
 			unleashv1.UnleashSecretTokenKey: []byte(migrationToken),
@@ -92,8 +97,8 @@ func TestMigrateLegacyAdminSecretMigratesTenantSecret(t *testing.T) {
 	require.NoError(t, reconciler.Get(context.Background(), namespaceBoundSecretKey(t), migratedSecret))
 	assert.Equal(t, migrationTenantNamespace,
 		migratedSecret.Annotations[unleashv1.UnleashSecretAuthorizedNamespaceAnnotation])
-	assert.Equal(t, migrationToken, migratedSecret.StringData[unleashv1.UnleashSecretTokenKey])
-	assert.Equal(t, migrationURL, migratedSecret.StringData[unleashv1.UnleashSecretServerURLKey])
+	assert.Equal(t, []byte(migrationToken), migratedSecret.Data[unleashv1.UnleashSecretTokenKey])
+	assert.Equal(t, []byte(migrationURL), migratedSecret.Data[unleashv1.UnleashSecretServerURLKey])
 
 	legacyKey := types.NamespacedName{Name: "unleasherator-test-unleash-abc123", Namespace: migrationTenantNamespace}
 	err = reconciler.Get(context.Background(), legacyKey, &corev1.Secret{})
@@ -211,4 +216,98 @@ func TestMigrateLegacyAdminSecretRequiresTokenKey(t *testing.T) {
 	require.Error(t, err)
 	assert.False(t, migrated)
 	assert.Contains(t, err.Error(), "missing key")
+}
+
+func TestMigrateLegacyAdminSecretSkipsTenantOwnedSecret(t *testing.T) {
+	remoteUnleash := legacyRemoteUnleash()
+	secret := legacySecret()
+	secret.Labels = nil // tenant-authored secret without operator labels
+	reconciler := migrationTestSetup(t, remoteUnleash, secret)
+
+	migrated, err := reconciler.migrateLegacyAdminSecret(context.Background(), remoteUnleash, ctrl.Log.WithName("test"))
+	require.NoError(t, err)
+	assert.False(t, migrated, "tenant-owned secrets must never be migrated or deleted")
+
+	updated := &unleashv1.RemoteUnleash{}
+	require.NoError(t, reconciler.Get(context.Background(), remoteUnleash.NamespacedName(), updated))
+	assert.Equal(t, "unleasherator-test-unleash-abc123", updated.Spec.AdminSecret.Name)
+
+	legacyKey := types.NamespacedName{Name: secret.Name, Namespace: migrationTenantNamespace}
+	require.NoError(t, reconciler.Get(context.Background(), legacyKey, &corev1.Secret{}),
+		"tenant-owned secret must be preserved")
+}
+
+func TestMigrateLegacyAdminSecretAbortsOnConcurrentSpecChange(t *testing.T) {
+	remoteUnleash := legacyRemoteUnleash()
+	secret := legacySecret()
+	reconciler := migrationTestSetup(t, remoteUnleash, secret)
+
+	// Simulate a concurrent federation rotation repointing the resource before
+	// the migration's spec update lands.
+	updated := &unleashv1.RemoteUnleash{}
+	require.NoError(t, reconciler.Get(context.Background(), remoteUnleash.NamespacedName(), updated))
+	updated.Spec.AdminSecret.Name = "unleasherator-test-unleash-tenant-a-admin-key-rotated"
+	updated.Spec.AdminSecret.Namespace = migrationOperatorNamespace
+	require.NoError(t, reconciler.Update(context.Background(), updated))
+
+	// Reset the in-memory object to the pre-rotation reference, as the
+	// reconciler would have read it before the rotation landed.
+	incoming := legacyRemoteUnleash()
+	migrated, err := reconciler.migrateLegacyAdminSecret(context.Background(), incoming, ctrl.Log.WithName("test"))
+	require.NoError(t, err)
+	assert.False(t, migrated, "migration must abort when the reference changed concurrently")
+
+	current := &unleashv1.RemoteUnleash{}
+	require.NoError(t, reconciler.Get(context.Background(), remoteUnleash.NamespacedName(), current))
+	assert.Equal(t, "unleasherator-test-unleash-tenant-a-admin-key-rotated", current.Spec.AdminSecret.Name,
+		"concurrent repoint must not be overwritten by a stale migration")
+}
+
+func TestMigrateLegacyAdminSecretRefusesURLDrift(t *testing.T) {
+	remoteUnleash := legacyRemoteUnleash()
+	secret := legacySecret()
+	secret.Data[unleashv1.UnleashSecretServerURLKey] = []byte("https://attacker.example.com")
+	reconciler := migrationTestSetup(t, remoteUnleash, secret)
+
+	migrated, err := reconciler.migrateLegacyAdminSecret(context.Background(), remoteUnleash, ctrl.Log.WithName("test"))
+	require.Error(t, err)
+	assert.False(t, migrated)
+	assert.Contains(t, err.Error(), "does not match")
+}
+
+func TestMigrateLegacyAdminSecretIsIdempotentOnRetry(t *testing.T) {
+	remoteUnleash := legacyRemoteUnleash()
+	secret := legacySecret()
+	reconciler := migrationTestSetup(t, remoteUnleash, secret)
+
+	// Simulate a crash after the replacement was created but before repoint:
+	// the namespace-bound secret already exists with identical content.
+	boundKey := namespaceBoundSecretKey(t)
+	existing := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      boundKey.Name,
+			Namespace: migrationOperatorNamespace,
+			Labels: map[string]string{
+				"app.kubernetes.io/instance":   "test-unleash",
+				"app.kubernetes.io/part-of":    "unleasherator",
+				"app.kubernetes.io/created-by": "controller-manager",
+			},
+			Annotations: map[string]string{
+				unleashv1.UnleashSecretAuthorizedNamespaceAnnotation: migrationTenantNamespace,
+			},
+		},
+		Data: map[string][]byte{
+			unleashv1.UnleashSecretTokenKey:     []byte(migrationToken),
+			unleashv1.UnleashSecretServerURLKey: []byte(migrationURL),
+		},
+	}
+	require.NoError(t, reconciler.Create(context.Background(), existing))
+
+	migrated, err := reconciler.migrateLegacyAdminSecret(context.Background(), remoteUnleash, ctrl.Log.WithName("test"))
+	require.NoError(t, err)
+	assert.True(t, migrated, "retry with an existing identical replacement must converge")
+
+	final := &unleashv1.RemoteUnleash{}
+	require.NoError(t, reconciler.Get(context.Background(), remoteUnleash.NamespacedName(), final))
+	assert.Equal(t, boundKey, final.AdminSecretNamespacedName())
 }

--- a/internal/controller/remoteunleash_migration_test.go
+++ b/internal/controller/remoteunleash_migration_test.go
@@ -1,0 +1,214 @@
+package controller
+
+import (
+	"context"
+	"testing"
+
+	unleashv1 "github.com/nais/unleasherator/api/v1"
+	"github.com/nais/unleasherator/internal/federation"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+const (
+	migrationOperatorNamespace = "nais-system"
+	migrationTenantNamespace   = "tenant-a"
+	migrationToken             = "admin-token-value"
+	migrationURL               = "https://unleash.example.com"
+)
+
+func migrationTestSetup(t *testing.T, objects ...client.Object) *RemoteUnleashReconciler {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, unleashv1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build()
+	return &RemoteUnleashReconciler{
+		Client:            fakeClient,
+		APIReader:         fakeClient,
+		Scheme:            scheme,
+		OperatorNamespace: migrationOperatorNamespace,
+	}
+}
+
+func legacyRemoteUnleash() *unleashv1.RemoteUnleash {
+	return &unleashv1.RemoteUnleash{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-unleash", Namespace: migrationTenantNamespace},
+		Spec: unleashv1.RemoteUnleashSpec{
+			Server: unleashv1.RemoteUnleashServer{URL: migrationURL},
+			AdminSecret: unleashv1.RemoteUnleashSecret{
+				Name: "unleasherator-test-unleash-abc123",
+				Key:  unleashv1.UnleashSecretTokenKey,
+			},
+		},
+	}
+}
+
+func legacySecret() *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "unleasherator-test-unleash-abc123",
+			Namespace: migrationTenantNamespace,
+		},
+		Data: map[string][]byte{
+			unleashv1.UnleashSecretTokenKey: []byte(migrationToken),
+		},
+	}
+}
+
+func namespaceBoundSecretKey(t *testing.T) types.NamespacedName {
+	t.Helper()
+	nonce, err := federation.StableSecretNonce("test-unleash", migrationURL, migrationToken)
+	require.NoError(t, err)
+	return types.NamespacedName{
+		Name:      "unleasherator-test-unleash-" + migrationTenantNamespace + "-admin-key-" + nonce,
+		Namespace: migrationOperatorNamespace,
+	}
+}
+
+func TestMigrateLegacyAdminSecretMigratesTenantSecret(t *testing.T) {
+	remoteUnleash := legacyRemoteUnleash()
+	secret := legacySecret()
+	reconciler := migrationTestSetup(t, remoteUnleash, secret)
+
+	migrated, err := reconciler.migrateLegacyAdminSecret(context.Background(), remoteUnleash, ctrl.Log.WithName("test"))
+	require.NoError(t, err)
+	assert.True(t, migrated)
+
+	updated := &unleashv1.RemoteUnleash{}
+	require.NoError(t, reconciler.Get(context.Background(), remoteUnleash.NamespacedName(), updated))
+	assert.Equal(t, namespaceBoundSecretKey(t), updated.AdminSecretNamespacedName())
+
+	migratedSecret := &corev1.Secret{}
+	require.NoError(t, reconciler.Get(context.Background(), namespaceBoundSecretKey(t), migratedSecret))
+	assert.Equal(t, migrationTenantNamespace,
+		migratedSecret.Annotations[unleashv1.UnleashSecretAuthorizedNamespaceAnnotation])
+	assert.Equal(t, migrationToken, migratedSecret.StringData[unleashv1.UnleashSecretTokenKey])
+	assert.Equal(t, migrationURL, migratedSecret.StringData[unleashv1.UnleashSecretServerURLKey])
+
+	legacyKey := types.NamespacedName{Name: "unleasherator-test-unleash-abc123", Namespace: migrationTenantNamespace}
+	err = reconciler.Get(context.Background(), legacyKey, &corev1.Secret{})
+	assert.True(t, apierrors.IsNotFound(err), "legacy secret should be deleted after migration")
+}
+
+func TestMigrateLegacyAdminSecretPreservesSharedSecret(t *testing.T) {
+	remoteUnleash := legacyRemoteUnleash()
+	secret := legacySecret()
+
+	other := &unleashv1.RemoteUnleash{
+		ObjectMeta: metav1.ObjectMeta{Name: "other-unleash", Namespace: "tenant-b"},
+		Spec: unleashv1.RemoteUnleashSpec{
+			Server: unleashv1.RemoteUnleashServer{URL: migrationURL},
+			AdminSecret: unleashv1.RemoteUnleashSecret{
+				Name:      secret.Name,
+				Namespace: migrationTenantNamespace,
+				Key:       unleashv1.UnleashSecretTokenKey,
+			},
+		},
+	}
+	reconciler := migrationTestSetup(t, remoteUnleash, secret, other)
+
+	migrated, err := reconciler.migrateLegacyAdminSecret(context.Background(), remoteUnleash, ctrl.Log.WithName("test"))
+	require.NoError(t, err)
+	assert.True(t, migrated)
+
+	updated := &unleashv1.RemoteUnleash{}
+	require.NoError(t, reconciler.Get(context.Background(), remoteUnleash.NamespacedName(), updated))
+	assert.Equal(t, namespaceBoundSecretKey(t), updated.AdminSecretNamespacedName())
+
+	legacyKey := types.NamespacedName{Name: secret.Name, Namespace: migrationTenantNamespace}
+	require.NoError(t, reconciler.Get(context.Background(), legacyKey, &corev1.Secret{}),
+		"shared legacy secret must be preserved until the other RemoteUnleash migrates")
+}
+
+func TestMigrateLegacyAdminSecretNoopWhenNamespaceBound(t *testing.T) {
+	boundKey := namespaceBoundSecretKey(t)
+	remoteUnleash := legacyRemoteUnleash()
+	remoteUnleash.Spec.AdminSecret.Name = boundKey.Name
+	remoteUnleash.Spec.AdminSecret.Namespace = migrationOperatorNamespace
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      boundKey.Name,
+			Namespace: migrationOperatorNamespace,
+			Annotations: map[string]string{
+				unleashv1.UnleashSecretAuthorizedNamespaceAnnotation: migrationTenantNamespace,
+			},
+		},
+		Data: map[string][]byte{
+			unleashv1.UnleashSecretTokenKey:     []byte(migrationToken),
+			unleashv1.UnleashSecretServerURLKey: []byte(migrationURL),
+		},
+	}
+	reconciler := migrationTestSetup(t, remoteUnleash, secret)
+
+	migrated, err := reconciler.migrateLegacyAdminSecret(context.Background(), remoteUnleash, ctrl.Log.WithName("test"))
+	require.NoError(t, err)
+	assert.False(t, migrated)
+}
+
+func TestMigrateLegacyAdminSecretMigratesNameBoundOperatorSecret(t *testing.T) {
+	remoteUnleash := legacyRemoteUnleash()
+	remoteUnleash.Spec.AdminSecret.Namespace = migrationOperatorNamespace
+
+	secret := legacySecret()
+	secret.Namespace = migrationOperatorNamespace
+	reconciler := migrationTestSetup(t, remoteUnleash, secret)
+
+	migrated, err := reconciler.migrateLegacyAdminSecret(context.Background(), remoteUnleash, ctrl.Log.WithName("test"))
+	require.NoError(t, err)
+	assert.True(t, migrated, "name-bound operator secret without annotation is legacy and must migrate")
+
+	require.NoError(t, reconciler.Get(context.Background(), namespaceBoundSecretKey(t), &corev1.Secret{}))
+}
+
+func TestMigrateLegacyAdminSecretRejectsConflictingSecret(t *testing.T) {
+	remoteUnleash := legacyRemoteUnleash()
+	secret := legacySecret()
+
+	boundKey := namespaceBoundSecretKey(t)
+	conflicting := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      boundKey.Name,
+			Namespace: migrationOperatorNamespace,
+			Annotations: map[string]string{
+				unleashv1.UnleashSecretAuthorizedNamespaceAnnotation: "other-tenant",
+			},
+		},
+		Data: map[string][]byte{
+			unleashv1.UnleashSecretTokenKey: []byte("other-token"),
+		},
+	}
+	reconciler := migrationTestSetup(t, remoteUnleash, secret, conflicting)
+
+	migrated, err := reconciler.migrateLegacyAdminSecret(context.Background(), remoteUnleash, ctrl.Log.WithName("test"))
+	require.Error(t, err)
+	assert.False(t, migrated)
+	assert.Contains(t, err.Error(), "conflicting content")
+
+	updated := &unleashv1.RemoteUnleash{}
+	require.NoError(t, reconciler.Get(context.Background(), remoteUnleash.NamespacedName(), updated))
+	assert.Equal(t, "unleasherator-test-unleash-abc123", updated.Spec.AdminSecret.Name,
+		"reference must not change when the replacement secret conflicts")
+}
+
+func TestMigrateLegacyAdminSecretRequiresTokenKey(t *testing.T) {
+	remoteUnleash := legacyRemoteUnleash()
+	secret := legacySecret()
+	secret.Data = map[string][]byte{}
+	reconciler := migrationTestSetup(t, remoteUnleash, secret)
+
+	migrated, err := reconciler.migrateLegacyAdminSecret(context.Background(), remoteUnleash, ctrl.Log.WithName("test"))
+	require.Error(t, err)
+	assert.False(t, migrated)
+	assert.Contains(t, err.Error(), "missing key")
+}

--- a/internal/controller/remoteunleash_migration_test.go
+++ b/internal/controller/remoteunleash_migration_test.go
@@ -65,7 +65,8 @@ func legacySecret() *corev1.Secret {
 			},
 		},
 		Data: map[string][]byte{
-			unleashv1.UnleashSecretTokenKey: []byte(migrationToken),
+			unleashv1.UnleashSecretTokenKey:     []byte(migrationToken),
+			unleashv1.UnleashSecretServerURLKey: []byte(migrationURL),
 		},
 	}
 }
@@ -124,15 +125,19 @@ func TestMigrateLegacyAdminSecretPreservesSharedSecret(t *testing.T) {
 
 	migrated, err := reconciler.migrateLegacyAdminSecret(context.Background(), remoteUnleash, ctrl.Log.WithName("test"))
 	require.NoError(t, err)
-	assert.True(t, migrated)
+	assert.False(t, migrated, "shared legacy secrets are refused before any mutation")
 
 	updated := &unleashv1.RemoteUnleash{}
 	require.NoError(t, reconciler.Get(context.Background(), remoteUnleash.NamespacedName(), updated))
-	assert.Equal(t, namespaceBoundSecretKey(t), updated.AdminSecretNamespacedName())
+	assert.Equal(t, "unleasherator-test-unleash-abc123", updated.Spec.AdminSecret.Name,
+		"reference must stay on the shared legacy secret")
 
 	legacyKey := types.NamespacedName{Name: secret.Name, Namespace: migrationTenantNamespace}
 	require.NoError(t, reconciler.Get(context.Background(), legacyKey, &corev1.Secret{}),
-		"shared legacy secret must be preserved until the other RemoteUnleash migrates")
+		"shared legacy secret must be preserved")
+
+	require.True(t, apierrors.IsNotFound(reconciler.Get(context.Background(), namespaceBoundSecretKey(t), &corev1.Secret{})),
+		"no replacement grant may be minted for a shared secret")
 }
 
 func TestMigrateLegacyAdminSecretNoopWhenNamespaceBound(t *testing.T) {
@@ -272,7 +277,7 @@ func TestMigrateLegacyAdminSecretRefusesURLDrift(t *testing.T) {
 	migrated, err := reconciler.migrateLegacyAdminSecret(context.Background(), remoteUnleash, ctrl.Log.WithName("test"))
 	require.Error(t, err)
 	assert.False(t, migrated)
-	assert.Contains(t, err.Error(), "does not match")
+	assert.Contains(t, err.Error(), "republication required")
 }
 
 func TestMigrateLegacyAdminSecretIsIdempotentOnRetry(t *testing.T) {

--- a/internal/federation/subscriber.go
+++ b/internal/federation/subscriber.go
@@ -223,16 +223,23 @@ func (s *subscriber) handleMessage(ctx context.Context, msg *pubsub.Message, han
 }
 
 func stableNonce(instance *pb.Instance) (string, error) {
-	if instance.GetSecretToken() == "" {
+	return StableSecretNonce(instance.GetName(), instance.GetUrl(), instance.GetSecretToken())
+}
+
+// StableSecretNonce derives a deterministic secret nonce from the instance
+// identity and credential, so reconciles and republications converge on the
+// same secret name while credential rotation produces a new one.
+func StableSecretNonce(name, url, secretToken string) (string, error) {
+	if secretToken == "" {
 		return "", fmt.Errorf("cannot derive stable nonce without an admin token")
 	}
 
 	hash := sha256.New()
-	hash.Write([]byte(instance.GetName()))
+	hash.Write([]byte(name))
 	hash.Write([]byte{0})
-	hash.Write([]byte(instance.GetUrl()))
+	hash.Write([]byte(url))
 	hash.Write([]byte{0})
-	hash.Write([]byte(instance.GetSecretToken()))
+	hash.Write([]byte(secretToken))
 
 	return hex.EncodeToString(hash.Sum(nil)[:6]), nil
 }


### PR DESCRIPTION
## Summary

Replaces manual replay-based migration (canary script) with declarative, reconcile-driven migration of legacy federation admin secrets to the namespace-bound layout. No manual steps: migration converges automatically on the hourly reconcile.

When `namespaceBoundSecrets=true` and `legacy=true` (migration mode), the RemoteUnleash reconciler:

1. Verifies the existing credential against Unleash (existing stats check).
2. Migrates only operator-managed secrets (labels + name prefix); tenant-owned secrets are never touched.
3. Refuses shared legacy secrets before any mutation (manual-review case).
4. For same-namespace legacy secrets missing the `url` key, stamps the spec URL — sound because the reconcile just verified the credential against exactly that URL. Cross-namespace url-less secrets are refused until the publisher writes it; a recorded mismatching URL fails as genuine drift.
5. Creates the namespace-bound secret in the operator namespace with the authoritative authorized-namespace annotation, repoints `spec.adminSecret` (conflict-safe; aborts if a concurrent spec change won the race), and deletes the legacy secret with UID/RV preconditions.

Every step is idempotent. Observability via `unleasherator_federation_secret_migrations_total{result=migrated|refused|cleanup_failed|failed}` and Kubernetes events.

## Rollout

Controlled by existing Fasit flags. At `true/true`, in-field legacy secrets migrate automatically on their hourly reconcile — no republication or scripts needed. The canary script remains as manual fallback.

## Validation

- 12 unit tests: tenant-owned skip, absent/mismatching/cross-namespace URL, shared-secret refusal (no mutation), concurrent spec-change abort, idempotent retry, conflicting replacement.
- `make all`, `make test`, `-race` ×3 green.
- Adversarial review: 7 rounds, all blockers resolved.