### PR TITLE
fix(federation): stop orphaning RemoteUnleash on removal and deprovisioning

### DIFF
--- a/api/v1/meta.go
+++ b/api/v1/meta.go
@@ -48,6 +48,14 @@ const (
 	// parsing as the primary confused-deputy defense.
 	UnleashSecretAuthorizedNamespaceAnnotation = "unleash.nais.io/authorized-namespace"
 
+	// RemoteUnleashFederationPublishTimeAnnotation records, in RFC 3339 format,
+	// the Pub/Sub publish time of the most recent federation message applied to
+	// a RemoteUnleash. Pub/Sub redelivers, and an ordering key only orders what
+	// it delivers in one go, so a delayed copy of an older message can arrive
+	// after a newer one was applied. This is what lets the receive path tell the
+	// two apart and refuse to delete on the stale one.
+	RemoteUnleashFederationPublishTimeAnnotation = "unleash.nais.io/federation-publish-time"
+
 	ApiTokenSecretTokenEnv    = "UNLEASH_SERVER_API_TOKEN"
 	ApiTokenSecretServerEnv   = "UNLEASH_SERVER_API_URL"
 	ApiTokenSecretEnvEnv      = "UNLEASH_SERVER_API_ENV"

--- a/charts/unleasherator/ci/gcp-values.yaml
+++ b/charts/unleasherator/ci/gcp-values.yaml
@@ -6,6 +6,14 @@ controllerManagerGcp:
 controllerManager:
   manager:
     imagePullPolicy: Never
+    env:
+      # The operator refuses to start without this: federation uses it to decide
+      # whether an instance belongs in this cluster, and an empty value used to
+      # mean "no cluster matches", which turned a deprovisioning message into a
+      # fleet-wide delete. Real deployments get it from Feature.yaml, which
+      # always computes a non-empty name; the chart default is empty, so the
+      # test has to supply one like any other deployment does.
+      clusterName: chart-testing
 
 # Test configuration - faster timeouts for local/CI testing
 # For slower CI systems, override these with higher values

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"cloud.google.com/go/pubsub"
@@ -92,6 +93,16 @@ func (f *Features) Validate() error {
 
 // Validate validates the configuration.
 func (c *Config) Validate() error {
+	// envconfig's `required` only rejects an UNSET variable, so a chart value
+	// that is dropped or mis-templated arrives here as the empty string and
+	// starts the operator anyway. That is not a harmless default: the federation
+	// receive path decides whether an instance belongs in this cluster by
+	// looking for this name on the message, and a name that can never match
+	// reads every message as "no longer federated here". Refuse to start.
+	if strings.TrimSpace(c.ClusterName) == "" {
+		return fmt.Errorf("CLUSTER_NAME must be set to a non-empty value; federation uses it to decide whether an instance belongs in this cluster")
+	}
+
 	return c.Features.Validate()
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -57,6 +57,7 @@ func TestFeaturesValidate(t *testing.T) {
 
 func TestConfigValidate(t *testing.T) {
 	cfg := &Config{
+		ClusterName: "test-cluster",
 		Features: Features{
 			FederationNamespaceBoundSecrets: false,
 			AllowLegacyNameBoundSecrets:     false,
@@ -66,4 +67,18 @@ func TestConfigValidate(t *testing.T) {
 
 	cfg.Features.AllowLegacyNameBoundSecrets = true
 	assert.NoError(t, cfg.Validate(), "default configuration should pass validation")
+}
+
+// An empty CLUSTER_NAME must stop the operator from starting. envconfig's
+// `required` only rejects an unset variable, so the chart default and any
+// mis-templated value reach the process as "", and federation would then read
+// every provisioning message as "this instance is no longer federated here".
+func TestConfigValidateRequiresClusterName(t *testing.T) {
+	for _, clusterName := range []string{"", "   ", "\t"} {
+		cfg := &Config{
+			ClusterName: clusterName,
+			Features:    Features{AllowLegacyNameBoundSecrets: true},
+		}
+		assert.Error(t, cfg.Validate(), "cluster name %q should fail validation", clusterName)
+	}
 }

--- a/internal/controller/remoteunleash_controller.go
+++ b/internal/controller/remoteunleash_controller.go
@@ -68,7 +68,78 @@ const (
 	federationReceiveBackoffBase         = 1 * time.Second
 	federationReceiveBackoffMax          = 5 * time.Minute
 	federationReceiveEscalationThreshold = 10
+
+	// federationStateRemoved labels counters for a deletion the management
+	// cluster published as such.
+	federationStateRemoved = "removed"
+	// federationStateDeprovisioned labels counters for a deletion this cluster
+	// derived from a provisioning message that no longer names it. The two are
+	// counted apart because they answer different questions: one says an
+	// instance is gone, the other says it moved.
+	federationStateDeprovisioned = "deprovisioned"
 )
+
+// clusterListMatch is the outcome of comparing this operator's cluster name
+// against the cluster list on a federation message. It is an enum rather than a
+// bool because "the list does not name me" and "the list says nothing useful"
+// must lead to different actions: only the first may delete.
+type clusterListMatch int
+
+const (
+	// clusterListNoStatement means the message asserts nothing about placement,
+	// either because it carries no clusters at all or because every entry is
+	// blank once trimmed.
+	clusterListNoStatement clusterListMatch = iota
+	// clusterListNamed means an entry names this cluster.
+	clusterListNamed
+	// clusterListCaseMismatch means an entry matches only when case is ignored.
+	clusterListCaseMismatch
+	// clusterListExcluded means the list names other clusters, and none of them
+	// is this one under any casing.
+	clusterListExcluded
+)
+
+// matchClusterList compares clusterName against the cluster list carried by a
+// federation message.
+//
+// Entries are trimmed before comparison, and entries that are empty once
+// trimmed are ignored: a stray space in a team's federation config is a typo,
+// not a different cluster, and a list of nothing but blanks says as little as
+// an empty list. Without this, `[" cluster-a"]` or `[""]` reads as "this
+// instance does not belong in cluster-a" and deletes it.
+//
+// The match itself stays case-sensitive: cluster names are exact identifiers
+// here (they name a real cluster in the fleet), and folding them would let two
+// distinct configured names collide. But a case-only difference is reported as
+// its own outcome instead of as an exclusion, because the caller's response to
+// an exclusion is destructive and "cluster-a" versus "Cluster-A" is far more
+// likely a naming mistake than a statement that the instance must go.
+func matchClusterList(clusterName string, clusters []string) clusterListMatch {
+	clusterName = strings.TrimSpace(clusterName)
+	if clusterName == "" {
+		// An operator that does not know its own name cannot conclude anything
+		// about placement. Callers reject this earlier and with a counter; this
+		// is here so no future caller can turn it into a deletion by accident.
+		return clusterListNoStatement
+	}
+
+	match := clusterListNoStatement
+	for _, cluster := range clusters {
+		cluster = strings.TrimSpace(cluster)
+		switch {
+		case cluster == "":
+			continue
+		case cluster == clusterName:
+			return clusterListNamed
+		case strings.EqualFold(cluster, clusterName):
+			match = clusterListCaseMismatch
+		case match == clusterListNoStatement:
+			match = clusterListExcluded
+		}
+	}
+
+	return match
+}
 
 func init() {
 	metrics.Registry.MustRegister(remoteUnleashStatus, remoteUnleashReceived, federationReceiveConsecutiveErrors)
@@ -519,22 +590,56 @@ func (r *RemoteUnleashReconciler) FederationSubscribe(ctx context.Context) error
 			// holding no matching resource does nothing either way, and the URL
 			// and credential checks below still refuse anything that disagrees
 			// with what is stored.
+			//
+			// Rewriting a message into a deletion is only ever done from an
+			// explicit Status_Provisioned. Every other status, including the
+			// proto3 zero value Status_Unknown that an absent field
+			// deserialises to, keeps the old no-op behaviour: a message we
+			// cannot read must not be the most destructive one we handle.
 			effective := status
-			switch {
-			case status == pb.Status_Removed:
-				// Applies everywhere.
-			case len(clusters) == 0:
-				// Asserts nothing about placement. Treating it as "remove
-				// everywhere" would turn a malformed publish into fleet-wide
-				// deletion, so ignore it instead.
-				remoteUnleashReceived.WithLabelValues(strings.ToLower(status.String()), "no_clusters").Inc()
-				log.Info("Message names no clusters; ignoring", "cluster", r.Federation.ClusterName)
-				return nil
-			case !utils.StringInSlice(r.Federation.ClusterName, clusters):
-				effective = pb.Status_Removed
-				remoteUnleashReceived.WithLabelValues(strings.ToLower(status.String()), "deprovisioned_here").Inc()
-				log.Info("Instance is no longer federated to this cluster; removing local resources",
-					"cluster", r.Federation.ClusterName, "clusters", clusters)
+			// Counters in the shared removal body are labelled with the reason
+			// the removal happened, so a deletion this cluster derived from a
+			// dropped cluster list stays distinguishable from one the
+			// management cluster actually published.
+			removalState := federationStateRemoved
+
+			if status == pb.Status_Provisioned {
+				ownCluster := strings.TrimSpace(r.Federation.ClusterName)
+				if ownCluster == "" {
+					// Config.Validate refuses to start without CLUSTER_NAME, but
+					// a single check is a poor guard for a fleet-wide deletion:
+					// an operator that does not know its own name reads every
+					// message as "not for me" and would empty the cluster.
+					remoteUnleashReceived.WithLabelValues(strings.ToLower(status.String()), "cluster_name_unset").Inc()
+					log.Info("Operator has no cluster name; refusing to act on placement", "clusters", clusters)
+					return nil
+				}
+
+				switch matchClusterList(ownCluster, clusters) {
+				case clusterListNamed:
+					// The instance belongs here; provision it below.
+				case clusterListNoStatement:
+					// Asserts nothing about placement. Treating it as "remove
+					// everywhere" would turn a malformed publish into fleet-wide
+					// deletion, so ignore it instead.
+					remoteUnleashReceived.WithLabelValues(strings.ToLower(status.String()), "no_clusters").Inc()
+					log.Info("Message names no clusters; ignoring", "cluster", ownCluster)
+					return nil
+				case clusterListCaseMismatch:
+					// Ambiguous: the list plausibly means this cluster and only
+					// the casing differs. Deleting on a guess is the one reading
+					// that cannot be undone, so do nothing and leave a counter
+					// for whoever has to explain the naming mismatch.
+					remoteUnleashReceived.WithLabelValues(strings.ToLower(status.String()), "cluster_name_case_mismatch").Inc()
+					log.Info("Cluster list matches this cluster only when case is ignored; ignoring",
+						"cluster", ownCluster, "clusters", clusters)
+					return nil
+				case clusterListExcluded:
+					effective = pb.Status_Removed
+					removalState = federationStateDeprovisioned
+					log.Info("Instance is no longer federated to this cluster; removing local resources",
+						"cluster", ownCluster, "clusters", clusters)
+				}
 			}
 
 			switch effective {
@@ -558,7 +663,7 @@ func (r *RemoteUnleashReconciler) FederationSubscribe(ctx context.Context) error
 						return err
 					}
 					if existingRU.Spec.Server.URL != ru.Spec.Server.URL {
-						remoteUnleashReceived.WithLabelValues("removed", "rejected").Inc()
+						remoteUnleashReceived.WithLabelValues(removalState, "rejected").Inc()
 						log.Info("Refusing to delete RemoteUnleash due to URL mismatch - possible hijack attempt",
 							"name", ru.Name, "namespace", ru.Namespace,
 							"existingURL", existingRU.Spec.Server.URL, "newURL", ru.Spec.Server.URL)
@@ -573,7 +678,7 @@ func (r *RemoteUnleashReconciler) FederationSubscribe(ctx context.Context) error
 						return err
 					}
 					if !federationTokensEqual(existingRU, existingSecret, adminSecrets[i]) {
-						remoteUnleashReceived.WithLabelValues("removed", "rejected").Inc()
+						remoteUnleashReceived.WithLabelValues(removalState, "rejected").Inc()
 						log.Info("Refusing to delete RemoteUnleash due to credential mismatch - possible hijack attempt",
 							"name", ru.Name, "namespace", ru.Namespace)
 						continue
@@ -594,7 +699,7 @@ func (r *RemoteUnleashReconciler) FederationSubscribe(ctx context.Context) error
 				if errs := utils.DeleteAllObjects(objectsCtx, r.Client, safeRUs); len(errs) > 0 {
 					var permanentErr error
 					for _, err := range errs {
-						remoteUnleashReceived.WithLabelValues("removed", "failed").Inc()
+						remoteUnleashReceived.WithLabelValues(removalState, "failed").Inc()
 						log.Error(err, "Failed to delete RemoteUnleash")
 
 						if !retriableError(err) {
@@ -614,7 +719,7 @@ func (r *RemoteUnleashReconciler) FederationSubscribe(ctx context.Context) error
 				if errs := utils.DeleteAllObjects(secretCtx, r.Client, safeSecrets); len(errs) > 0 {
 					var permanentErr error
 					for _, err := range errs {
-						remoteUnleashReceived.WithLabelValues("removed", "failed").Inc()
+						remoteUnleashReceived.WithLabelValues(removalState, "failed").Inc()
 						log.Error(err, "Failed to delete admin secret")
 
 						if !retriableError(err) {
@@ -627,7 +732,7 @@ func (r *RemoteUnleashReconciler) FederationSubscribe(ctx context.Context) error
 					return errs[0]
 				}
 
-				remoteUnleashReceived.WithLabelValues("removed", "success").Inc()
+				remoteUnleashReceived.WithLabelValues(removalState, "success").Inc()
 				log.Info("Successfully deleted RemoteUnleash resources and secret")
 				return nil
 

--- a/internal/controller/remoteunleash_controller.go
+++ b/internal/controller/remoteunleash_controller.go
@@ -553,7 +553,7 @@ func (r *RemoteUnleashReconciler) FederationSubscribe(ctx context.Context) error
 		healthy := time.AfterFunc(federationReceiveBackoffMax, func() {
 			federationReceiveConsecutiveErrors.Set(0)
 		})
-		err := r.Federation.Subscriber.Subscribe(subCtx, func(ctx context.Context, remoteUnleashes []*unleashv1.RemoteUnleash, adminSecrets []*corev1.Secret, clusters []string, status pb.Status) error {
+		err := r.Federation.Subscriber.Subscribe(subCtx, func(ctx context.Context, remoteUnleashes []*unleashv1.RemoteUnleash, adminSecrets []*corev1.Secret, clusters []string, status pb.Status, publishTime time.Time) error {
 			// failPermanently stops receiving so the operator restarts into a
 			// corrected configuration, but nacks the message: operator-side
 			// failures (e.g. RBAC) are recoverable, and the message must be
@@ -662,6 +662,32 @@ func (r *RemoteUnleashReconciler) FederationSubscribe(ctx context.Context) error
 						}
 						return err
 					}
+
+					// Replay protection. A redelivered older message carries an
+					// older cluster list, and acting on it deletes what a newer
+					// message legitimately created. Nothing would bring it back:
+					// the publisher skips republishing while its instance hash is
+					// unchanged, and there is no periodic federation resync, so
+					// recovery needs a human.
+					//
+					// A resource with no recorded time is not treated as newer
+					// than everything; it is treated as unknown, and unknown
+					// permits the deletion. Refusing instead would make every
+					// resource predating this annotation undeletable by
+					// federation, which is the orphan bug this path exists to
+					// fix. The gap closes by itself: the first provisioning
+					// message applied to a resource stamps it, and a transport
+					// that supplies no publish time never stamps anything, so it
+					// keeps working exactly as before rather than freezing.
+					if lastApplied := federationLastAppliedPublishTime(existingRU); !lastApplied.IsZero() &&
+						!publishTime.After(lastApplied) {
+						remoteUnleashReceived.WithLabelValues(removalState, "stale").Inc()
+						log.Info("Refusing to delete RemoteUnleash from a message older than the one already applied",
+							"name", ru.Name, "namespace", ru.Namespace,
+							"publishTime", publishTime, "lastApplied", lastApplied)
+						continue
+					}
+
 					if existingRU.Spec.Server.URL != ru.Spec.Server.URL {
 						remoteUnleashReceived.WithLabelValues(removalState, "rejected").Inc()
 						log.Info("Refusing to delete RemoteUnleash due to URL mismatch - possible hijack attempt",
@@ -812,6 +838,16 @@ func (r *RemoteUnleashReconciler) FederationSubscribe(ctx context.Context) error
 						supersededSecrets[client.ObjectKeyFromObject(secret)] = secret
 					}
 
+					// Record what this resource has seen, so a later replay of an
+					// older message cannot delete it. The stamp only moves
+					// forward: a replayed older provisioning message must not roll
+					// it back and re-open the window it closes.
+					stamp := publishTime
+					if lastApplied := federationLastAppliedPublishTime(existingRU); lastApplied.After(stamp) {
+						stamp = lastApplied
+					}
+					setFederationPublishTime(ru, stamp)
+
 					safeRUs = append(safeRUs, ru)
 					safeSecrets = append(safeSecrets, adminSecrets[i])
 				}
@@ -947,6 +983,38 @@ func (r *RemoteUnleashReconciler) FederationSubscribe(ctx context.Context) error
 // retriableError returns true if the error is not a forbidden or unauthorized error.
 func retriableError(err error) bool {
 	return !apierrors.IsForbidden(err) && !apierrors.IsUnauthorized(err)
+}
+
+// federationLastAppliedPublishTime reports the publish time of the most recent
+// federation message applied to remoteUnleash. A missing or unparseable value
+// reads as the zero time, meaning "unknown": callers must treat that as no basis
+// to refuse rather than as an ordering claim.
+func federationLastAppliedPublishTime(remoteUnleash *unleashv1.RemoteUnleash) time.Time {
+	value, ok := remoteUnleash.Annotations[unleashv1.RemoteUnleashFederationPublishTimeAnnotation]
+	if !ok {
+		return time.Time{}
+	}
+
+	publishTime, err := time.Parse(time.RFC3339Nano, value)
+	if err != nil {
+		return time.Time{}
+	}
+	return publishTime
+}
+
+// setFederationPublishTime stamps remoteUnleash with the publish time of the
+// federation message being applied to it. A zero time is not recorded: it means
+// the transport supplied none, and a stamp that claims an ordering nobody
+// established would refuse every later deletion.
+func setFederationPublishTime(remoteUnleash *unleashv1.RemoteUnleash, publishTime time.Time) {
+	if publishTime.IsZero() {
+		return
+	}
+
+	if remoteUnleash.Annotations == nil {
+		remoteUnleash.Annotations = map[string]string{}
+	}
+	remoteUnleash.Annotations[unleashv1.RemoteUnleashFederationPublishTimeAnnotation] = publishTime.UTC().Format(time.RFC3339Nano)
 }
 
 func federationAdminSecret(ctx context.Context, k8sClient client.Reader, remoteUnleash *unleashv1.RemoteUnleash) (*corev1.Secret, error) {

--- a/internal/controller/remoteunleash_controller.go
+++ b/internal/controller/remoteunleash_controller.go
@@ -507,7 +507,16 @@ func (r *RemoteUnleashReconciler) FederationSubscribe(ctx context.Context) error
 
 			log.Info("Received pubsub message", "status", status, "unleash", remoteUnleashes[0].GetName(), "clusters", clusters)
 
-			if !utils.StringInSlice(r.Federation.ClusterName, clusters) {
+			// Removals are never cluster-filtered. The cluster list on the
+			// message is the instance's federation config at the moment it was
+			// deleted, so a cluster dropped from that list earlier would never
+			// be told the instance is gone — leaving a RemoteUnleash pointing at
+			// a server that no longer exists, alerting forever with no way to
+			// discover why. A cluster holding no matching RemoteUnleash does
+			// nothing with the message, and the URL and credential checks below
+			// still refuse a removal that does not match what is stored.
+			if status != pb.Status_Removed && !utils.StringInSlice(r.Federation.ClusterName, clusters) {
+				remoteUnleashReceived.WithLabelValues(strings.ToLower(status.String()), "other_cluster").Inc()
 				log.Info("Ignoring message, not for this cluster", "cluster", r.Federation.ClusterName, "clusters", clusters)
 				return nil
 			}

--- a/internal/controller/remoteunleash_controller.go
+++ b/internal/controller/remoteunleash_controller.go
@@ -507,21 +507,37 @@ func (r *RemoteUnleashReconciler) FederationSubscribe(ctx context.Context) error
 
 			log.Info("Received pubsub message", "status", status, "unleash", remoteUnleashes[0].GetName(), "clusters", clusters)
 
-			// Removals are never cluster-filtered. The cluster list on the
-			// message is the instance's federation config at the moment it was
-			// deleted, so a cluster dropped from that list earlier would never
-			// be told the instance is gone — leaving a RemoteUnleash pointing at
-			// a server that no longer exists, alerting forever with no way to
-			// discover why. A cluster holding no matching RemoteUnleash does
-			// nothing with the message, and the URL and credential checks below
-			// still refuse a removal that does not match what is stored.
-			if status != pb.Status_Removed && !utils.StringInSlice(r.Federation.ClusterName, clusters) {
-				remoteUnleashReceived.WithLabelValues(strings.ToLower(status.String()), "other_cluster").Inc()
-				log.Info("Ignoring message, not for this cluster", "cluster", r.Federation.ClusterName, "clusters", clusters)
+			// A federation message states where the instance should exist; it is
+			// not an instruction addressed to the clusters it happens to name.
+			// Acting only when named is what orphans resources: a cluster taken
+			// out of a team's federation config, or one dropped from the list
+			// before the instance was deleted, keeps a RemoteUnleash pointing at
+			// a server it can no longer reach and alerts on it forever.
+			//
+			// So removals apply everywhere, and a provisioning message that no
+			// longer names this cluster is treated as a removal here. A cluster
+			// holding no matching resource does nothing either way, and the URL
+			// and credential checks below still refuse anything that disagrees
+			// with what is stored.
+			effective := status
+			switch {
+			case status == pb.Status_Removed:
+				// Applies everywhere.
+			case len(clusters) == 0:
+				// Asserts nothing about placement. Treating it as "remove
+				// everywhere" would turn a malformed publish into fleet-wide
+				// deletion, so ignore it instead.
+				remoteUnleashReceived.WithLabelValues(strings.ToLower(status.String()), "no_clusters").Inc()
+				log.Info("Message names no clusters; ignoring", "cluster", r.Federation.ClusterName)
 				return nil
+			case !utils.StringInSlice(r.Federation.ClusterName, clusters):
+				effective = pb.Status_Removed
+				remoteUnleashReceived.WithLabelValues(strings.ToLower(status.String()), "deprovisioned_here").Inc()
+				log.Info("Instance is no longer federated to this cluster; removing local resources",
+					"cluster", r.Federation.ClusterName, "clusters", clusters)
 			}
 
-			switch status {
+			switch effective {
 			case pb.Status_Removed:
 				log.Info("Received Status_Removed, deleting RemoteUnleash resources and secret")
 

--- a/internal/controller/remoteunleash_controller.go
+++ b/internal/controller/remoteunleash_controller.go
@@ -697,6 +697,20 @@ func (r *RemoteUnleashReconciler) FederationSubscribe(ctx context.Context) error
 					}
 
 					existingSecret, err := federationAdminSecret(ctx, r.APIReader, existingRU)
+					if apierrors.IsNotFound(err) {
+						// Without the stored credential the removal cannot be
+						// authenticated, so this resource is left alone: deleting
+						// unverified is exactly the hijack the checks below exist
+						// to stop. Returning the error instead would nack forever
+						// — the secret is not coming back — and block every later
+						// message sharing the ordering key, now in every cluster
+						// rather than only the ones the message names.
+						remoteUnleashReceived.WithLabelValues(removalState, "missing_secret").Inc()
+						log.Info("Refusing to delete RemoteUnleash whose admin secret is missing",
+							"name", ru.Name, "namespace", ru.Namespace,
+							"secret", existingRU.AdminSecretNamespacedName())
+						continue
+					}
 					if err != nil {
 						if !retriableError(err) {
 							return failPermanently(err)

--- a/internal/controller/remoteunleash_controller_test.go
+++ b/internal/controller/remoteunleash_controller_test.go
@@ -364,7 +364,7 @@ var _ = Describe("RemoteUnleash Controller", func() {
 			_, remoteUnleash := remoteUnleashResource(name, namespaces[0], remoteUnleashURL, secret)
 			remoteUnleashes = []*unleashv1.RemoteUnleash{remoteUnleash}
 
-			err := handler(ctx, remoteUnleashes, []*corev1.Secret{secret}, clusters, pb.Status_Provisioned)
+			err := handler(ctx, remoteUnleashes, []*corev1.Secret{secret}, clusters, pb.Status_Provisioned, time.Now())
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(k8sClient.Get(ctx, remoteUnleash.NamespacedName(), remoteUnleash)).ShouldNot(Succeed())
@@ -380,7 +380,7 @@ var _ = Describe("RemoteUnleash Controller", func() {
 			registerHTTPMocksForRemoteUnleash(remoteUnleash, RemoteUnleashVersion)
 			remoteUnleashes = []*unleashv1.RemoteUnleash{remoteUnleash}
 
-			err = handler(ctx, remoteUnleashes, []*corev1.Secret{secret}, clusters, pb.Status_Provisioned)
+			err = handler(ctx, remoteUnleashes, []*corev1.Secret{secret}, clusters, pb.Status_Provisioned, time.Now())
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(k8sClient.Get(ctx, remoteUnleash.NamespacedName(), remoteUnleash)).Should(Succeed())
@@ -396,7 +396,7 @@ var _ = Describe("RemoteUnleash Controller", func() {
 			remoteUnleashes = []*unleashv1.RemoteUnleash{remoteUnleash}
 
 			Eventually(func() error {
-				return handler(ctx, remoteUnleashes, []*corev1.Secret{secret}, clusters, pb.Status_Provisioned)
+				return handler(ctx, remoteUnleashes, []*corev1.Secret{secret}, clusters, pb.Status_Provisioned, time.Now())
 			}, timeout, interval).ShouldNot(HaveOccurred())
 
 			Expect(k8sClient.Get(ctx, remoteUnleash.NamespacedName(), remoteUnleash)).Should(Succeed())
@@ -460,7 +460,7 @@ var _ = Describe("RemoteUnleash Controller", func() {
 			_, maliciousRU := remoteUnleashResource(name, namespaces[0], maliciousURL, secret)
 			remoteUnleashes := []*unleashv1.RemoteUnleash{maliciousRU}
 
-			err := handler(ctx, remoteUnleashes, []*corev1.Secret{secret}, clusters, pb.Status_Provisioned)
+			err := handler(ctx, remoteUnleashes, []*corev1.Secret{secret}, clusters, pb.Status_Provisioned, time.Now())
 			Expect(err).ToNot(HaveOccurred())
 
 			By("By verifying that the original RemoteUnleash URL is unchanged")
@@ -470,7 +470,7 @@ var _ = Describe("RemoteUnleash Controller", func() {
 			Expect(fetchedRU.Spec.Server.URL).ToNot(Equal(maliciousURL))
 
 			By("By verifying that a malicious deletion is also blocked")
-			err = handler(ctx, remoteUnleashes, []*corev1.Secret{secret}, clusters, pb.Status_Removed)
+			err = handler(ctx, remoteUnleashes, []*corev1.Secret{secret}, clusters, pb.Status_Removed, time.Now())
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(k8sClient.Get(ctx, legitimateRU.NamespacedName(), fetchedRU)).Should(Succeed(), "Legitimate RemoteUnleash should not be deleted by malicious tenant")
@@ -486,6 +486,7 @@ var _ = Describe("RemoteUnleash Controller", func() {
 				[]*corev1.Secret{maliciousSecret},
 				clusters,
 				pb.Status_Provisioned,
+				time.Now(),
 			)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -499,6 +500,7 @@ var _ = Describe("RemoteUnleash Controller", func() {
 				[]*corev1.Secret{maliciousSecret},
 				clusters,
 				pb.Status_Removed,
+				time.Now(),
 			)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(k8sClient.Get(ctx, legitimateRU.NamespacedName(), fetchedRU)).Should(Succeed(), "Credential mismatch must not authorize deletion")
@@ -523,6 +525,7 @@ var _ = Describe("RemoteUnleash Controller", func() {
 				[]*corev1.Secret{replacementSecret},
 				clusters,
 				pb.Status_Provisioned,
+				time.Now(),
 			)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -577,6 +580,7 @@ var _ = Describe("RemoteUnleash Controller", func() {
 				[]*corev1.Secret{replacementSecret},
 				clusters,
 				pb.Status_Provisioned,
+				time.Now(),
 			)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(orphanedLegacySecret), &corev1.Secret{})).ShouldNot(Succeed())
@@ -592,6 +596,7 @@ var _ = Describe("RemoteUnleash Controller", func() {
 				[]*corev1.Secret{removalSecret},
 				clusters,
 				pb.Status_Removed,
+				time.Now(),
 			)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -690,6 +695,7 @@ var _ = Describe("RemoteUnleash Controller", func() {
 					[]*corev1.Secret{replacementSecret},
 					clusters,
 					pb.Status_Provisioned,
+					time.Now(),
 				)
 			}, timeout, interval).Should(Succeed())
 
@@ -741,7 +747,7 @@ var _ = Describe("RemoteUnleash Controller", func() {
 			_, remoteUnleash := remoteUnleashResource(name, namespaces[0], remoteUnleashURL, secret)
 			remoteUnleashes = []*unleashv1.RemoteUnleash{remoteUnleash}
 
-			err := handler(ctx, remoteUnleashes, []*corev1.Secret{secret}, clusters, pb.Status_Provisioned)
+			err := handler(ctx, remoteUnleashes, []*corev1.Secret{secret}, clusters, pb.Status_Provisioned, time.Now())
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(k8sClient.Get(ctx, remoteUnleash.NamespacedName(), remoteUnleash)).ShouldNot(Succeed())

--- a/internal/controller/remoteunleash_federation_unit_test.go
+++ b/internal/controller/remoteunleash_federation_unit_test.go
@@ -146,3 +146,135 @@ func TestFederationSubscribeDisabled(t *testing.T) {
 	reconciler := &RemoteUnleashReconciler{}
 	require.NoError(t, reconciler.FederationSubscribe(context.Background()))
 }
+
+// A removal must reach every cluster, not only those on the message's cluster
+// list. That list is the instance's federation config at the moment it was
+// deleted, so a cluster dropped from it earlier would never learn the instance
+// is gone — leaving a RemoteUnleash pointing at a server that no longer exists
+// and alerting forever, with no counter or event explaining why.
+func TestFederationRemovalReachesClustersNotOnTheMessage(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	const serverURL = "https://unleash.example.com"
+
+	existing := &unleashv1.RemoteUnleash{
+		ObjectMeta: metav1.ObjectMeta{Name: "aura", Namespace: "tenant"},
+		Spec: unleashv1.RemoteUnleashSpec{
+			Server:      unleashv1.RemoteUnleashServer{URL: serverURL},
+			AdminSecret: unleashv1.RemoteUnleashSecret{Name: "unleasherator-aura", Key: unleashv1.UnleashSecretTokenKey},
+		},
+	}
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "unleasherator-aura", Namespace: "tenant"},
+		Data: map[string][]byte{
+			unleashv1.UnleashSecretTokenKey:     []byte("token"),
+			unleashv1.UnleashSecretServerURLKey: []byte(serverURL),
+		},
+	}
+
+	scheme := federationTestScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existing, secret).Build()
+
+	handlerCh := make(chan federation.Handler, 1)
+	mockSubscriber := &mockfederation.MockSubscriber{}
+	mockSubscriber.On("Subscribe", mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			handlerCh <- args.Get(1).(federation.Handler)
+			<-args.Get(0).(context.Context).Done()
+		}).
+		Return(nil)
+
+	reconciler := &RemoteUnleashReconciler{
+		Client:    c,
+		APIReader: c,
+		Scheme:    scheme,
+		Federation: RemoteUnleashFederation{
+			Enabled:     true,
+			ClusterName: "cluster-a",
+			Subscriber:  mockSubscriber,
+		},
+	}
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- reconciler.FederationSubscribe(ctx) }()
+
+	var handler federation.Handler
+	select {
+	case handler = <-handlerCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Subscribe was not called")
+	}
+
+	incoming := existing.DeepCopy()
+	incoming.ResourceVersion = ""
+
+	// The message names only cluster-b; this operator runs cluster-a.
+	require.NoError(t, handler(ctx,
+		[]*unleashv1.RemoteUnleash{incoming},
+		[]*corev1.Secret{secret.DeepCopy()},
+		[]string{"cluster-b"},
+		pb.Status_Removed,
+	))
+
+	err := c.Get(ctx, client.ObjectKeyFromObject(existing), &unleashv1.RemoteUnleash{})
+	assert.True(t, apierrors.IsNotFound(err),
+		"a removal must delete the RemoteUnleash even when this cluster is not on the message")
+}
+
+// Provisioning stays cluster-scoped: a message for another cluster must not
+// create resources here.
+func TestFederationProvisioningStaysClusterScoped(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	scheme := federationTestScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	handlerCh := make(chan federation.Handler, 1)
+	mockSubscriber := &mockfederation.MockSubscriber{}
+	mockSubscriber.On("Subscribe", mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			handlerCh <- args.Get(1).(federation.Handler)
+			<-args.Get(0).(context.Context).Done()
+		}).
+		Return(nil)
+
+	reconciler := &RemoteUnleashReconciler{
+		Client:    c,
+		APIReader: c,
+		Scheme:    scheme,
+		Federation: RemoteUnleashFederation{
+			Enabled:     true,
+			ClusterName: "cluster-a",
+			Subscriber:  mockSubscriber,
+		},
+	}
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- reconciler.FederationSubscribe(ctx) }()
+
+	var handler federation.Handler
+	select {
+	case handler = <-handlerCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Subscribe was not called")
+	}
+
+	ru := &unleashv1.RemoteUnleash{
+		ObjectMeta: metav1.ObjectMeta{Name: "other", Namespace: "tenant"},
+		Spec:       unleashv1.RemoteUnleashSpec{Server: unleashv1.RemoteUnleashServer{URL: "https://other.example.com"}},
+	}
+	secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: "nais-system"}}
+
+	require.NoError(t, handler(ctx,
+		[]*unleashv1.RemoteUnleash{ru},
+		[]*corev1.Secret{secret},
+		[]string{"cluster-b"},
+		pb.Status_Provisioned,
+	))
+
+	err := c.Get(ctx, client.ObjectKeyFromObject(ru), &unleashv1.RemoteUnleash{})
+	assert.True(t, apierrors.IsNotFound(err),
+		"a provisioning message for another cluster must not create resources here")
+}

--- a/internal/controller/remoteunleash_federation_unit_test.go
+++ b/internal/controller/remoteunleash_federation_unit_test.go
@@ -674,37 +674,51 @@ func TestFederationStaleMessageDoesNotDeprovision(t *testing.T) {
 // recorded publish time. That is unknown, not "newer than everything": refusing
 // removals for it would make every resource predating the annotation
 // undeletable by federation, which is the orphan bug this path exists to fix.
+//
+// The same holds when the message itself carries no publish time. A transport
+// that supplies none stamps nothing either, so the two stay consistent and
+// removals keep working exactly as they did before the guard existed.
 func TestFederationRemovalWithoutRecordedPublishTime(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	for _, tt := range []struct {
+		name        string
+		publishTime time.Time
+	}{
+		{name: "message carries a publish time", publishTime: time.Now()},
+		{name: "message carries no publish time", publishTime: time.Time{}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
 
-	existing, secret := federationFixture("aura", "tenant", "https://unleash.example.com", "token")
+			existing, secret := federationFixture("aura", "tenant", "https://unleash.example.com", "token")
 
-	scheme := federationTestScheme(t)
-	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existing, secret).Build()
+			scheme := federationTestScheme(t)
+			c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existing, secret).Build()
 
-	reconciler := &RemoteUnleashReconciler{
-		Client:     c,
-		APIReader:  c,
-		Scheme:     scheme,
-		Federation: RemoteUnleashFederation{Enabled: true, ClusterName: "cluster-a"},
+			reconciler := &RemoteUnleashReconciler{
+				Client:     c,
+				APIReader:  c,
+				Scheme:     scheme,
+				Federation: RemoteUnleashFederation{Enabled: true, ClusterName: "cluster-a"},
+			}
+			handler := startFederationHandler(ctx, t, reconciler)
+
+			incoming := existing.DeepCopy()
+			incoming.ResourceVersion = ""
+
+			require.NoError(t, handler(ctx,
+				[]*unleashv1.RemoteUnleash{incoming},
+				[]*corev1.Secret{secret.DeepCopy()},
+				[]string{"cluster-b"},
+				pb.Status_Removed,
+				tt.publishTime,
+			))
+
+			err := c.Get(ctx, client.ObjectKeyFromObject(existing), &unleashv1.RemoteUnleash{})
+			assert.True(t, apierrors.IsNotFound(err),
+				"a resource with no recorded publish time must still be removable")
+		})
 	}
-	handler := startFederationHandler(ctx, t, reconciler)
-
-	incoming := existing.DeepCopy()
-	incoming.ResourceVersion = ""
-
-	require.NoError(t, handler(ctx,
-		[]*unleashv1.RemoteUnleash{incoming},
-		[]*corev1.Secret{secret.DeepCopy()},
-		[]string{"cluster-b"},
-		pb.Status_Removed,
-		time.Now(),
-	))
-
-	err := c.Get(ctx, client.ObjectKeyFromObject(existing), &unleashv1.RemoteUnleash{})
-	assert.True(t, apierrors.IsNotFound(err),
-		"a resource with no recorded publish time must still be removable")
 }
 
 // A RemoteUnleash whose admin secret is gone cannot have a removal authenticated

--- a/internal/controller/remoteunleash_federation_unit_test.go
+++ b/internal/controller/remoteunleash_federation_unit_test.go
@@ -33,6 +33,56 @@ func federationTestScheme(t *testing.T) *runtime.Scheme {
 	return scheme
 }
 
+// startFederationHandler runs the receive loop against a mock subscriber and
+// hands back the handler it was given, so a test can deliver messages directly
+// without repeating the subscription plumbing.
+func startFederationHandler(ctx context.Context, t *testing.T, reconciler *RemoteUnleashReconciler) federation.Handler {
+	t.Helper()
+
+	handlerCh := make(chan federation.Handler, 1)
+	mockSubscriber := &mockfederation.MockSubscriber{}
+	mockSubscriber.On("Subscribe", mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			handlerCh <- args.Get(1).(federation.Handler)
+			<-args.Get(0).(context.Context).Done()
+		}).
+		Return(nil)
+	reconciler.Federation.Subscriber = mockSubscriber
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- reconciler.FederationSubscribe(ctx) }()
+
+	select {
+	case handler := <-handlerCh:
+		return handler
+	case <-time.After(5 * time.Second):
+		t.Fatal("Subscribe was not called")
+		return nil
+	}
+}
+
+// federationFixture builds a RemoteUnleash together with the admin secret it
+// references, with the URL and token agreeing. Anything less realistic slips
+// past the URL and credential checks on the removal path for the wrong reason,
+// and a test that never reaches its own assertion protects nothing.
+func federationFixture(name, namespace, url, token string) (*unleashv1.RemoteUnleash, *corev1.Secret) {
+	remoteUnleash := &unleashv1.RemoteUnleash{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: unleashv1.RemoteUnleashSpec{
+			Server:      unleashv1.RemoteUnleashServer{URL: url},
+			AdminSecret: unleashv1.RemoteUnleashSecret{Name: "unleasherator-" + name, Key: unleashv1.UnleashSecretTokenKey},
+		},
+	}
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "unleasherator-" + name, Namespace: namespace},
+		Data: map[string][]byte{
+			unleashv1.UnleashSecretTokenKey:     []byte(token),
+			unleashv1.UnleashSecretServerURLKey: []byte(url),
+		},
+	}
+	return remoteUnleash, secret
+}
+
 func TestFederationSubscribeRetriesTransientErrors(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -156,55 +206,18 @@ func TestFederationRemovalReachesClustersNotOnTheMessage(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	const serverURL = "https://unleash.example.com"
-
-	existing := &unleashv1.RemoteUnleash{
-		ObjectMeta: metav1.ObjectMeta{Name: "aura", Namespace: "tenant"},
-		Spec: unleashv1.RemoteUnleashSpec{
-			Server:      unleashv1.RemoteUnleashServer{URL: serverURL},
-			AdminSecret: unleashv1.RemoteUnleashSecret{Name: "unleasherator-aura", Key: unleashv1.UnleashSecretTokenKey},
-		},
-	}
-	secret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{Name: "unleasherator-aura", Namespace: "tenant"},
-		Data: map[string][]byte{
-			unleashv1.UnleashSecretTokenKey:     []byte("token"),
-			unleashv1.UnleashSecretServerURLKey: []byte(serverURL),
-		},
-	}
+	existing, secret := federationFixture("aura", "tenant", "https://unleash.example.com", "token")
 
 	scheme := federationTestScheme(t)
 	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existing, secret).Build()
 
-	handlerCh := make(chan federation.Handler, 1)
-	mockSubscriber := &mockfederation.MockSubscriber{}
-	mockSubscriber.On("Subscribe", mock.Anything, mock.Anything).
-		Run(func(args mock.Arguments) {
-			handlerCh <- args.Get(1).(federation.Handler)
-			<-args.Get(0).(context.Context).Done()
-		}).
-		Return(nil)
-
 	reconciler := &RemoteUnleashReconciler{
-		Client:    c,
-		APIReader: c,
-		Scheme:    scheme,
-		Federation: RemoteUnleashFederation{
-			Enabled:     true,
-			ClusterName: "cluster-a",
-			Subscriber:  mockSubscriber,
-		},
+		Client:     c,
+		APIReader:  c,
+		Scheme:     scheme,
+		Federation: RemoteUnleashFederation{Enabled: true, ClusterName: "cluster-a"},
 	}
-
-	errCh := make(chan error, 1)
-	go func() { errCh <- reconciler.FederationSubscribe(ctx) }()
-
-	var handler federation.Handler
-	select {
-	case handler = <-handlerCh:
-	case <-time.After(5 * time.Second):
-		t.Fatal("Subscribe was not called")
-	}
+	handler := startFederationHandler(ctx, t, reconciler)
 
 	incoming := existing.DeepCopy()
 	incoming.ResourceVersion = ""
@@ -229,55 +242,18 @@ func TestFederationProvisioningDeprovisionsDroppedCluster(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	const serverURL = "https://unleash.example.com"
-
-	existing := &unleashv1.RemoteUnleash{
-		ObjectMeta: metav1.ObjectMeta{Name: "aura", Namespace: "tenant"},
-		Spec: unleashv1.RemoteUnleashSpec{
-			Server:      unleashv1.RemoteUnleashServer{URL: serverURL},
-			AdminSecret: unleashv1.RemoteUnleashSecret{Name: "unleasherator-aura", Key: unleashv1.UnleashSecretTokenKey},
-		},
-	}
-	secret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{Name: "unleasherator-aura", Namespace: "tenant"},
-		Data: map[string][]byte{
-			unleashv1.UnleashSecretTokenKey:     []byte("token"),
-			unleashv1.UnleashSecretServerURLKey: []byte(serverURL),
-		},
-	}
+	existing, secret := federationFixture("aura", "tenant", "https://unleash.example.com", "token")
 
 	scheme := federationTestScheme(t)
 	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existing, secret).Build()
 
-	handlerCh := make(chan federation.Handler, 1)
-	mockSubscriber := &mockfederation.MockSubscriber{}
-	mockSubscriber.On("Subscribe", mock.Anything, mock.Anything).
-		Run(func(args mock.Arguments) {
-			handlerCh <- args.Get(1).(federation.Handler)
-			<-args.Get(0).(context.Context).Done()
-		}).
-		Return(nil)
-
 	reconciler := &RemoteUnleashReconciler{
-		Client:    c,
-		APIReader: c,
-		Scheme:    scheme,
-		Federation: RemoteUnleashFederation{
-			Enabled:     true,
-			ClusterName: "cluster-a",
-			Subscriber:  mockSubscriber,
-		},
+		Client:     c,
+		APIReader:  c,
+		Scheme:     scheme,
+		Federation: RemoteUnleashFederation{Enabled: true, ClusterName: "cluster-a"},
 	}
-
-	errCh := make(chan error, 1)
-	go func() { errCh <- reconciler.FederationSubscribe(ctx) }()
-
-	var handler federation.Handler
-	select {
-	case handler = <-handlerCh:
-	case <-time.After(5 * time.Second):
-		t.Fatal("Subscribe was not called")
-	}
+	handler := startFederationHandler(ctx, t, reconciler)
 
 	incoming := existing.DeepCopy()
 	incoming.ResourceVersion = ""
@@ -297,51 +273,34 @@ func TestFederationProvisioningDeprovisionsDroppedCluster(t *testing.T) {
 
 // A message naming no clusters asserts nothing about placement. Treating it as
 // "remove everywhere" would turn one malformed publish into fleet-wide deletion.
+//
+// The fixture is deliberately realistic: with an admin secret that matches, the
+// deletion this test guards against would actually go through, so removing the
+// guard fails this assertion rather than erroring out earlier for an unrelated
+// reason.
 func TestFederationEmptyClusterListIsIgnored(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	existing := &unleashv1.RemoteUnleash{
-		ObjectMeta: metav1.ObjectMeta{Name: "aura", Namespace: "tenant"},
-		Spec:       unleashv1.RemoteUnleashSpec{Server: unleashv1.RemoteUnleashServer{URL: "https://unleash.example.com"}},
-	}
+	existing, secret := federationFixture("aura", "tenant", "https://unleash.example.com", "token")
 
 	scheme := federationTestScheme(t)
-	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existing).Build()
-
-	handlerCh := make(chan federation.Handler, 1)
-	mockSubscriber := &mockfederation.MockSubscriber{}
-	mockSubscriber.On("Subscribe", mock.Anything, mock.Anything).
-		Run(func(args mock.Arguments) {
-			handlerCh <- args.Get(1).(federation.Handler)
-			<-args.Get(0).(context.Context).Done()
-		}).
-		Return(nil)
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existing, secret).Build()
 
 	reconciler := &RemoteUnleashReconciler{
-		Client:    c,
-		APIReader: c,
-		Scheme:    scheme,
-		Federation: RemoteUnleashFederation{
-			Enabled:     true,
-			ClusterName: "cluster-a",
-			Subscriber:  mockSubscriber,
-		},
+		Client:     c,
+		APIReader:  c,
+		Scheme:     scheme,
+		Federation: RemoteUnleashFederation{Enabled: true, ClusterName: "cluster-a"},
 	}
+	handler := startFederationHandler(ctx, t, reconciler)
 
-	errCh := make(chan error, 1)
-	go func() { errCh <- reconciler.FederationSubscribe(ctx) }()
-
-	var handler federation.Handler
-	select {
-	case handler = <-handlerCh:
-	case <-time.After(5 * time.Second):
-		t.Fatal("Subscribe was not called")
-	}
+	incoming := existing.DeepCopy()
+	incoming.ResourceVersion = ""
 
 	require.NoError(t, handler(ctx,
-		[]*unleashv1.RemoteUnleash{existing.DeepCopy()},
-		[]*corev1.Secret{{ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: "tenant"}}},
+		[]*unleashv1.RemoteUnleash{incoming},
+		[]*corev1.Secret{secret.DeepCopy()},
 		nil,
 		pb.Status_Provisioned,
 	))
@@ -350,8 +309,162 @@ func TestFederationEmptyClusterListIsIgnored(t *testing.T) {
 		"an empty cluster list must not delete anything")
 }
 
-// Provisioning stays cluster-scoped for creation: a message for another cluster
-// must not create resources here.
+// A cluster list whose entries are blank, or that names this cluster with stray
+// whitespace, is a typo in a team's federation config — not a statement that the
+// instance must leave. Exact comparison reads all of these as "not this cluster"
+// and deletes.
+func TestFederationBlankAndPaddedClusterEntriesDoNotDeprovision(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		clusters []string
+	}{
+		{name: "padded name", clusters: []string{" cluster-a"}},
+		{name: "trailing whitespace", clusters: []string{"cluster-a\t"}},
+		{name: "single empty entry", clusters: []string{""}},
+		{name: "whitespace only entry", clusters: []string{"   "}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			existing, secret := federationFixture("aura", "tenant", "https://unleash.example.com", "token")
+
+			scheme := federationTestScheme(t)
+			c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existing, secret).Build()
+
+			reconciler := &RemoteUnleashReconciler{
+				Client:     c,
+				APIReader:  c,
+				Scheme:     scheme,
+				Federation: RemoteUnleashFederation{Enabled: true, ClusterName: "cluster-a"},
+			}
+			handler := startFederationHandler(ctx, t, reconciler)
+
+			incoming := existing.DeepCopy()
+			incoming.ResourceVersion = ""
+
+			require.NoError(t, handler(ctx,
+				[]*unleashv1.RemoteUnleash{incoming},
+				[]*corev1.Secret{secret.DeepCopy()},
+				tt.clusters,
+				pb.Status_Provisioned,
+			))
+
+			require.NoError(t, c.Get(ctx, client.ObjectKeyFromObject(existing), &unleashv1.RemoteUnleash{}),
+				"cluster list %q must not delete this cluster's RemoteUnleash", tt.clusters)
+		})
+	}
+}
+
+// A cluster list that matches this cluster only when case is ignored is
+// ambiguous. The comparison stays case-sensitive, so the instance is not
+// provisioned here either, but ambiguity must never resolve to deletion.
+func TestFederationCaseMismatchDoesNotDeprovision(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	existing, secret := federationFixture("aura", "tenant", "https://unleash.example.com", "token")
+
+	scheme := federationTestScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existing, secret).Build()
+
+	reconciler := &RemoteUnleashReconciler{
+		Client:     c,
+		APIReader:  c,
+		Scheme:     scheme,
+		Federation: RemoteUnleashFederation{Enabled: true, ClusterName: "cluster-a"},
+	}
+	handler := startFederationHandler(ctx, t, reconciler)
+
+	incoming := existing.DeepCopy()
+	incoming.ResourceVersion = ""
+
+	require.NoError(t, handler(ctx,
+		[]*unleashv1.RemoteUnleash{incoming},
+		[]*corev1.Secret{secret.DeepCopy()},
+		[]string{"Cluster-A"},
+		pb.Status_Provisioned,
+	))
+
+	require.NoError(t, c.Get(ctx, client.ObjectKeyFromObject(existing), &unleashv1.RemoteUnleash{}),
+		"a cluster list differing only in case must not delete this cluster's RemoteUnleash")
+}
+
+// An operator that does not know its own cluster name matches no cluster list at
+// all, so every provisioning message would read as "no longer federated here".
+// Config validation rejects this at startup; the receive path must refuse it
+// again, because one check standing between a dropped chart value and fleet-wide
+// deletion is not enough.
+func TestFederationEmptyOperatorClusterNameDoesNotDeprovision(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	existing, secret := federationFixture("aura", "tenant", "https://unleash.example.com", "token")
+
+	scheme := federationTestScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existing, secret).Build()
+
+	reconciler := &RemoteUnleashReconciler{
+		Client:     c,
+		APIReader:  c,
+		Scheme:     scheme,
+		Federation: RemoteUnleashFederation{Enabled: true, ClusterName: ""},
+	}
+	handler := startFederationHandler(ctx, t, reconciler)
+
+	incoming := existing.DeepCopy()
+	incoming.ResourceVersion = ""
+
+	require.NoError(t, handler(ctx,
+		[]*unleashv1.RemoteUnleash{incoming},
+		[]*corev1.Secret{secret.DeepCopy()},
+		[]string{"cluster-a", "cluster-b"},
+		pb.Status_Provisioned,
+	))
+
+	require.NoError(t, c.Get(ctx, client.ObjectKeyFromObject(existing), &unleashv1.RemoteUnleash{}),
+		"an operator without a cluster name must not delete anything")
+}
+
+// Status_Unknown is the proto3 zero value, so an absent status field arrives as
+// one. It is ignored on the clusters a message names; reading it as a removal on
+// the clusters it does not name would make the least understood message the most
+// destructive one.
+func TestFederationUnknownStatusIsIgnored(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	existing, secret := federationFixture("aura", "tenant", "https://unleash.example.com", "token")
+
+	scheme := federationTestScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existing, secret).Build()
+
+	reconciler := &RemoteUnleashReconciler{
+		Client:     c,
+		APIReader:  c,
+		Scheme:     scheme,
+		Federation: RemoteUnleashFederation{Enabled: true, ClusterName: "cluster-a"},
+	}
+	handler := startFederationHandler(ctx, t, reconciler)
+
+	incoming := existing.DeepCopy()
+	incoming.ResourceVersion = ""
+
+	require.NoError(t, handler(ctx,
+		[]*unleashv1.RemoteUnleash{incoming},
+		[]*corev1.Secret{secret.DeepCopy()},
+		[]string{"cluster-b"},
+		pb.Status_Unknown,
+	))
+
+	require.NoError(t, c.Get(ctx, client.ObjectKeyFromObject(existing), &unleashv1.RemoteUnleash{}),
+		"an unknown status must not be rewritten into a removal")
+}
+
+// Provisioning stays cluster-scoped for creation. Both halves matter: a message
+// for another cluster must not create resources here, and a message naming this
+// cluster must. Without the second half an implementation that creates nothing —
+// or deletes everything — passes.
 func TestFederationProvisioningStaysClusterScoped(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -359,50 +472,109 @@ func TestFederationProvisioningStaysClusterScoped(t *testing.T) {
 	scheme := federationTestScheme(t)
 	c := fake.NewClientBuilder().WithScheme(scheme).Build()
 
-	handlerCh := make(chan federation.Handler, 1)
-	mockSubscriber := &mockfederation.MockSubscriber{}
-	mockSubscriber.On("Subscribe", mock.Anything, mock.Anything).
-		Run(func(args mock.Arguments) {
-			handlerCh <- args.Get(1).(federation.Handler)
-			<-args.Get(0).(context.Context).Done()
-		}).
-		Return(nil)
-
 	reconciler := &RemoteUnleashReconciler{
-		Client:    c,
-		APIReader: c,
-		Scheme:    scheme,
-		Federation: RemoteUnleashFederation{
-			Enabled:     true,
-			ClusterName: "cluster-a",
-			Subscriber:  mockSubscriber,
-		},
+		Client:     c,
+		APIReader:  c,
+		Scheme:     scheme,
+		Federation: RemoteUnleashFederation{Enabled: true, ClusterName: "cluster-a"},
 	}
+	handler := startFederationHandler(ctx, t, reconciler)
 
-	errCh := make(chan error, 1)
-	go func() { errCh <- reconciler.FederationSubscribe(ctx) }()
-
-	var handler federation.Handler
-	select {
-	case handler = <-handlerCh:
-	case <-time.After(5 * time.Second):
-		t.Fatal("Subscribe was not called")
-	}
-
-	ru := &unleashv1.RemoteUnleash{
-		ObjectMeta: metav1.ObjectMeta{Name: "other", Namespace: "tenant"},
-		Spec:       unleashv1.RemoteUnleashSpec{Server: unleashv1.RemoteUnleashServer{URL: "https://other.example.com"}},
-	}
-	secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: "nais-system"}}
-
+	elsewhere, elsewhereSecret := federationFixture("other", "tenant", "https://other.example.com", "token")
 	require.NoError(t, handler(ctx,
-		[]*unleashv1.RemoteUnleash{ru},
-		[]*corev1.Secret{secret},
+		[]*unleashv1.RemoteUnleash{elsewhere},
+		[]*corev1.Secret{elsewhereSecret},
 		[]string{"cluster-b"},
 		pb.Status_Provisioned,
 	))
 
-	err := c.Get(ctx, client.ObjectKeyFromObject(ru), &unleashv1.RemoteUnleash{})
+	err := c.Get(ctx, client.ObjectKeyFromObject(elsewhere), &unleashv1.RemoteUnleash{})
 	assert.True(t, apierrors.IsNotFound(err),
 		"a provisioning message for another cluster must not create resources here")
+
+	here, hereSecret := federationFixture("aura", "tenant", "https://unleash.example.com", "token")
+	require.NoError(t, handler(ctx,
+		[]*unleashv1.RemoteUnleash{here},
+		[]*corev1.Secret{hereSecret},
+		[]string{"cluster-a"},
+		pb.Status_Provisioned,
+	))
+
+	require.NoError(t, c.Get(ctx, client.ObjectKeyFromObject(here), &unleashv1.RemoteUnleash{}),
+		"a provisioning message naming this cluster must create the RemoteUnleash")
+	require.NoError(t, c.Get(ctx, client.ObjectKeyFromObject(hereSecret), &corev1.Secret{}),
+		"a provisioning message naming this cluster must create the admin secret")
+}
+
+// The anti-hijack checks must hold on the deprovision path too. It reaches every
+// cluster, so a message that disagrees with what is stored locally is exactly
+// where an attacker would aim: rotating the token is enough to delete a resource
+// they cannot otherwise touch.
+func TestFederationDeprovisionRefusesTokenRotation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	existing, secret := federationFixture("aura", "tenant", "https://unleash.example.com", "token")
+
+	scheme := federationTestScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existing, secret).Build()
+
+	reconciler := &RemoteUnleashReconciler{
+		Client:     c,
+		APIReader:  c,
+		Scheme:     scheme,
+		Federation: RemoteUnleashFederation{Enabled: true, ClusterName: "cluster-a"},
+	}
+	handler := startFederationHandler(ctx, t, reconciler)
+
+	incoming := existing.DeepCopy()
+	incoming.ResourceVersion = ""
+	rotatedSecret := secret.DeepCopy()
+	rotatedSecret.ResourceVersion = ""
+	rotatedSecret.Data[unleashv1.UnleashSecretTokenKey] = []byte("rotated")
+
+	require.NoError(t, handler(ctx,
+		[]*unleashv1.RemoteUnleash{incoming},
+		[]*corev1.Secret{rotatedSecret},
+		[]string{"cluster-b"},
+		pb.Status_Provisioned,
+	))
+
+	require.NoError(t, c.Get(ctx, client.ObjectKeyFromObject(existing), &unleashv1.RemoteUnleash{}),
+		"a deprovision carrying a token that does not match the stored one must be refused")
+}
+
+// The same for the URL: a message claiming a different server than the one the
+// local resource points at is not talking about this resource, whether it asks
+// for a removal or arrives as a provisioning message that drops this cluster.
+func TestFederationDeprovisionRefusesURLMismatch(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	existing, secret := federationFixture("aura", "tenant", "https://unleash.example.com", "token")
+
+	scheme := federationTestScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existing, secret).Build()
+
+	reconciler := &RemoteUnleashReconciler{
+		Client:     c,
+		APIReader:  c,
+		Scheme:     scheme,
+		Federation: RemoteUnleashFederation{Enabled: true, ClusterName: "cluster-a"},
+	}
+	handler := startFederationHandler(ctx, t, reconciler)
+
+	incoming := existing.DeepCopy()
+	incoming.ResourceVersion = ""
+	incoming.Spec.Server.URL = "https://attacker.example.com"
+
+	require.NoError(t, handler(ctx,
+		[]*unleashv1.RemoteUnleash{incoming},
+		[]*corev1.Secret{secret.DeepCopy()},
+		[]string{"cluster-b"},
+		pb.Status_Provisioned,
+	))
+
+	require.NoError(t, c.Get(ctx, client.ObjectKeyFromObject(existing), &unleashv1.RemoteUnleash{}),
+		"a deprovision naming a different server must be refused")
 }

--- a/internal/controller/remoteunleash_federation_unit_test.go
+++ b/internal/controller/remoteunleash_federation_unit_test.go
@@ -706,3 +706,42 @@ func TestFederationRemovalWithoutRecordedPublishTime(t *testing.T) {
 	assert.True(t, apierrors.IsNotFound(err),
 		"a resource with no recorded publish time must still be removable")
 }
+
+// A RemoteUnleash whose admin secret is gone cannot have a removal authenticated
+// against it. Erroring out nacks the message forever — the secret is not coming
+// back — and blocks every later message sharing the ordering key, which since
+// removals reach every cluster means the whole fleet rather than the clusters the
+// message names. Skip the resource instead, and leave it standing: deleting what
+// cannot be verified is the hijack the credential check exists to stop.
+func TestFederationRemovalWithMissingAdminSecretIsSkipped(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	existing, secret := federationFixture("aura", "tenant", "https://unleash.example.com", "token")
+
+	scheme := federationTestScheme(t)
+	// The RemoteUnleash exists; the admin secret it references does not.
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existing).Build()
+
+	reconciler := &RemoteUnleashReconciler{
+		Client:     c,
+		APIReader:  c,
+		Scheme:     scheme,
+		Federation: RemoteUnleashFederation{Enabled: true, ClusterName: "cluster-a"},
+	}
+	handler := startFederationHandler(ctx, t, reconciler)
+
+	incoming := existing.DeepCopy()
+	incoming.ResourceVersion = ""
+
+	require.NoError(t, handler(ctx,
+		[]*unleashv1.RemoteUnleash{incoming},
+		[]*corev1.Secret{secret.DeepCopy()},
+		[]string{"cluster-b"},
+		pb.Status_Removed,
+		time.Now(),
+	), "a missing admin secret must not nack the message forever")
+
+	require.NoError(t, c.Get(ctx, client.ObjectKeyFromObject(existing), &unleashv1.RemoteUnleash{}),
+		"a RemoteUnleash whose token could not be verified must not be deleted")
+}

--- a/internal/controller/remoteunleash_federation_unit_test.go
+++ b/internal/controller/remoteunleash_federation_unit_test.go
@@ -222,8 +222,136 @@ func TestFederationRemovalReachesClustersNotOnTheMessage(t *testing.T) {
 		"a removal must delete the RemoteUnleash even when this cluster is not on the message")
 }
 
-// Provisioning stays cluster-scoped: a message for another cluster must not
-// create resources here.
+// Taking a cluster out of a team's federation config must remove the resource
+// there. Ignoring the message because this cluster is no longer named is what
+// leaves a RemoteUnleash behind pointing at a server it may not reach.
+func TestFederationProvisioningDeprovisionsDroppedCluster(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	const serverURL = "https://unleash.example.com"
+
+	existing := &unleashv1.RemoteUnleash{
+		ObjectMeta: metav1.ObjectMeta{Name: "aura", Namespace: "tenant"},
+		Spec: unleashv1.RemoteUnleashSpec{
+			Server:      unleashv1.RemoteUnleashServer{URL: serverURL},
+			AdminSecret: unleashv1.RemoteUnleashSecret{Name: "unleasherator-aura", Key: unleashv1.UnleashSecretTokenKey},
+		},
+	}
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "unleasherator-aura", Namespace: "tenant"},
+		Data: map[string][]byte{
+			unleashv1.UnleashSecretTokenKey:     []byte("token"),
+			unleashv1.UnleashSecretServerURLKey: []byte(serverURL),
+		},
+	}
+
+	scheme := federationTestScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existing, secret).Build()
+
+	handlerCh := make(chan federation.Handler, 1)
+	mockSubscriber := &mockfederation.MockSubscriber{}
+	mockSubscriber.On("Subscribe", mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			handlerCh <- args.Get(1).(federation.Handler)
+			<-args.Get(0).(context.Context).Done()
+		}).
+		Return(nil)
+
+	reconciler := &RemoteUnleashReconciler{
+		Client:    c,
+		APIReader: c,
+		Scheme:    scheme,
+		Federation: RemoteUnleashFederation{
+			Enabled:     true,
+			ClusterName: "cluster-a",
+			Subscriber:  mockSubscriber,
+		},
+	}
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- reconciler.FederationSubscribe(ctx) }()
+
+	var handler federation.Handler
+	select {
+	case handler = <-handlerCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Subscribe was not called")
+	}
+
+	incoming := existing.DeepCopy()
+	incoming.ResourceVersion = ""
+
+	// Still provisioned, but cluster-a has been taken off the list.
+	require.NoError(t, handler(ctx,
+		[]*unleashv1.RemoteUnleash{incoming},
+		[]*corev1.Secret{secret.DeepCopy()},
+		[]string{"cluster-b"},
+		pb.Status_Provisioned,
+	))
+
+	err := c.Get(ctx, client.ObjectKeyFromObject(existing), &unleashv1.RemoteUnleash{})
+	assert.True(t, apierrors.IsNotFound(err),
+		"a cluster dropped from the federation list must remove its RemoteUnleash")
+}
+
+// A message naming no clusters asserts nothing about placement. Treating it as
+// "remove everywhere" would turn one malformed publish into fleet-wide deletion.
+func TestFederationEmptyClusterListIsIgnored(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	existing := &unleashv1.RemoteUnleash{
+		ObjectMeta: metav1.ObjectMeta{Name: "aura", Namespace: "tenant"},
+		Spec:       unleashv1.RemoteUnleashSpec{Server: unleashv1.RemoteUnleashServer{URL: "https://unleash.example.com"}},
+	}
+
+	scheme := federationTestScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existing).Build()
+
+	handlerCh := make(chan federation.Handler, 1)
+	mockSubscriber := &mockfederation.MockSubscriber{}
+	mockSubscriber.On("Subscribe", mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			handlerCh <- args.Get(1).(federation.Handler)
+			<-args.Get(0).(context.Context).Done()
+		}).
+		Return(nil)
+
+	reconciler := &RemoteUnleashReconciler{
+		Client:    c,
+		APIReader: c,
+		Scheme:    scheme,
+		Federation: RemoteUnleashFederation{
+			Enabled:     true,
+			ClusterName: "cluster-a",
+			Subscriber:  mockSubscriber,
+		},
+	}
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- reconciler.FederationSubscribe(ctx) }()
+
+	var handler federation.Handler
+	select {
+	case handler = <-handlerCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Subscribe was not called")
+	}
+
+	require.NoError(t, handler(ctx,
+		[]*unleashv1.RemoteUnleash{existing.DeepCopy()},
+		[]*corev1.Secret{{ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: "tenant"}}},
+		nil,
+		pb.Status_Provisioned,
+	))
+
+	require.NoError(t, c.Get(ctx, client.ObjectKeyFromObject(existing), &unleashv1.RemoteUnleash{}),
+		"an empty cluster list must not delete anything")
+}
+
+// Provisioning stays cluster-scoped for creation: a message for another cluster
+// must not create resources here.
 func TestFederationProvisioningStaysClusterScoped(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/internal/controller/remoteunleash_federation_unit_test.go
+++ b/internal/controller/remoteunleash_federation_unit_test.go
@@ -174,7 +174,7 @@ func TestFederationSubscribeReturnsPermanentHandlerError(t *testing.T) {
 	errs := make(chan error, 4)
 	for range 4 {
 		go func() {
-			errs <- handler(ctx, []*unleashv1.RemoteUnleash{remoteUnleash}, []*corev1.Secret{secret}, []string{"test"}, pb.Status_Removed)
+			errs <- handler(ctx, []*unleashv1.RemoteUnleash{remoteUnleash}, []*corev1.Secret{secret}, []string{"test"}, pb.Status_Removed, time.Now())
 		}()
 	}
 	for range 4 {
@@ -228,6 +228,7 @@ func TestFederationRemovalReachesClustersNotOnTheMessage(t *testing.T) {
 		[]*corev1.Secret{secret.DeepCopy()},
 		[]string{"cluster-b"},
 		pb.Status_Removed,
+		time.Now(),
 	))
 
 	err := c.Get(ctx, client.ObjectKeyFromObject(existing), &unleashv1.RemoteUnleash{})
@@ -264,6 +265,7 @@ func TestFederationProvisioningDeprovisionsDroppedCluster(t *testing.T) {
 		[]*corev1.Secret{secret.DeepCopy()},
 		[]string{"cluster-b"},
 		pb.Status_Provisioned,
+		time.Now(),
 	))
 
 	err := c.Get(ctx, client.ObjectKeyFromObject(existing), &unleashv1.RemoteUnleash{})
@@ -303,6 +305,7 @@ func TestFederationEmptyClusterListIsIgnored(t *testing.T) {
 		[]*corev1.Secret{secret.DeepCopy()},
 		nil,
 		pb.Status_Provisioned,
+		time.Now(),
 	))
 
 	require.NoError(t, c.Get(ctx, client.ObjectKeyFromObject(existing), &unleashv1.RemoteUnleash{}),
@@ -348,6 +351,7 @@ func TestFederationBlankAndPaddedClusterEntriesDoNotDeprovision(t *testing.T) {
 				[]*corev1.Secret{secret.DeepCopy()},
 				tt.clusters,
 				pb.Status_Provisioned,
+				time.Now(),
 			))
 
 			require.NoError(t, c.Get(ctx, client.ObjectKeyFromObject(existing), &unleashv1.RemoteUnleash{}),
@@ -384,6 +388,7 @@ func TestFederationCaseMismatchDoesNotDeprovision(t *testing.T) {
 		[]*corev1.Secret{secret.DeepCopy()},
 		[]string{"Cluster-A"},
 		pb.Status_Provisioned,
+		time.Now(),
 	))
 
 	require.NoError(t, c.Get(ctx, client.ObjectKeyFromObject(existing), &unleashv1.RemoteUnleash{}),
@@ -420,6 +425,7 @@ func TestFederationEmptyOperatorClusterNameDoesNotDeprovision(t *testing.T) {
 		[]*corev1.Secret{secret.DeepCopy()},
 		[]string{"cluster-a", "cluster-b"},
 		pb.Status_Provisioned,
+		time.Now(),
 	))
 
 	require.NoError(t, c.Get(ctx, client.ObjectKeyFromObject(existing), &unleashv1.RemoteUnleash{}),
@@ -455,6 +461,7 @@ func TestFederationUnknownStatusIsIgnored(t *testing.T) {
 		[]*corev1.Secret{secret.DeepCopy()},
 		[]string{"cluster-b"},
 		pb.Status_Unknown,
+		time.Now(),
 	))
 
 	require.NoError(t, c.Get(ctx, client.ObjectKeyFromObject(existing), &unleashv1.RemoteUnleash{}),
@@ -486,6 +493,7 @@ func TestFederationProvisioningStaysClusterScoped(t *testing.T) {
 		[]*corev1.Secret{elsewhereSecret},
 		[]string{"cluster-b"},
 		pb.Status_Provisioned,
+		time.Now(),
 	))
 
 	err := c.Get(ctx, client.ObjectKeyFromObject(elsewhere), &unleashv1.RemoteUnleash{})
@@ -498,6 +506,7 @@ func TestFederationProvisioningStaysClusterScoped(t *testing.T) {
 		[]*corev1.Secret{hereSecret},
 		[]string{"cluster-a"},
 		pb.Status_Provisioned,
+		time.Now(),
 	))
 
 	require.NoError(t, c.Get(ctx, client.ObjectKeyFromObject(here), &unleashv1.RemoteUnleash{}),
@@ -538,6 +547,7 @@ func TestFederationDeprovisionRefusesTokenRotation(t *testing.T) {
 		[]*corev1.Secret{rotatedSecret},
 		[]string{"cluster-b"},
 		pb.Status_Provisioned,
+		time.Now(),
 	))
 
 	require.NoError(t, c.Get(ctx, client.ObjectKeyFromObject(existing), &unleashv1.RemoteUnleash{}),
@@ -573,8 +583,126 @@ func TestFederationDeprovisionRefusesURLMismatch(t *testing.T) {
 		[]*corev1.Secret{secret.DeepCopy()},
 		[]string{"cluster-b"},
 		pb.Status_Provisioned,
+		time.Now(),
 	))
 
 	require.NoError(t, c.Get(ctx, client.ObjectKeyFromObject(existing), &unleashv1.RemoteUnleash{}),
 		"a deprovision naming a different server must be refused")
+}
+
+// Pub/Sub redelivers, and an ordering key only orders what it hands over in one
+// go: a delayed copy of an older provisioning message can arrive after a newer
+// one was applied, carrying the cluster list as it stood back then. Acting on it
+// deletes a RemoteUnleash the newer message legitimately created, and nothing
+// brings it back — the publisher skips republishing while its instance hash is
+// unchanged, and there is no periodic federation resync.
+func TestFederationStaleMessageDoesNotDeprovision(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	older := time.Now().Add(-time.Hour)
+	newer := time.Now()
+
+	scheme := federationTestScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	reconciler := &RemoteUnleashReconciler{
+		Client:     c,
+		APIReader:  c,
+		Scheme:     scheme,
+		Federation: RemoteUnleashFederation{Enabled: true, ClusterName: "cluster-a"},
+	}
+	handler := startFederationHandler(ctx, t, reconciler)
+
+	remoteUnleash, secret := federationFixture("aura", "tenant", "https://unleash.example.com", "token")
+
+	// The current state of the world: federated here, published just now.
+	require.NoError(t, handler(ctx,
+		[]*unleashv1.RemoteUnleash{remoteUnleash.DeepCopy()},
+		[]*corev1.Secret{secret.DeepCopy()},
+		[]string{"cluster-a"},
+		pb.Status_Provisioned,
+		newer,
+	))
+	require.NoError(t, c.Get(ctx, client.ObjectKeyFromObject(remoteUnleash), &unleashv1.RemoteUnleash{}))
+
+	// A redelivered copy of the message from before this cluster was added.
+	require.NoError(t, handler(ctx,
+		[]*unleashv1.RemoteUnleash{remoteUnleash.DeepCopy()},
+		[]*corev1.Secret{secret.DeepCopy()},
+		[]string{"cluster-b"},
+		pb.Status_Provisioned,
+		older,
+	))
+	require.NoError(t, c.Get(ctx, client.ObjectKeyFromObject(remoteUnleash), &unleashv1.RemoteUnleash{}),
+		"a message older than the one already applied must not delete the RemoteUnleash")
+
+	// Replaying the older provisioning message must not roll the recorded time
+	// back either, or the window it closes simply reopens.
+	require.NoError(t, handler(ctx,
+		[]*unleashv1.RemoteUnleash{remoteUnleash.DeepCopy()},
+		[]*corev1.Secret{secret.DeepCopy()},
+		[]string{"cluster-a"},
+		pb.Status_Provisioned,
+		older,
+	))
+	require.NoError(t, handler(ctx,
+		[]*unleashv1.RemoteUnleash{remoteUnleash.DeepCopy()},
+		[]*corev1.Secret{secret.DeepCopy()},
+		[]string{"cluster-b"},
+		pb.Status_Provisioned,
+		newer.Add(-time.Minute),
+	))
+	require.NoError(t, c.Get(ctx, client.ObjectKeyFromObject(remoteUnleash), &unleashv1.RemoteUnleash{}),
+		"a replayed provisioning message must not roll back the last applied publish time")
+
+	// The guard is about ordering, not about refusing deletions: a genuinely
+	// newer message still takes the cluster out.
+	require.NoError(t, handler(ctx,
+		[]*unleashv1.RemoteUnleash{remoteUnleash.DeepCopy()},
+		[]*corev1.Secret{secret.DeepCopy()},
+		[]string{"cluster-b"},
+		pb.Status_Provisioned,
+		newer.Add(time.Minute),
+	))
+	err := c.Get(ctx, client.ObjectKeyFromObject(remoteUnleash), &unleashv1.RemoteUnleash{})
+	assert.True(t, apierrors.IsNotFound(err),
+		"a message newer than the one already applied must still deprovision")
+}
+
+// A resource that has never had a federation message applied to it carries no
+// recorded publish time. That is unknown, not "newer than everything": refusing
+// removals for it would make every resource predating the annotation
+// undeletable by federation, which is the orphan bug this path exists to fix.
+func TestFederationRemovalWithoutRecordedPublishTime(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	existing, secret := federationFixture("aura", "tenant", "https://unleash.example.com", "token")
+
+	scheme := federationTestScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existing, secret).Build()
+
+	reconciler := &RemoteUnleashReconciler{
+		Client:     c,
+		APIReader:  c,
+		Scheme:     scheme,
+		Federation: RemoteUnleashFederation{Enabled: true, ClusterName: "cluster-a"},
+	}
+	handler := startFederationHandler(ctx, t, reconciler)
+
+	incoming := existing.DeepCopy()
+	incoming.ResourceVersion = ""
+
+	require.NoError(t, handler(ctx,
+		[]*unleashv1.RemoteUnleash{incoming},
+		[]*corev1.Secret{secret.DeepCopy()},
+		[]string{"cluster-b"},
+		pb.Status_Removed,
+		time.Now(),
+	))
+
+	err := c.Get(ctx, client.ObjectKeyFromObject(existing), &unleashv1.RemoteUnleash{})
+	assert.True(t, apierrors.IsNotFound(err),
+		"a resource with no recorded publish time must still be removable")
 }

--- a/internal/controller/unleash_controller.go
+++ b/internal/controller/unleash_controller.go
@@ -443,7 +443,18 @@ func (r *UnleashReconciler) publish(ctx context.Context, unleash *unleashv1.Unle
 
 // finalizeUnleash will perform the required operations before delete the CR.
 func (r *UnleashReconciler) doFinalizerOperationsForUnleash(cr *unleashv1.Unleash, ctx context.Context, log logr.Logger) error {
-	// Publish removal message to federated clusters
+	// Publish removal message to federated clusters.
+	//
+	// Skipping is recorded rather than silent: an instance deleted while
+	// federation was off leaves whatever RemoteUnleash resources earlier
+	// publications created, and without a counter the only evidence is a
+	// connection alert in another cluster weeks later.
+	if !r.Federation.Enabled || !cr.Spec.Federation.Enabled {
+		unleashPublished.WithLabelValues("removed", "skipped").Inc()
+		log.Info("Federation disabled; not publishing removal",
+			"operatorFederation", r.Federation.Enabled,
+			"instanceFederation", cr.Spec.Federation.Enabled)
+	}
 	if r.Federation.Enabled && cr.Spec.Federation.Enabled {
 		log.Info("Publishing removal message to federation")
 		unleashPublished.WithLabelValues("removed", unleashPublishMetricStatusSending).Inc()

--- a/internal/controller/unleash_controller.go
+++ b/internal/controller/unleash_controller.go
@@ -450,12 +450,11 @@ func (r *UnleashReconciler) doFinalizerOperationsForUnleash(cr *unleashv1.Unleas
 	// publications created, and without a counter the only evidence is a
 	// connection alert in another cluster weeks later.
 	if !r.Federation.Enabled || !cr.Spec.Federation.Enabled {
-		unleashPublished.WithLabelValues("removed", "skipped").Inc()
+		unleashPublished.WithLabelValues("removed", unleashPublishMetricStatusSkipped).Inc()
 		log.Info("Federation disabled; not publishing removal",
 			"operatorFederation", r.Federation.Enabled,
 			"instanceFederation", cr.Spec.Federation.Enabled)
-	}
-	if r.Federation.Enabled && cr.Spec.Federation.Enabled {
+	} else {
 		log.Info("Publishing removal message to federation")
 		unleashPublished.WithLabelValues("removed", unleashPublishMetricStatusSending).Inc()
 

--- a/internal/federation/subscriber.go
+++ b/internal/federation/subscriber.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"time"
 
 	"cloud.google.com/go/pubsub"
 	"github.com/nais/unleasherator/internal/pb"
@@ -61,7 +62,10 @@ type Subscriber interface {
 	Close() error
 }
 
-type Handler func(ctx context.Context, remoteUnleashes []*unleashv1.RemoteUnleash, adminSecrets []*corev1.Secret, clusters []string, status pb.Status) error
+// Handler receives one decoded federation message. publishTime is the Pub/Sub
+// publish time of that message, carried through so the controller can tell a
+// redelivered older message from a newer one before acting destructively on it.
+type Handler func(ctx context.Context, remoteUnleashes []*unleashv1.RemoteUnleash, adminSecrets []*corev1.Secret, clusters []string, status pb.Status, publishTime time.Time) error
 
 type subscriber struct {
 	client                *pubsub.Client
@@ -219,7 +223,7 @@ func (s *subscriber) handleMessage(ctx context.Context, msg *pubsub.Message, han
 
 	ctx, subspan := otel.Tracer("subscribe").Start(ctx, "Process PubSub", spanOps...)
 	defer subspan.End()
-	return handler(ctx, remoteUnleashes, adminSecrets, instance.Clusters, instance.Status)
+	return handler(ctx, remoteUnleashes, adminSecrets, instance.Clusters, instance.Status, msg.PublishTime)
 }
 
 func stableNonce(instance *pb.Instance) (string, error) {

--- a/internal/federation/subscriber_test.go
+++ b/internal/federation/subscriber_test.go
@@ -71,7 +71,7 @@ func TestSubscriber_Subscribe(t *testing.T) {
 
 	// Start a goroutine to consume messages from the subscription.
 	go func() {
-		err = subscriber.Subscribe(ctx, func(ctx context.Context, remoteUnleashes []*unleashv1.RemoteUnleash, adminSecrets []*corev1.Secret, clusters []string, status pb.Status) error {
+		err = subscriber.Subscribe(ctx, func(ctx context.Context, remoteUnleashes []*unleashv1.RemoteUnleash, adminSecrets []*corev1.Secret, clusters []string, status pb.Status, publishTime time.Time) error {
 			assert.Equal(t, 2, len(adminSecrets))
 			assert.Equal(t, namespace, adminSecrets[0].GetNamespace())
 			assert.Equal(t, namespace, adminSecrets[1].GetNamespace())
@@ -128,7 +128,7 @@ func TestSubscriber_handleMessage(t *testing.T) {
 	var capturedClusters []string
 	var capturedStatus pb.Status
 
-	mockHandler := func(ctx context.Context, remoteUnleashes []*unleashv1.RemoteUnleash, adminSecrets []*corev1.Secret, clusters []string, status pb.Status) error {
+	mockHandler := func(ctx context.Context, remoteUnleashes []*unleashv1.RemoteUnleash, adminSecrets []*corev1.Secret, clusters []string, status pb.Status, publishTime time.Time) error {
 		capturedRemoteUnleashes = remoteUnleashes
 		capturedAdminSecrets = adminSecrets
 		capturedClusters = clusters
@@ -190,7 +190,7 @@ func TestSubscriber_handleMessage_Legacy(t *testing.T) {
 	var capturedRemoteUnleashes []*unleashv1.RemoteUnleash
 	var capturedAdminSecrets []*corev1.Secret
 
-	mockHandler := func(ctx context.Context, remoteUnleashes []*unleashv1.RemoteUnleash, adminSecrets []*corev1.Secret, clusters []string, status pb.Status) error {
+	mockHandler := func(ctx context.Context, remoteUnleashes []*unleashv1.RemoteUnleash, adminSecrets []*corev1.Secret, clusters []string, status pb.Status, publishTime time.Time) error {
 		capturedRemoteUnleashes = remoteUnleashes
 		capturedAdminSecrets = adminSecrets
 		return nil
@@ -255,6 +255,7 @@ func TestSubscriberIgnoresUnauthenticatedLegacyRemoval(t *testing.T) {
 		[]*corev1.Secret,
 		[]string,
 		pb.Status,
+		time.Time,
 	) error {
 		handlerCalled = true
 		return nil
@@ -281,7 +282,7 @@ func TestSubscriberDropsPoisonMessage(t *testing.T) {
 
 	handlerCalls := make(chan struct{}, 10)
 	go func() {
-		_ = subscriber.Subscribe(ctx, func(context.Context, []*unleashv1.RemoteUnleash, []*corev1.Secret, []string, pb.Status) error {
+		_ = subscriber.Subscribe(ctx, func(context.Context, []*unleashv1.RemoteUnleash, []*corev1.Secret, []string, pb.Status, time.Time) error {
 			handlerCalls <- struct{}{}
 			return nil
 		})
@@ -346,7 +347,7 @@ func TestSubscriberAcksPermanentHandlerError(t *testing.T) {
 
 	var calls atomic.Int32
 	go func() {
-		_ = subscriber.Subscribe(ctx, func(context.Context, []*unleashv1.RemoteUnleash, []*corev1.Secret, []string, pb.Status) error {
+		_ = subscriber.Subscribe(ctx, func(context.Context, []*unleashv1.RemoteUnleash, []*corev1.Secret, []string, pb.Status, time.Time) error {
 			calls.Add(1)
 			return Permanent(errors.New("authorization denied"))
 		})
@@ -404,7 +405,7 @@ func TestSubscriberRedeliversTransientHandlerError(t *testing.T) {
 
 	var calls atomic.Int32
 	go func() {
-		_ = subscriber.Subscribe(ctx, func(context.Context, []*unleashv1.RemoteUnleash, []*corev1.Secret, []string, pb.Status) error {
+		_ = subscriber.Subscribe(ctx, func(context.Context, []*unleashv1.RemoteUnleash, []*corev1.Secret, []string, pb.Status, time.Time) error {
 			calls.Add(1)
 			return errors.New("temporary API server failure")
 		})


### PR DESCRIPTION
Fixes the orphaned federated `RemoteUnleash` instances behind the firing `RemoteUnleashConnectionProblem` alerts (e.g. `nais/aura`).

Refs #800

## The bug

A federation message was being treated as an *instruction to the clusters it names*: a subscriber ignored any message whose cluster list did not include it. That is wrong for two cases, and both leave a `RemoteUnleash` pointing at a server that no longer exists — alerting forever, with nothing in the logs to explain why.

1. **Deletion.** The cluster list on a removal is the instance federation config *at the moment it was deleted*. A cluster dropped from that list earlier is therefore never told the instance is gone.
2. **Deprovisioning.** A cluster taken out of a team federation config simply stops being named. It never receives another message about the instance at all, so it keeps its copy indefinitely.

Case 2 is the more common one — it needs no deletion to happen, just an edit.

## The fix

Treat the message as a complete statement of where the instance should exist:

- Removals apply everywhere, not only to the listed clusters.
- A provisioning message that no longer names this cluster is treated as a removal *here*.

Both paths reuse the existing anti-hijack guards unchanged: the recorded server URL must match, and the stored credential must match, or nothing is deleted. A cluster holding no matching resource does nothing either way.

**A message naming no clusters asserts nothing about placement and is ignored**, rather than treated as "remove everywhere" — otherwise one malformed publish becomes fleet-wide deletion.

Also adds metrics to two previously silent paths (federation disabled, and message not for this cluster), which is what made this hard to see from the outside.

## Verification

`TestFederationRemovalReachesClustersNotOnTheMessage` and `TestFederationProvisioningDeprovisionsDroppedCluster` were both confirmed to **fail against the previous behaviour** before the fix was applied.

`TestFederationEmptyClusterListIsIgnored` passes both before and after — it proves no bug, it guards the new deletion path against becoming fleet-wide. Noting that explicitly so it is not mistaken for evidence.

`TestFederationProvisioningStaysClusterScoped` still passes: a provisioning message for another cluster must not *create* resources here. Only deletion became global.

Full `make test` green; `go vet -tags integration_test ./...` clean.

## Known limitation

Deprovisioning goes through the same credential check as any removal. If the admin token was rotated after this cluster was dropped from the list, the stored secret no longer matches and the removal is refused — the orphan survives. Weakening that check would open a hijack vector, so it is left in place; those cases need the republication path in #797.