### PR TITLE
fix(unleashclient): keep token secrets out of traces and bound HTTP requests

### DIFF
--- a/internal/unleashclient/client.go
+++ b/internal/unleashclient/client.go
@@ -12,9 +12,22 @@ import (
 	"os"
 	"path"
 	"strings"
+	"time"
 
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 )
+
+// DefaultTimeout bounds a single Unleash API call. Reconcilers hand the client
+// a context without a deadline, so without it a server that accepts the
+// connection but never answers pins a reconcile worker forever. It is a var so
+// tests can shorten it.
+var DefaultTimeout = 30 * time.Second
+
+// maxResponseBytes caps how much of a response body is buffered. The instance
+// URL is user controlled through RemoteUnleash, so an unbounded read lets a
+// hostile or broken server OOM the operator. The largest response we expect is
+// a full token list, which is orders of magnitude smaller than this.
+const maxResponseBytes = 10 << 20 // 10 MiB
 
 type Client struct {
 	URL        url.URL
@@ -29,9 +42,9 @@ func NewClient(instanceUrl string, apiToken string) (*Client, error) {
 	if os.Getenv("UNLEASH_TEST_MODE") == "true" {
 		// Create a new client that uses whatever http.DefaultTransport currently is
 		// If httpmock has been activated, this will be the mock transport
-		httpClient = &http.Client{Transport: http.DefaultTransport}
+		httpClient = &http.Client{Transport: http.DefaultTransport, Timeout: DefaultTimeout}
 	} else {
-		httpClient = &http.Client{Transport: newTransport(http.DefaultTransport)}
+		httpClient = &http.Client{Transport: newTransport(http.DefaultTransport), Timeout: DefaultTimeout}
 	}
 
 	return NewClientWithHttpClient(instanceUrl, apiToken, httpClient)
@@ -165,6 +178,22 @@ func parseAPIError(statusCode int, body []byte) *UnleashAPIError {
 	// Return with just raw body if parsing fails
 	return apiErr
 }
+
+// readResponseBody buffers the response up to maxResponseBytes and fails rather
+// than growing without bound when the server sends more.
+func readResponseBody(res *http.Response) ([]byte, error) {
+	body, err := io.ReadAll(io.LimitReader(res.Body, maxResponseBytes+1))
+	if err != nil {
+		return nil, err
+	}
+
+	if len(body) > maxResponseBytes {
+		return nil, fmt.Errorf("response body exceeds %d bytes", maxResponseBytes)
+	}
+
+	return body, nil
+}
+
 func (c *Client) requestURL(requestPath string) *url.URL {
 	req := new(url.URL)
 	*req = c.URL
@@ -190,8 +219,9 @@ func (c *Client) HTTPGet(ctx context.Context, requestPath string, v any) (*http.
 	if err != nil {
 		return res, err
 	}
+	defer res.Body.Close()
 
-	body, err := io.ReadAll(res.Body)
+	body, err := readResponseBody(res)
 	if err != nil {
 		return res, err
 	}
@@ -275,7 +305,7 @@ func (c *Client) HTTPPost(ctx context.Context, requestPath string, p, v any) (*h
 	}
 	defer res.Body.Close()
 
-	body, err := io.ReadAll(res.Body)
+	body, err := readResponseBody(res)
 	if err != nil {
 		return res, err
 	}

--- a/internal/unleashclient/client.go
+++ b/internal/unleashclient/client.go
@@ -31,10 +31,77 @@ func NewClient(instanceUrl string, apiToken string) (*Client, error) {
 		// If httpmock has been activated, this will be the mock transport
 		httpClient = &http.Client{Transport: http.DefaultTransport}
 	} else {
-		httpClient = &http.Client{Transport: otelhttp.NewTransport(http.DefaultTransport)}
+		httpClient = &http.Client{Transport: newTransport(http.DefaultTransport)}
 	}
 
 	return NewClientWithHttpClient(instanceUrl, apiToken, httpClient)
+}
+
+// redactedPathSegment stands in for a secret that the Unleash admin API insists
+// on receiving as a path segment.
+const redactedPathSegment = "REDACTED"
+
+type contextKey int
+
+const (
+	// redactedURLContextKey carries the URL that instrumentation is allowed to
+	// see, set by the request builder that knows which part is secret.
+	redactedURLContextKey contextKey = iota
+
+	// unredactedURLContextKey carries the real URL past instrumentation so the
+	// layer closest to the network can put it back.
+	unredactedURLContextKey
+)
+
+// withRedactedURL marks a request whose URL embeds a secret.
+func withRedactedURL(ctx context.Context, redacted string) context.Context {
+	return context.WithValue(ctx, redactedURLContextKey, redacted)
+}
+
+// newTransport builds the transport chain used against real Unleash instances.
+// otelhttp records the full request URL as a span attribute, which would ship
+// deleted token secrets to the trace backend, so redaction has to happen above
+// otelhttp and restoration below it: the span sees a placeholder while only the
+// wire sees the secret.
+func newTransport(base http.RoundTripper, opts ...otelhttp.Option) http.RoundTripper {
+	return &redactingTransport{next: otelhttp.NewTransport(&restoringTransport{next: base}, opts...)}
+}
+
+type redactingTransport struct {
+	next http.RoundTripper
+}
+
+func (t *redactingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	redacted, ok := req.Context().Value(redactedURLContextKey).(string)
+	if !ok {
+		return t.next.RoundTrip(req)
+	}
+
+	redactedURL, err := url.Parse(redacted)
+	if err != nil {
+		return nil, err
+	}
+
+	req = req.Clone(context.WithValue(req.Context(), unredactedURLContextKey, req.URL))
+	req.URL = redactedURL
+
+	return t.next.RoundTrip(req)
+}
+
+type restoringTransport struct {
+	next http.RoundTripper
+}
+
+func (t *restoringTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	unredacted, ok := req.Context().Value(unredactedURLContextKey).(*url.URL)
+	if !ok {
+		return t.next.RoundTrip(req)
+	}
+
+	req = req.Clone(req.Context())
+	req.URL = unredacted
+
+	return t.next.RoundTrip(req)
 }
 
 func NewClientWithHttpClient(instanceUrl string, apiToken string, httpClient *http.Client) (*Client, error) {
@@ -144,6 +211,12 @@ func (c *Client) HTTPGet(ctx context.Context, requestPath string, v any) (*http.
 func (c *Client) HTTPDelete(ctx context.Context, requestPath string, item string) error {
 	requestURL := c.requestURL(fmt.Sprintf("%s/%s", requestPath, item)).String()
 	requestMethod := "DELETE"
+
+	// The Unleash admin API identifies the token to delete by its secret, and
+	// only accepts it as a path segment, so it cannot move to a header the way
+	// the admin credential does. Hand the transport chain a redacted URL to
+	// hold up to instrumentation instead.
+	ctx = withRedactedURL(ctx, c.requestURL(fmt.Sprintf("%s/%s", requestPath, redactedPathSegment)).String())
 
 	req, err := http.NewRequestWithContext(ctx, requestMethod, requestURL, nil)
 

--- a/internal/unleashclient/client_test.go
+++ b/internal/unleashclient/client_test.go
@@ -4,9 +4,14 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"strings"
 	"testing"
+
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 )
 
 type roundTripperFunc func(*http.Request) (*http.Response, error)
@@ -63,5 +68,88 @@ func TestHTTPDeleteSanitizesTokenFromTransportError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "connection refused") {
 		t.Fatalf("transport error lost cause: %v", err)
+	}
+}
+
+func TestHTTPDeleteKeepsSecretOutOfSpans(t *testing.T) {
+	const (
+		tokenSecret = "project:development.5ec4e7"
+		adminToken  = "admin-token"
+	)
+
+	var (
+		requestURL   string
+		authHeader   string
+		requestCount int
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		requestURL = r.URL.String()
+		authHeader = r.Header.Get("Authorization")
+	}))
+	defer server.Close()
+
+	recorder := tracetest.NewSpanRecorder()
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+
+	client, err := NewClientWithHttpClient(server.URL, adminToken, &http.Client{
+		Transport: newTransport(http.DefaultTransport, otelhttp.WithTracerProvider(provider)),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := client.DeleteApiToken(context.Background(), tokenSecret); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// The delete has to keep working: Unleash only accepts the secret as a path
+	// segment, so redaction must not reach the wire.
+	if requestCount != 1 {
+		t.Fatalf("expected 1 request, got %d", requestCount)
+	}
+	if want := ApiTokensEndpoint + "/" + tokenSecret; requestURL != want {
+		t.Fatalf("expected request URL %q, got %q", want, requestURL)
+	}
+	if authHeader != adminToken {
+		t.Fatalf("expected admin token in Authorization header, got %q", authHeader)
+	}
+
+	spans := recorder.Ended()
+	if len(spans) == 0 {
+		t.Fatal("expected the delete to be traced")
+	}
+	for _, span := range spans {
+		if strings.Contains(span.Name(), tokenSecret) {
+			t.Errorf("span name leaked token secret: %s", span.Name())
+		}
+		for _, attr := range span.Attributes() {
+			if strings.Contains(attr.Value.Emit(), tokenSecret) {
+				t.Errorf("span attribute %s leaked token secret: %s", attr.Key, attr.Value.Emit())
+			}
+		}
+	}
+}
+
+func TestHTTPDeleteKeepsAdminTokenOutOfRequestURL(t *testing.T) {
+	const adminToken = "admin-token"
+
+	var requestURL string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestURL = r.URL.String()
+	}))
+	defer server.Close()
+
+	client, err := NewClientWithHttpClient(server.URL, adminToken, server.Client())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := client.DeleteApiToken(context.Background(), "some-token"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if strings.Contains(requestURL, adminToken) {
+		t.Fatalf("admin token leaked into request URL: %s", requestURL)
 	}
 }

--- a/internal/unleashclient/client_test.go
+++ b/internal/unleashclient/client_test.go
@@ -3,11 +3,13 @@ package unleashclient
 import (
 	"context"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"strings"
 	"testing"
+	"time"
 
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
@@ -151,5 +153,112 @@ func TestHTTPDeleteKeepsAdminTokenOutOfRequestURL(t *testing.T) {
 
 	if strings.Contains(requestURL, adminToken) {
 		t.Fatalf("admin token leaked into request URL: %s", requestURL)
+	}
+}
+
+func TestNewClientHasTimeout(t *testing.T) {
+	client, err := NewClient("http://localhost:4242", "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if client.HttpClient.Timeout == 0 {
+		t.Fatal("expected the client to bound requests with a timeout")
+	}
+	if client.HttpClient.Timeout != DefaultTimeout {
+		t.Fatalf("expected timeout %s, got %s", DefaultTimeout, client.HttpClient.Timeout)
+	}
+}
+
+func TestHTTPGetGivesUpOnHungServer(t *testing.T) {
+	released := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-released
+	}))
+	defer server.Close()
+	defer close(released)
+
+	original := DefaultTimeout
+	DefaultTimeout = 100 * time.Millisecond
+	defer func() { DefaultTimeout = original }()
+
+	client, err := NewClient(server.URL, "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := client.HTTPGet(context.Background(), HealthEndpoint, &HealthResult{})
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("expected the hung request to fail")
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("request to a hung server never returned")
+	}
+}
+
+func TestHTTPGetRejectsOversizedBody(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		chunk := make([]byte, 1<<20)
+		for written := 0; written <= maxResponseBytes; written += len(chunk) {
+			if _, err := w.Write(chunk); err != nil {
+				return
+			}
+		}
+	}))
+	defer server.Close()
+
+	client, err := NewClientWithHttpClient(server.URL, "test", server.Client())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = client.HTTPGet(context.Background(), HealthEndpoint, &HealthResult{})
+	if err == nil {
+		t.Fatal("expected an oversized response body to be rejected")
+	}
+	if !strings.Contains(err.Error(), "exceeds") {
+		t.Fatalf("expected a size limit error, got: %v", err)
+	}
+}
+
+// countingBody reports whether the response body was closed, which is what
+// returns the connection to the pool.
+type countingBody struct {
+	io.Reader
+	closed bool
+}
+
+func (b *countingBody) Close() error {
+	b.closed = true
+	return nil
+}
+
+func TestHTTPGetClosesResponseBody(t *testing.T) {
+	for name, status := range map[string]int{"ok": http.StatusOK, "error": http.StatusInternalServerError} {
+		t.Run(name, func(t *testing.T) {
+			body := &countingBody{Reader: strings.NewReader(`{"health":"GOOD"}`)}
+			client, err := NewClientWithHttpClient("http://unleash.example.com", "test", &http.Client{
+				Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+					return &http.Response{StatusCode: status, Body: body, Header: http.Header{}}, nil
+				}),
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			//nolint:errcheck // the error is irrelevant, the body must be closed either way
+			client.HTTPGet(context.Background(), HealthEndpoint, &HealthResult{})
+
+			if !body.closed {
+				t.Fatal("HTTPGet leaked the response body")
+			}
+		})
 	}
 }


### PR DESCRIPTION
Closes #748, closes #751.

## #748 — the premise needed correcting

The issue said the admin API token is placed in a DELETE request URL. **That is not what happens.** `c.ApiToken` was already only ever sent as an `Authorization` header and never appears in a URL.

What *is* in the URL is the secret of the token **being deleted** — and that cannot move to a header: the Unleash admin API is `DELETE /api/admin/api-tokens/{secret}` with no id- or name-based alternative. So the fix is redaction at the instrumentation boundary rather than relocation.

`newTransport` builds `redactingTransport → otelhttp → restoringTransport → base`. `HTTPDelete` puts a redacted URL (`.../api-tokens/REDACTED`) in the context; the top layer swaps it in before otelhttp records `url.full`, and the bottom layer restores the real URL just before the wire. The secret therefore exists only on the wire, never in a span.

Only `NewClient` uses this chain, so `NewClientWithHttpClient` callers are unaffected.

Already correct and left alone: `withoutURLError` strips the URL from transport errors, and this package does not log.

## #751 — timeout, unbounded read, leaked bodies

- `DefaultTimeout = 30s` applied in `NewClient`. Declared a `var` to match the repo's existing test-override idiom. `NewClientWithHttpClient` deliberately does *not* inject one — existing tests pass `http.DefaultClient`, and setting `.Timeout` on it would mutate a process-global.
- `readResponseBody()` wraps `io.LimitReader` with a 10 MiB cap and errors on overflow; used by `HTTPGet` and `HTTPPost`.
- `defer res.Body.Close()` added to `HTTPGet`, covering the non-200 and unmarshal-error paths.

`config.TimeoutConfig` was **not** wired in: reaching `unleashclient.NewClient` from config means changing the `resources.UnleashInstance.ApiClient` interface and every implementor. Worth doing, but it is a wider refactor than these two bugs.

## Test evidence

Each test was run with its specific hunk reverted:

| Test | Failure without the fix |
|---|---|
| `TestHTTPDeleteKeepsSecretOutOfSpans` | `span attribute url.full leaked token secret: .../api-tokens/project:development.5ec4e7` |
| `TestNewClientHasTimeout` | `expected the client to bound requests with a timeout` |
| `TestHTTPGetGivesUpOnHungServer` | `request to a hung server never returned` |
| `TestHTTPGetRejectsOversizedBody` | `expected a size limit error, got: invalid character '\x00' ...` |
| `TestHTTPGetClosesResponseBody` (both subtests) | `HTTPGet leaked the response body` |

**One test is not evidence and is labelled as such:** `TestHTTPDeleteKeepsAdminTokenOutOfRequestURL` passes both before and after, because that behaviour was already correct. It is a regression guard. The span test is the decisive one for #748.

## Verification

`go build ./...` exit 0 · `go vet -tags integration_test ./...` exit 0 · `make test` exit 0 · `golangci-lint run ./internal/unleashclient/...` 0 issues.

## Follow-up not fixed here

`requestURL` builds the delete path with `path.Join`, so a token secret containing `../` could rewrite the path. Unleash generates these secrets, so it is not currently reachable — but it is a latent sharp edge worth its own issue.