### PR TITLE
fix(apitoken): create the replacement before deleting the old token

### DIFF
--- a/internal/controller/apitoken_controller.go
+++ b/internal/controller/apitoken_controller.go
@@ -306,7 +306,12 @@ func (r *ApiTokenReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		return ti.After(tj)
 	})
 
-	// Delete outdated tokens in Unleash
+	// Identify the up-to-date token and collect the outdated ones. Nothing is
+	// deleted here: the superseded tokens are the only working credential until
+	// a replacement exists and its secret has been written. Deleting first meant
+	// a failed create left the ApiToken with no valid token at all, and every
+	// later reconcile repeated delete(none) -> create -> fail.
+	var outdated []unleashclient.ApiToken
 	for _, t := range apiTokens.Tokens {
 		// Check if the token is up to date and that we have not already found an up to date token
 		if token.IsEqual(t) && apiToken == nil {
@@ -317,7 +322,6 @@ func (r *ApiTokenReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		}
 
 		log.WithValues("token", t.TokenName, "created_at", t.CreatedAt).Info(fmt.Sprintf("Token is outdated in Unleash. Token diff: %s", token.Diff(t)))
-		span.AddEvent(fmt.Sprintf("Deleting old token for %s created at %s in Unleash", t.TokenName, t.CreatedAt))
 
 		// If ApiTokenUpdateEnabled is false, prevent deletion of outdated tokens and subsequent creation of new tokens
 		// This also prevents deletion of duplicate tokens.
@@ -332,16 +336,8 @@ func (r *ApiTokenReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 			continue
 		}
 
-		// At this point we know that the token is outdated or duplicate and it is safe to delete it
-		log.WithValues("token", t.TokenName, "created_at", t.CreatedAt).Info("Deleting token in Unleash for ApiToken")
-		apiTokenDeletedCounter.WithLabelValues(token.Namespace, token.Name).Inc()
-		err = apiClient.DeleteApiToken(ctx, t.Secret)
-		if err != nil {
-			if err := r.updateStatusFailed(ctx, token, err, "TokenUpdateFailed", "Failed to delete old token in Unleash"); err != nil {
-				return ctrl.Result{}, err
-			}
-			return ctrl.Result{}, err
-		}
+		// Outdated or duplicate; queued for deletion once the replacement is in place.
+		outdated = append(outdated, t)
 	}
 
 	// Create token if it does not exist in Unleash
@@ -414,6 +410,22 @@ func (r *ApiTokenReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		log.Info("Creating token secret for ApiToken")
 		if err := r.Create(ctx, secret); err != nil {
 			if err := r.updateStatusFailed(ctx, token, err, "TokenSecretFailed", "Failed to create new token secret"); err != nil {
+				return ctrl.Result{}, err
+			}
+			return ctrl.Result{}, err
+		}
+	}
+
+	// The replacement is in place and its secret is written, so the superseded
+	// tokens can go. A failure here leaves an extra valid token in Unleash,
+	// which the next reconcile collects again — strictly better than leaving
+	// the ApiToken with none.
+	for _, t := range outdated {
+		log.WithValues("token", t.TokenName, "created_at", t.CreatedAt).Info("Deleting superseded token in Unleash for ApiToken")
+		span.AddEvent(fmt.Sprintf("Deleting old token for %s created at %s in Unleash", t.TokenName, t.CreatedAt))
+		apiTokenDeletedCounter.WithLabelValues(token.Namespace, token.Name).Inc()
+		if err := apiClient.DeleteApiToken(ctx, t.Secret); err != nil {
+			if err := r.updateStatusFailed(ctx, token, err, "TokenUpdateFailed", "Failed to delete old token in Unleash"); err != nil {
 				return ctrl.Result{}, err
 			}
 			return ctrl.Result{}, err

--- a/internal/controller/apitoken_controller_test.go
+++ b/internal/controller/apitoken_controller_test.go
@@ -558,6 +558,15 @@ var _ = Describe("ApiToken Controller", Ordered, func() {
 				g.Expect(getTokens()[0].Environment).To(Equal(originalEnvironment))
 				g.Expect(httpmock.GetCallCountInfo()[fmt.Sprintf("DELETE =~%s%s/.*", serverURL, unleashclient.ApiTokensEndpoint)]).To(Equal(0))
 			}, "2s", interval).Should(Succeed())
+
+			By("Cleaning up the ApiToken")
+			// Restore the working responders first. Without this the ApiToken
+			// keeps reconciling against a permanent 500 for the rest of the
+			// suite, and its GET responder serves the shared token store — so a
+			// later ordering regression here could have it act on another
+			// spec's tokens.
+			registerApiTokenMocks(serverURL)
+			Expect(k8sClient.Delete(ctx, apiTokenCreated)).Should(Succeed())
 		})
 
 		It("Should update ApiToken in Unleash when it differs from Kubernetes", func() {

--- a/internal/controller/apitoken_controller_test.go
+++ b/internal/controller/apitoken_controller_test.go
@@ -510,6 +510,56 @@ var _ = Describe("ApiToken Controller", Ordered, func() {
 	})
 
 	Context("When updating an existing ApiToken", func() {
+		It("Should keep the existing token when creating its replacement fails", func() {
+			ctx := context.Background()
+
+			apiTokenName := "test-apitoken-create-fails"
+			apiTokenLookup := types.NamespacedName{Name: apiTokenName, Namespace: ApiTokenNamespace}
+			serverURL := mockRemoteUnleashURL(apiTokenName, ApiTokenNamespace)
+
+			By("By creating a new RemoteUnleash")
+			secretCreated := remoteUnleashSecretResource(apiTokenName, ApiTokenNamespace, ApiTokenSecret)
+			Expect(k8sClient.Create(ctx, secretCreated)).Should(Succeed())
+			unleashKey, unleashCreated := remoteUnleashResource(apiTokenName, ApiTokenNamespace, serverURL, secretCreated)
+			registerApiTokenMocks(serverURL)
+			Expect(k8sClient.Create(ctx, unleashCreated)).Should(Succeed())
+			Eventually(remoteUnleashEventually(ctx, unleashKey, unleashCreated), timeout, interval).Should(ContainElement(remoteUnleashSuccessCondition()))
+
+			By("By creating a new ApiToken that succeeds")
+			apiTokenCreated := remoteUnleashApiTokenResource(apiTokenName, ApiTokenNamespace, apiTokenName, unleashCreated)
+			Expect(k8sClient.Create(ctx, apiTokenCreated)).Should(Succeed())
+			Eventually(apiTokenEventually(ctx, apiTokenLookup, apiTokenCreated), timeout, interval).Should(ContainElement(apiTokenSuccessCondition()))
+			Expect(getTokens()).Should(HaveLen(1))
+			originalEnvironment := getTokens()[0].Environment
+
+			By("By making token creation fail from now on")
+			httpmock.ZeroCallCounters()
+			httpmock.RegisterResponder("POST", serverURL+unleashclient.ApiTokensEndpoint,
+				httpmock.NewStringResponder(500, `{"message": "boom"}`))
+
+			By("By changing the spec so the existing token is superseded")
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, apiTokenLookup, apiTokenCreated)).To(Succeed())
+				apiTokenCreated.Spec.Environment = "production"
+				g.Expect(k8sClient.Update(ctx, apiTokenCreated)).To(Succeed())
+			}, timeout, interval).Should(Succeed())
+
+			By("By waiting for the reconcile to report the failure")
+			Eventually(func(g Gomega) {
+				g.Expect(httpmock.GetCallCountInfo()[fmt.Sprintf("POST %s%s", serverURL, unleashclient.ApiTokensEndpoint)]).To(BeNumerically(">", 0))
+			}, timeout, interval).Should(Succeed())
+
+			By("By verifying the old token was never deleted")
+			// This is the whole point: deleting first meant a failed create left
+			// the ApiToken with no valid token at all, and every later reconcile
+			// repeated delete(none) -> create -> fail.
+			Consistently(func(g Gomega) {
+				g.Expect(getTokens()).To(HaveLen(1), "the existing token must survive a failed replacement")
+				g.Expect(getTokens()[0].Environment).To(Equal(originalEnvironment))
+				g.Expect(httpmock.GetCallCountInfo()[fmt.Sprintf("DELETE =~%s%s/.*", serverURL, unleashclient.ApiTokensEndpoint)]).To(Equal(0))
+			}, "2s", interval).Should(Succeed())
+		})
+
 		It("Should update ApiToken in Unleash when it differs from Kubernetes", func() {
 			ctx := context.Background()
 


### PR DESCRIPTION
**Draft** — pending review.

Closes #757.

## Problem

With `ApiTokenUpdateEnabled`, a spec change deleted the outdated token in Unleash **before** creating its replacement (`apitoken_controller.go:320` preceded `:344`).

A failed create left the ApiToken with no valid token at all. Workloads consuming the secret get 401s, and it does not self-heal: every later reconcile finds nothing to delete, tries to create, fails again. A transient failure — a 5xx, a v7 incompatibility — becomes a persistent outage that repeats on every loop.

## Change

The loop now identifies the up-to-date token and **collects** the superseded ones without deleting. Creation and the secret write happen first; only then are the old tokens removed.

The ordering matters in both directions:

- **Create fails** → the existing token is untouched and keeps working. The reconcile reports failure and retries.
- **Delete fails** → an extra valid token is left in Unleash, which the next reconcile collects again. Strictly better than the old failure mode, where the ApiToken was left with none.

The `ApiTokenUpdateEnabled=false` path is unchanged: it still suppresses both deletion and creation, including for duplicates.

## Test

With creation failing after a spec change, the existing token must survive and no `DELETE` may be issued:

```
Consistently(func(g Gomega) {
    g.Expect(getTokens()).To(HaveLen(1), "the existing token must survive a failed replacement")
    g.Expect(getTokens()[0].Environment).To(Equal(originalEnvironment))
    g.Expect(httpmock.GetCallCountInfo()[…DELETE…]).To(Equal(0))
})
```

Verified against the old ordering by reverting the fix — it fails with `the existing token must survive a failed replacement`.

`make test` green: controller package at 67.8% coverage, all suites pass.

## Note on scope

This is one of the thirteen findings from the adversarial audit (#747–#761), untouched for a month. #749 (SSRF and plaintext HTTP to a tenant-controlled admin URL) is the other one with real security weight and is worth taking next; the remaining eleven are lower severity.
