### PR TITLE
fix(federation): unblock legacy secret migration without republication

### DIFF
--- a/internal/controller/remoteunleash_controller.go
+++ b/internal/controller/remoteunleash_controller.go
@@ -100,7 +100,7 @@ type RemoteUnleashFederation struct {
 //+kubebuilder:rbac:groups=unleash.nais.io,resources=remoteunleashes,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=unleash.nais.io,resources=remoteunleashes/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=unleash.nais.io,resources=remoteunleashes/finalizers,verbs=update
-//+kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;create;update;delete
+//+kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;create;update;patch;delete
 
 func (r *RemoteUnleashReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	spanOpts := o11y.ReconcilerAttributes(ctx, req)

--- a/internal/controller/remoteunleash_migration.go
+++ b/internal/controller/remoteunleash_migration.go
@@ -118,8 +118,10 @@ func (r *RemoteUnleashReconciler) migrateLegacyAdminSecret(ctx context.Context, 
 		}
 		legacySecret.Data[unleashv1.UnleashSecretServerURLKey] = []byte(remoteUnleash.Spec.Server.URL)
 		if err := r.Patch(ctx, legacySecret, patch); err != nil {
-			if apierrors.IsNotFound(err) {
-				return false, nil // deleted concurrently; next reconcile re-evaluates
+			if apierrors.IsNotFound(err) || apierrors.IsConflict(err) {
+				// Deleted or modified concurrently; the next reconcile
+				// re-reads and re-evaluates.
+				return false, nil
 			}
 			federationSecretMigrations.WithLabelValues("failed").Inc()
 			return false, fmt.Errorf("stamping url onto legacy admin secret %s: %w", legacyKey, err)

--- a/internal/controller/remoteunleash_migration.go
+++ b/internal/controller/remoteunleash_migration.go
@@ -80,37 +80,9 @@ func (r *RemoteUnleashReconciler) migrateLegacyAdminSecret(ctx context.Context, 
 		return false, fmt.Errorf("legacy admin secret %s is missing key %q", legacyKey, remoteUnleash.Spec.AdminSecret.Key)
 	}
 
-	// Never derive the authoritative URL binding from tenant-controlled spec:
-	// pre-#746 legacy secrets carry no URL, and a tenant could otherwise point
-	// the spec at an attacker server and have the grant survive the legacy
-	// enforcement flip.
-	//
-	// The credential was just verified against the Unleash server at this URL
-	// (the stats call succeeded), so filling an absent url key is a faithful
-	// statement of where the credential was proven to work — no republication
-	// needed. A recorded URL that disagrees is genuine drift: fail loudly.
-	recordedURL := string(legacySecret.Data[unleashv1.UnleashSecretServerURLKey])
-	if recordedURL == "" {
-		patch := client.MergeFrom(legacySecret.DeepCopy())
-		if legacySecret.Data == nil {
-			legacySecret.Data = map[string][]byte{}
-		}
-		legacySecret.Data[unleashv1.UnleashSecretServerURLKey] = []byte(remoteUnleash.Spec.Server.URL)
-		if err := r.Patch(ctx, legacySecret, patch); err != nil {
-			if apierrors.IsNotFound(err) {
-				return false, nil // deleted concurrently; next reconcile re-evaluates
-			}
-			federationSecretMigrations.WithLabelValues("failed").Inc()
-			return false, fmt.Errorf("stamping url onto legacy admin secret %s: %w", legacyKey, err)
-		}
-	} else if recordedURL != remoteUnleash.Spec.Server.URL {
-		federationSecretMigrations.WithLabelValues("failed").Inc()
-		return false, fmt.Errorf("legacy admin secret %s URL %q does not match spec.server.url %q", legacyKey, recordedURL, remoteUnleash.Spec.Server.URL)
-	}
-
-	// Refuse shared legacy secrets before minting anything: each referencing
-	// RemoteUnleash would otherwise receive its own annotated grant, and the
-	// canary tooling already treats shared secrets as manual-review cases.
+	// Refuse shared legacy secrets before minting or mutating anything: each
+	// referencing RemoteUnleash would otherwise receive its own annotated
+	// grant, and the canary tooling treats shared secrets as manual-review.
 	shared, err := federationAdminSecretReferencedByOtherRemoteUnleash(
 		ctx, r.APIReader, legacyKey, client.ObjectKeyFromObject(remoteUnleash))
 	if err != nil {
@@ -124,6 +96,45 @@ func (r *RemoteUnleashReconciler) migrateLegacyAdminSecret(ctx context.Context, 
 		}
 		federationSecretMigrations.WithLabelValues("refused").Inc()
 		return false, nil
+	}
+
+	// Never derive the authoritative URL binding from tenant-controlled spec:
+	// pre-#746 legacy secrets carry no URL, and a tenant could otherwise point
+	// the spec at an attacker server and have the grant survive the legacy
+	// enforcement flip.
+	//
+	// For a same-namespace legacy secret the credential is already readable by
+	// the tenant, and the reconcile just verified it against the spec URL via
+	// the stats call, so filling an absent url key is faithful and needs no
+	// republication. A cross-namespace url-less secret asserts nothing about
+	// the URL and is refused until the publisher writes it. A recorded URL
+	// that disagrees is genuine drift and fails loudly.
+	recordedURL := string(legacySecret.Data[unleashv1.UnleashSecretServerURLKey])
+	switch {
+	case recordedURL == "" && legacyKey.Namespace == remoteUnleash.Namespace:
+		patch := client.MergeFrom(legacySecret.DeepCopy())
+		if legacySecret.Data == nil {
+			legacySecret.Data = map[string][]byte{}
+		}
+		legacySecret.Data[unleashv1.UnleashSecretServerURLKey] = []byte(remoteUnleash.Spec.Server.URL)
+		if err := r.Patch(ctx, legacySecret, patch); err != nil {
+			if apierrors.IsNotFound(err) {
+				return false, nil // deleted concurrently; next reconcile re-evaluates
+			}
+			federationSecretMigrations.WithLabelValues("failed").Inc()
+			return false, fmt.Errorf("stamping url onto legacy admin secret %s: %w", legacyKey, err)
+		}
+	case recordedURL == "":
+		log.Info("Refusing to migrate cross-namespace legacy admin secret without a url assertion; republication required", "secret", legacyKey)
+		if r.Recorder != nil {
+			r.Recorder.Event(remoteUnleash, "Warning", "FederationSecretMigrationRefused",
+				"Legacy admin secret does not assert its URL; republication is required before migration")
+		}
+		federationSecretMigrations.WithLabelValues("refused").Inc()
+		return false, nil
+	case recordedURL != remoteUnleash.Spec.Server.URL:
+		federationSecretMigrations.WithLabelValues("failed").Inc()
+		return false, fmt.Errorf("legacy admin secret %s URL %q does not match spec.server.url %q", legacyKey, recordedURL, remoteUnleash.Spec.Server.URL)
 	}
 
 	// Same derivation as the federation subscriber fallback, so a later

--- a/internal/controller/remoteunleash_migration.go
+++ b/internal/controller/remoteunleash_migration.go
@@ -112,7 +112,11 @@ func (r *RemoteUnleashReconciler) migrateLegacyAdminSecret(ctx context.Context, 
 	recordedURL := string(legacySecret.Data[unleashv1.UnleashSecretServerURLKey])
 	switch {
 	case recordedURL == "" && legacyKey.Namespace == remoteUnleash.Namespace:
-		patch := client.MergeFrom(legacySecret.DeepCopy())
+		// Optimistic lock: a plain MergeFrom omits resourceVersion, so the
+		// patch would silently win over a publisher that wrote the real url
+		// between the read above and this write — destroying the very drift
+		// signal the mismatch case below exists to surface.
+		patch := client.MergeFromWithOptions(legacySecret.DeepCopy(), client.MergeFromWithOptimisticLock{})
 		if legacySecret.Data == nil {
 			legacySecret.Data = map[string][]byte{}
 		}
@@ -121,11 +125,15 @@ func (r *RemoteUnleashReconciler) migrateLegacyAdminSecret(ctx context.Context, 
 			if apierrors.IsNotFound(err) || apierrors.IsConflict(err) {
 				// Deleted or modified concurrently; the next reconcile
 				// re-reads and re-evaluates.
+				log.V(1).Info("Legacy admin secret changed while stamping url; retrying on next reconcile", "secret", legacyKey)
 				return false, nil
 			}
 			federationSecretMigrations.WithLabelValues("failed").Inc()
 			return false, fmt.Errorf("stamping url onto legacy admin secret %s: %w", legacyKey, err)
 		}
+		// Audit trail: the operator mutated a secret in the tenant namespace.
+		log.Info("Stamped verified url onto legacy admin secret", "secret", legacyKey, "url", remoteUnleash.Spec.Server.URL)
+		federationSecretMigrations.WithLabelValues("stamped").Inc()
 	case recordedURL == "":
 		log.Info("Refusing to migrate cross-namespace legacy admin secret without a url assertion; republication required", "secret", legacyKey)
 		if r.Recorder != nil {

--- a/internal/controller/remoteunleash_migration.go
+++ b/internal/controller/remoteunleash_migration.go
@@ -84,19 +84,26 @@ func (r *RemoteUnleashReconciler) migrateLegacyAdminSecret(ctx context.Context, 
 	// pre-#746 legacy secrets carry no URL, and a tenant could otherwise point
 	// the spec at an attacker server and have the grant survive the legacy
 	// enforcement flip.
+	//
+	// The credential was just verified against the Unleash server at this URL
+	// (the stats call succeeded), so filling an absent url key is a faithful
+	// statement of where the credential was proven to work — no republication
+	// needed. A recorded URL that disagrees is genuine drift: fail loudly.
 	recordedURL := string(legacySecret.Data[unleashv1.UnleashSecretServerURLKey])
-	if recordedURL != remoteUnleash.Spec.Server.URL {
-		if r.Recorder != nil {
-			r.Recorder.Event(remoteUnleash, "Warning", "FederationSecretMigrationRefused",
-				"Legacy admin secret does not assert its URL; republication is required before migration")
+	if recordedURL == "" {
+		patch := client.MergeFrom(legacySecret.DeepCopy())
+		if legacySecret.Data == nil {
+			legacySecret.Data = map[string][]byte{}
 		}
-		if recordedURL == "" {
-			// The documented, expected state before republication — not an
-			// error; the resource stays healthy on its normal requeue.
-			log.Info("Refusing to migrate legacy admin secret that does not assert its URL; republication required", "secret", legacyKey)
-			federationSecretMigrations.WithLabelValues("refused").Inc()
-			return false, nil
+		legacySecret.Data[unleashv1.UnleashSecretServerURLKey] = []byte(remoteUnleash.Spec.Server.URL)
+		if err := r.Patch(ctx, legacySecret, patch); err != nil {
+			if apierrors.IsNotFound(err) {
+				return false, nil // deleted concurrently; next reconcile re-evaluates
+			}
+			federationSecretMigrations.WithLabelValues("failed").Inc()
+			return false, fmt.Errorf("stamping url onto legacy admin secret %s: %w", legacyKey, err)
 		}
+	} else if recordedURL != remoteUnleash.Spec.Server.URL {
 		federationSecretMigrations.WithLabelValues("failed").Inc()
 		return false, fmt.Errorf("legacy admin secret %s URL %q does not match spec.server.url %q", legacyKey, recordedURL, remoteUnleash.Spec.Server.URL)
 	}

--- a/internal/controller/remoteunleash_migration_test.go
+++ b/internal/controller/remoteunleash_migration_test.go
@@ -330,7 +330,7 @@ func TestMigrateLegacyAdminSecretRefusesURLDrift(t *testing.T) {
 	assert.Contains(t, err.Error(), "does not match")
 }
 
-func TestMigrateLegacyAdminSecretRefusesUnassertedURL(t *testing.T) {
+func TestMigrateLegacyAdminSecretStampsAbsentURLAndMigrates(t *testing.T) {
 	remoteUnleash := legacyRemoteUnleash()
 	secret := legacySecret()
 	delete(secret.Data, unleashv1.UnleashSecretServerURLKey)

--- a/internal/controller/remoteunleash_migration_test.go
+++ b/internal/controller/remoteunleash_migration_test.go
@@ -286,15 +286,16 @@ func TestMigrateLegacyAdminSecretRefusesUnassertedURL(t *testing.T) {
 	delete(secret.Data, unleashv1.UnleashSecretServerURLKey)
 	reconciler := migrationTestSetup(t, remoteUnleash, secret)
 
+	// The credential was verified against the spec URL by the stats check
+	// earlier in the reconcile, so filling the absent url key is a faithful
+	// statement and the migration proceeds.
 	migrated, err := reconciler.migrateLegacyAdminSecret(context.Background(), remoteUnleash, ctrl.Log.WithName("test"))
-	require.NoError(t, err, "a missing URL is the expected pre-republication state, not an error")
-	assert.False(t, migrated)
+	require.NoError(t, err)
+	assert.True(t, migrated, "absent url is stamped from the verified spec URL, then migrated")
 
 	updated := &unleashv1.RemoteUnleash{}
 	require.NoError(t, reconciler.Get(context.Background(), remoteUnleash.NamespacedName(), updated))
-	assert.Equal(t, "unleasherator-test-unleash-abc123", updated.Spec.AdminSecret.Name)
-	require.True(t, apierrors.IsNotFound(reconciler.Get(context.Background(), namespaceBoundSecretKey(t), &corev1.Secret{})),
-		"no grant may be minted without a secret-asserted URL")
+	assert.Equal(t, namespaceBoundSecretKey(t), updated.AdminSecretNamespacedName())
 }
 
 func TestMigrateLegacyAdminSecretIsIdempotentOnRetry(t *testing.T) {

--- a/internal/controller/remoteunleash_migration_test.go
+++ b/internal/controller/remoteunleash_migration_test.go
@@ -172,6 +172,7 @@ func TestMigrateLegacyAdminSecretMigratesNameBoundOperatorSecret(t *testing.T) {
 
 	secret := legacySecret()
 	secret.Namespace = migrationOperatorNamespace
+	// Cross-namespace legacy secrets keep their publisher-asserted URL.
 	reconciler := migrationTestSetup(t, remoteUnleash, secret)
 
 	migrated, err := reconciler.migrateLegacyAdminSecret(context.Background(), remoteUnleash, ctrl.Log.WithName("test"))
@@ -179,6 +180,55 @@ func TestMigrateLegacyAdminSecretMigratesNameBoundOperatorSecret(t *testing.T) {
 	assert.True(t, migrated, "name-bound operator secret without annotation is legacy and must migrate")
 
 	require.NoError(t, reconciler.Get(context.Background(), namespaceBoundSecretKey(t), &corev1.Secret{}))
+}
+
+func TestMigrateLegacyAdminSecretRefusesCrossNamespaceUnassertedURL(t *testing.T) {
+	remoteUnleash := legacyRemoteUnleash()
+	remoteUnleash.Spec.AdminSecret.Namespace = migrationOperatorNamespace
+
+	secret := legacySecret()
+	secret.Namespace = migrationOperatorNamespace
+	delete(secret.Data, unleashv1.UnleashSecretServerURLKey)
+	reconciler := migrationTestSetup(t, remoteUnleash, secret)
+
+	migrated, err := reconciler.migrateLegacyAdminSecret(context.Background(), remoteUnleash, ctrl.Log.WithName("test"))
+	require.NoError(t, err)
+	assert.False(t, migrated, "cross-namespace url-less secrets assert nothing about the URL")
+
+	updated := &unleashv1.RemoteUnleash{}
+	require.NoError(t, reconciler.Get(context.Background(), remoteUnleash.NamespacedName(), updated))
+	assert.Equal(t, "unleasherator-test-unleash-abc123", updated.Spec.AdminSecret.Name)
+	assert.True(t, apierrors.IsNotFound(reconciler.Get(context.Background(), namespaceBoundSecretKey(t), &corev1.Secret{})),
+		"no grant may be minted from a url-less cross-namespace secret")
+}
+
+func TestMigrateLegacyAdminSecretDoesNotMutateSharedSecret(t *testing.T) {
+	remoteUnleash := legacyRemoteUnleash()
+	secret := legacySecret()
+	delete(secret.Data, unleashv1.UnleashSecretServerURLKey) // url-less: stamp must not fire
+
+	other := &unleashv1.RemoteUnleash{
+		ObjectMeta: metav1.ObjectMeta{Name: "other-unleash", Namespace: "tenant-b"},
+		Spec: unleashv1.RemoteUnleashSpec{
+			Server: unleashv1.RemoteUnleashServer{URL: migrationURL},
+			AdminSecret: unleashv1.RemoteUnleashSecret{
+				Name:      secret.Name,
+				Namespace: migrationTenantNamespace,
+				Key:       unleashv1.UnleashSecretTokenKey,
+			},
+		},
+	}
+	reconciler := migrationTestSetup(t, remoteUnleash, secret, other)
+
+	migrated, err := reconciler.migrateLegacyAdminSecret(context.Background(), remoteUnleash, ctrl.Log.WithName("test"))
+	require.NoError(t, err)
+	assert.False(t, migrated)
+
+	fresh := &corev1.Secret{}
+	legacyKey := types.NamespacedName{Name: secret.Name, Namespace: migrationTenantNamespace}
+	require.NoError(t, reconciler.Get(context.Background(), legacyKey, fresh))
+	assert.Empty(t, fresh.Data[unleashv1.UnleashSecretServerURLKey],
+		"refused shared secrets must not be mutated")
 }
 
 func TestMigrateLegacyAdminSecretRejectsConflictingSecret(t *testing.T) {

--- a/internal/controller/remoteunleash_migration_test.go
+++ b/internal/controller/remoteunleash_migration_test.go
@@ -16,6 +16,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 )
 
 const (
@@ -346,6 +347,71 @@ func TestMigrateLegacyAdminSecretStampsAbsentURLAndMigrates(t *testing.T) {
 	updated := &unleashv1.RemoteUnleash{}
 	require.NoError(t, reconciler.Get(context.Background(), remoteUnleash.NamespacedName(), updated))
 	assert.Equal(t, namespaceBoundSecretKey(t), updated.AdminSecretNamespacedName())
+
+	minted := &corev1.Secret{}
+	require.NoError(t, reconciler.Get(context.Background(), namespaceBoundSecretKey(t), minted))
+	assert.Equal(t, migrationURL, string(minted.Data[unleashv1.UnleashSecretServerURLKey]),
+		"the grant must record the verified spec URL, not an empty one")
+	assert.Equal(t, migrationToken, string(minted.Data[unleashv1.UnleashSecretTokenKey]))
+	assert.Equal(t, migrationTenantNamespace, minted.Annotations[unleashv1.UnleashSecretAuthorizedNamespaceAnnotation])
+
+	legacyKey := types.NamespacedName{Name: secret.Name, Namespace: migrationTenantNamespace}
+	assert.True(t, apierrors.IsNotFound(reconciler.Get(context.Background(), legacyKey, &corev1.Secret{})),
+		"the stamped legacy secret must still be cleaned up")
+}
+
+// A publisher writing the authoritative url between our read and our patch must
+// win: the optimistic lock turns the stamp into a no-op so the mismatch check
+// still sees genuine drift on the next reconcile.
+func TestMigrateLegacyAdminSecretAbortsStampOnConcurrentWrite(t *testing.T) {
+	const publisherURL = "https://publisher.example.com"
+
+	remoteUnleash := legacyRemoteUnleash()
+	legacy := legacySecret()
+	delete(legacy.Data, unleashv1.UnleashSecretServerURLKey)
+	legacyKey := types.NamespacedName{Name: legacy.Name, Namespace: legacy.Namespace}
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, unleashv1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	raced := false
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(remoteUnleash, legacy).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+				if s, ok := obj.(*corev1.Secret); ok && !raced && client.ObjectKeyFromObject(s) == legacyKey {
+					raced = true
+					competing := &corev1.Secret{}
+					require.NoError(t, c.Get(ctx, legacyKey, competing))
+					competing.Data[unleashv1.UnleashSecretServerURLKey] = []byte(publisherURL)
+					require.NoError(t, c.Update(ctx, competing))
+				}
+				return c.Patch(ctx, obj, patch, opts...)
+			},
+		}).
+		Build()
+
+	reconciler := &RemoteUnleashReconciler{
+		Client:            fakeClient,
+		APIReader:         fakeClient,
+		Scheme:            scheme,
+		OperatorNamespace: migrationOperatorNamespace,
+	}
+
+	migrated, err := reconciler.migrateLegacyAdminSecret(context.Background(), remoteUnleash, ctrl.Log.WithName("test"))
+	require.NoError(t, err, "a lost race is transient, not a migration failure")
+	assert.False(t, migrated)
+	assert.True(t, raced, "the interceptor must have fired, otherwise the race was never exercised")
+
+	fresh := &corev1.Secret{}
+	require.NoError(t, reconciler.Get(context.Background(), legacyKey, fresh))
+	assert.Equal(t, publisherURL, string(fresh.Data[unleashv1.UnleashSecretServerURLKey]),
+		"the publisher's url must survive the stamp attempt")
+
+	assert.True(t, apierrors.IsNotFound(reconciler.Get(context.Background(), namespaceBoundSecretKey(t), &corev1.Secret{})),
+		"no grant may be minted from a lost stamp race")
 }
 
 func TestMigrateLegacyAdminSecretIsIdempotentOnRetry(t *testing.T) {


### PR DESCRIPTION
## Summary

Follow-up hardening for the reconcile-driven federation migration (#786). Without this, every pre-existing legacy secret stays `refused` forever because it lacks the `url` key — verified in Mimir after rollout (only `refused`, zero `migrated`).

- The RemoteUnleash reconciler stamps the spec URL onto a same-namespace legacy secret whose url key is absent — sound because the reconcile just verified the credential against exactly that URL via the stats call. Migration then converges automatically on the hourly reconcile; no manual republication.
- Shared secrets are refused **before** any mutation (ordering fix).
- Cross-namespace url-less secrets are refused until the publisher writes the url (fail-closed).
- A recorded URL that mismatches the spec still fails as genuine drift.

## Validation

- New tests: same-namespace absent-url stamps and migrates; cross-namespace absent-url refused with no grant minted; shared url-less secret is refused without mutation.
- Migration tests pass 3× with `-race`; `make all` green.
- Adversarial review: all blockers resolved.

Refs #786

## Adversarial review follow-ups

- The stamp used `client.MergeFrom`, which omits `resourceVersion`, so it was last-writer-wins and the `IsConflict` branch was unreachable. A publisher writing the authoritative url between the read and the patch was silently overwritten. Now `MergeFromWithOptimisticLock`, covered by a test that fails against the old patch type.
- Stamping mutates a secret in the tenant namespace and previously left no trace. It now logs and increments `unleasherator_federation_secret_migrations_total{result="stamped"}`, so the rollout is verifiable the same way the original problem was found.
- `//+kubebuilder:rbac` on the RemoteUnleash controller now declares `patch`; it previously relied on the Unleash controller's marker to supply the verb to the shared ClusterRole. No manifest change.

## Behavioural note

Stamping tightens validation on the legacy secret itself. Before the stamp, `validatedRemoteUnleashAdminToken` skips the URL comparison entirely for a legacy same-namespace secret (`urlRequired` is false and `expectedURL` is empty). Afterwards the secret asserts a url, so `spec.server.url` must match it from then on. That is the intended fail-loud behaviour, but it means an instance URL change that updates the CR without rewriting the secret now fails reconciliation where it previously passed silently. The subscriber writes both together, so the window is narrow.

Recovery: `kubectl patch secret <name> -n <ns> --type merge -p '{"data":{"url":"<base64>"}}'`, or delete the secret and let federation republish. Rollback is safe — a stamped secret satisfies the pre-#791 code path, and setting `NamespaceBoundSecrets=false` disables migration outright.
