### PR TITLE
fix(federation): give URL drift its own event

### DIFF
--- a/internal/controller/remoteunleash_migration.go
+++ b/internal/controller/remoteunleash_migration.go
@@ -143,6 +143,16 @@ func (r *RemoteUnleashReconciler) migrateLegacyAdminSecret(ctx context.Context, 
 		federationSecretMigrations.WithLabelValues("refused").Inc()
 		return false, nil
 	case recordedURL != remoteUnleash.Spec.Server.URL:
+		// Drift gets its own reason. Every other refusal here emits an event,
+		// so without this the one outcome the URL binding exists to catch is
+		// the only one a tenant cannot see with kubectl describe. The URLs stay
+		// out of the message — they are already in the error for the operator
+		// log, and the event is visible to the tenant.
+		log.Info("Refusing to migrate legacy admin secret whose recorded URL differs from the spec", "secret", legacyKey)
+		if r.Recorder != nil {
+			r.Recorder.Event(remoteUnleash, "Warning", "FederationSecretURLDrift",
+				"Admin secret records a different server URL than spec.server.url; migration is blocked until they agree")
+		}
 		federationSecretMigrations.WithLabelValues("failed").Inc()
 		return false, fmt.Errorf("legacy admin secret %s URL %q does not match spec.server.url %q", legacyKey, recordedURL, remoteUnleash.Spec.Server.URL)
 	}

--- a/internal/controller/remoteunleash_migration_test.go
+++ b/internal/controller/remoteunleash_migration_test.go
@@ -13,6 +13,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -325,10 +326,23 @@ func TestMigrateLegacyAdminSecretRefusesURLDrift(t *testing.T) {
 	secret.Data[unleashv1.UnleashSecretServerURLKey] = []byte("https://attacker.example.com")
 	reconciler := migrationTestSetup(t, remoteUnleash, secret)
 
+	recorder := record.NewFakeRecorder(10)
+	reconciler.Recorder = recorder
+
 	migrated, err := reconciler.migrateLegacyAdminSecret(context.Background(), remoteUnleash, ctrl.Log.WithName("test"))
 	require.Error(t, err, "a recorded URL that mismatches the spec is genuine drift and must fail")
 	assert.False(t, migrated)
 	assert.Contains(t, err.Error(), "does not match")
+
+	// Drift must be visible to the tenant, not only in the operator log, and
+	// with a reason of its own rather than the url-less wording.
+	select {
+	case event := <-recorder.Events:
+		assert.Contains(t, event, "FederationSecretURLDrift")
+		assert.NotContains(t, event, "FederationSecretMigrationRefused")
+	default:
+		t.Fatal("drift emitted no event")
+	}
 }
 
 func TestMigrateLegacyAdminSecretStampsAbsentURLAndMigrates(t *testing.T) {


### PR DESCRIPTION
**Draft** — small and self-contained; opening as draft so it can ride along with the federation work rather than jumping the queue.

Closes #796.

## Problem

Every refusal path in `migrateLegacyAdminSecret` emits a Kubernetes event — shared secrets, cross-namespace url-less secrets, conflicting grants. One does not: a recorded URL that disagrees with `spec.server.url`.

That is the outcome the whole URL binding exists to catch. It means either a genuine instance URL change that never propagated, or a tenant pointing `spec.server.url` somewhere it should not. And it was the only refusal a tenant could not see with `kubectl describe`.

## How it got that way

Before #791 the drift branch shared an event with the url-less case, whose message read *"Legacy admin secret does not assert its URL; republication is required"*. That was factually wrong for drift — the secret **does** assert a URL, it just disagrees. #791 split the two cases and moved the event to where its wording is accurate, which left drift silent.

## Change

Drift emits `FederationSecretURLDrift` with a reason of its own:

> Admin secret records a different server URL than spec.server.url; migration is blocked until they agree

The URLs are deliberately kept out of the event message. They are already in the returned error for the operator log; the event is tenant-visible, and there is no reason to surface internal hostnames there.

Behaviour is otherwise unchanged: drift still returns an error and still counts `result="failed"`.

## Why now

The scope widened with #791. Stamping writes a url onto previously url-less same-namespace secrets, so from then on those secrets are subject to this comparison too — more instances can reach this branch than before.

## Verification

The test asserts the event fires with the drift reason and *not* with the url-less reason. It fails if the event is removed — checked by reverting it.

`make test` green.
