### PR TITLE
fix(apitoken): treat a missing Unleash instance as a state, not an error

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -78,6 +78,7 @@ The Unleasherator controller exposes metrics across several dimensions:
 | `unleasherator_apitoken_existing_tokens` | Gauge   | Existing tokens in Unleash for ApiToken                         | `namespace`, `name`, `environment` |
 | `unleasherator_apitoken_created_total`   | Counter | ApiTokens created in Unleash                                    | `namespace`, `name`                |
 | `unleasherator_apitoken_deleted_total`   | Counter | ApiTokens deleted from Unleash                                  | `namespace`, `name`                |
+| `unleasherator_apitoken_waiting_for_instance` | Gauge | 1 while an ApiToken waits for its Unleash instance to exist, 0 once it does | `namespace`, `name`      |
 
 #### 5. Controller Health Metrics (from controller-runtime)
 

--- a/internal/controller/apitoken_controller.go
+++ b/internal/controller/apitoken_controller.go
@@ -28,6 +28,7 @@ import (
 	"github.com/nais/unleasherator/internal/o11y"
 	"github.com/nais/unleasherator/internal/resources"
 	"github.com/nais/unleasherator/internal/unleashclient"
+	"github.com/nais/unleasherator/internal/utils"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -41,6 +42,17 @@ const (
 var (
 	// API Token controller timeouts - prefixed to avoid conflicts with other controllers
 	apiTokenRequeueAfter = 1 * time.Hour
+
+	// Poll interval used while the ApiToken is waiting for its Unleash instance
+	// to show up. This controller does not watch Unleash/RemoteUnleash, so the
+	// requeue is the only thing that will ever pick up a late arrival — it must
+	// stay well under the time a team is willing to wait. Ten minutes matches
+	// releaseChannelIdleRequeueInterval, the existing "idle poll" cadence, and
+	// is no slower than the ~16m ceiling of the controller-runtime backoff this
+	// replaces. Jittered because ApiTokens are applied in bulk by a deploy and
+	// would otherwise requeue in lockstep forever.
+	apiTokenMissingInstanceRequeueAfter  = 10 * time.Minute
+	apiTokenMissingInstanceRequeueJitter = 2 * time.Minute
 
 	// apiTokenStatus is a Prometheus metric which will be used to expose the status of the Unleash instances
 	apiTokenStatus = prometheus.NewGaugeVec(
@@ -74,10 +86,24 @@ var (
 		},
 		[]string{"namespace", "name"},
 	)
+
+	// A gauge, not a counter: "the Unleash instance is missing" is a state the
+	// ApiToken is in, not an event that happens. A counter would only tick at
+	// the rate we happen to poll, so its value would measure our requeue
+	// interval rather than the fleet. The question worth alerting on is "how
+	// many ApiTokens are blocked right now, and for how long", which is
+	// exactly what a 0/1 gauge answers.
+	apiTokenWaitingForInstance = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "unleasherator_apitoken_waiting_for_instance",
+			Help: "1 while an ApiToken is waiting for its Unleash instance to exist, 0 once it does",
+		},
+		[]string{"namespace", "name"},
+	)
 )
 
 func init() {
-	metrics.Registry.MustRegister(apiTokenStatus, apiTokenExistingTokens, apiTokenDeletedCounter, apiTokenCreatedCounter)
+	metrics.Registry.MustRegister(apiTokenStatus, apiTokenExistingTokens, apiTokenDeletedCounter, apiTokenCreatedCounter, apiTokenWaitingForInstance)
 }
 
 // ApiTokenReconciler reconciles a ApiToken object
@@ -121,6 +147,7 @@ func (r *ApiTokenReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 			log.Info("ApiToken resource not found. Ignoring since object must be deleted")
 			apiTokenStatus.DeleteLabelValues(req.Namespace, req.Name, unleashv1.ApiTokenStatusConditionTypeCreated)
 			apiTokenStatus.DeleteLabelValues(req.Namespace, req.Name, unleashv1.ApiTokenStatusConditionTypeFailed)
+			apiTokenWaitingForInstance.DeleteLabelValues(req.Namespace, req.Name)
 			return ctrl.Result{Requeue: false}, nil
 		}
 		log.Error(err, "Failed to get ApiToken")
@@ -243,17 +270,53 @@ func (r *ApiTokenReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	unleash, err := r.getUnleashInstance(ctx, token)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
+			// A missing Unleash instance is a state, not a controller fault.
+			// Teams apply ApiTokens before federation has delivered the
+			// RemoteUnleash, so most ApiTokens pass through here on their way to
+			// working. Returning the error made controller-runtime log its own
+			// "Reconciler error" line on top of ours and fast-retry with
+			// backoff; those two lines per retry were the single largest source
+			// of log volume in this operator. Requeue slowly with a nil error
+			// instead, so a late arrival is still picked up but nothing is
+			// reported as broken.
 			message := fmt.Sprintf("%s resource with name %s not found in namespace %s", token.Spec.UnleashInstance.Kind, token.Spec.UnleashInstance.Name, token.Namespace)
-			if statusErr := r.updateStatusFailed(ctx, token, err, "UnleashNotFound", message); statusErr != nil {
+
+			// Read the condition before writing it: this is the only record of
+			// what we already reported, and setStatusFailed overwrites it.
+			previous := meta.FindStatusCondition(token.Status.Conditions, unleashv1.ApiTokenStatusConditionTypeFailed)
+			alreadyReported := previous != nil &&
+				previous.Status == metav1.ConditionTrue &&
+				previous.Reason == "UnleashNotFound"
+
+			if statusErr := r.setStatusFailed(ctx, token, "UnleashNotFound", message); statusErr != nil {
 				return ctrl.Result{}, statusErr
 			}
 
-			return ctrl.Result{}, err
+			apiTokenWaitingForInstance.WithLabelValues(token.Namespace, token.Name).Set(1.0)
+
+			// The event is emitted every time rather than only on change: the
+			// API server aggregates repeats into a single event with a count,
+			// and events expire, so re-emitting keeps `kubectl describe` useful
+			// for as long as the ApiToken is actually stuck.
+			if r.Recorder != nil {
+				r.Recorder.Event(token, "Warning", "UnleashNotFound", message)
+			}
+
+			if !alreadyReported {
+				log.Info("Unleash instance not found, waiting for it to appear",
+					"kind", token.Spec.UnleashInstance.Kind,
+					"instance", token.Spec.UnleashInstance.Name)
+			}
+
+			return ctrl.Result{RequeueAfter: utils.RequeueAfterWithJitter(apiTokenMissingInstanceRequeueAfter, apiTokenMissingInstanceRequeueJitter)}, nil
 		}
 
 		log.Error(err, "Failed to get Unleash resource")
 		return ctrl.Result{}, err
 	}
+
+	// The instance exists, so the wait is over regardless of what happens next.
+	apiTokenWaitingForInstance.WithLabelValues(token.Namespace, token.Name).Set(0.0)
 
 	// Check if Unleash instance is ready
 	if !unleash.IsReady() {
@@ -508,6 +571,15 @@ func (r *ApiTokenReconciler) updateStatusFailed(ctx context.Context, apiToken *u
 	} else {
 		log.Info(fmt.Sprintf("%s for ApiToken", message))
 	}
+
+	return r.setStatusFailed(ctx, apiToken, reason, message)
+}
+
+// setStatusFailed records the failed condition without logging. It is split out
+// of updateStatusFailed for the states that are expected rather than exceptional
+// and therefore must not log on every reconcile.
+func (r *ApiTokenReconciler) setStatusFailed(ctx context.Context, apiToken *unleashv1.ApiToken, reason, message string) error {
+	log := log.FromContext(ctx).WithName("apitoken")
 
 	apiTokenStatus.WithLabelValues(apiToken.Namespace, apiToken.Name, unleashv1.ApiTokenStatusConditionTypeFailed).Set(1.0)
 

--- a/internal/controller/apitoken_controller_unit_test.go
+++ b/internal/controller/apitoken_controller_unit_test.go
@@ -3,16 +3,24 @@ package controller
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
+	"time"
 
+	"github.com/go-logr/logr/funcr"
 	unleashv1 "github.com/nais/unleasherator/api/v1"
 	"github.com/nais/unleasherator/internal/unleashclient"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 func TestCleanupTokenInUnleashRetriesWhenInstanceNotReady(t *testing.T) {
@@ -110,4 +118,221 @@ func TestIsTerminalTokenCleanupError(t *testing.T) {
 			}
 		})
 	}
+}
+
+// A missing Unleash instance is the single most common ApiToken state in the
+// fleet (teams apply ApiTokens before federation delivers the RemoteUnleash),
+// so it must not be reported as a controller error and must not log on every
+// reconcile. These tests pin all four halves of that: nil error, slow requeue,
+// log-on-change-only, and an event plus gauge so it stays observable.
+func TestReconcileMissingUnleashInstanceIsAState(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, unleashv1.AddToScheme(scheme))
+
+	token := &unleashv1.ApiToken{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "test-token",
+			Namespace:  "default",
+			Finalizers: []string{tokenFinalizer},
+		},
+		Spec: unleashv1.ApiTokenSpec{
+			UnleashInstance: unleashv1.ApiTokenUnleashInstance{
+				Name:       "missing-remote",
+				Kind:       "RemoteUnleash",
+				ApiVersion: unleashv1.GroupVersion.String(),
+			},
+		},
+		Status: unleashv1.ApiTokenStatus{
+			Conditions: []metav1.Condition{{
+				Type:               unleashv1.ApiTokenStatusConditionTypeCreated,
+				Status:             metav1.ConditionUnknown,
+				Reason:             "Reconciling",
+				Message:            "Starting reconciliation",
+				LastTransitionTime: metav1.Now(),
+			}},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(token).
+		WithStatusSubresource(token).
+		Build()
+
+	recorder := record.NewFakeRecorder(10)
+	reconciler := &ApiTokenReconciler{
+		Client:   fakeClient,
+		Scheme:   scheme,
+		Recorder: recorder,
+		Tracer:   otel.Tracer("test"),
+	}
+
+	var logged []string
+	logger := funcr.New(func(prefix, args string) {
+		logged = append(logged, args)
+	}, funcr.Options{})
+	ctx := log.IntoContext(context.Background(), logger)
+
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: "test-token", Namespace: "default"}}
+
+	apiTokenWaitingForInstance.Reset()
+
+	result, err := reconciler.Reconcile(ctx, req)
+	require.NoError(t, err, "a missing user-managed dependency must not surface as a reconciler error")
+	assert.Greater(t, result.RequeueAfter, time.Duration(0), "the ApiToken must keep polling so a late RemoteUnleash is still picked up")
+	assert.Less(t, result.RequeueAfter, 30*time.Minute, "requeue must stay fast enough that a team is not left waiting")
+
+	firstLogs := countLogsContaining(logged, "Unleash instance not found")
+	assert.Equal(t, 1, firstLogs, "the first observation of the missing instance should be logged once")
+
+	gaugeVal, err := promGaugeVecVal(apiTokenWaitingForInstance, "default", "test-token")
+	require.NoError(t, err)
+	assert.Equal(t, 1.0, gaugeVal, "the waiting gauge must be set while the instance is missing")
+
+	// Status condition is still the surface teams see in `kubectl get apitoken`.
+	updated := &unleashv1.ApiToken{}
+	require.NoError(t, fakeClient.Get(ctx, req.NamespacedName, updated))
+	failed := meta.FindStatusCondition(updated.Status.Conditions, unleashv1.ApiTokenStatusConditionTypeFailed)
+	require.NotNil(t, failed, "the failed condition must still be recorded")
+	assert.Equal(t, "UnleashNotFound", failed.Reason)
+	assert.Equal(t, metav1.ConditionTrue, failed.Status)
+
+	select {
+	case event := <-recorder.Events:
+		assert.Contains(t, event, "UnleashNotFound", "an event must be emitted so the state shows in kubectl describe")
+	default:
+		t.Fatal("expected an event to be recorded for the missing Unleash instance")
+	}
+
+	// Second consecutive reconcile of the unchanged state: no new log line.
+	logged = nil
+	result, err = reconciler.Reconcile(ctx, req)
+	require.NoError(t, err)
+	assert.Greater(t, result.RequeueAfter, time.Duration(0))
+	assert.Equal(t, 0, countLogsContaining(logged, "Unleash instance not found"),
+		"an unchanged missing-instance state must not log again; this is the log volume the change exists to remove")
+	assert.Equal(t, 0, countLogsContaining(logged, "not found in namespace"),
+		"updateStatusFailed must not log the message again either")
+}
+
+// The gauge must fall back to 0 once the instance appears, otherwise an alert on
+// it would fire forever for ApiTokens that recovered on their own.
+func TestReconcileClearsWaitingGaugeWhenInstanceAppears(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, unleashv1.AddToScheme(scheme))
+
+	remoteUnleash := &unleashv1.RemoteUnleash{
+		ObjectMeta: metav1.ObjectMeta{Name: "late-remote", Namespace: "default"},
+	}
+	token := &unleashv1.ApiToken{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "late-token",
+			Namespace:  "default",
+			Finalizers: []string{tokenFinalizer},
+		},
+		Spec: unleashv1.ApiTokenSpec{
+			UnleashInstance: unleashv1.ApiTokenUnleashInstance{
+				Name:       "late-remote",
+				Kind:       "RemoteUnleash",
+				ApiVersion: unleashv1.GroupVersion.String(),
+			},
+		},
+		Status: unleashv1.ApiTokenStatus{
+			Conditions: []metav1.Condition{{
+				Type:               unleashv1.ApiTokenStatusConditionTypeCreated,
+				Status:             metav1.ConditionUnknown,
+				Reason:             "Reconciling",
+				Message:            "Starting reconciliation",
+				LastTransitionTime: metav1.Now(),
+			}},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(token, remoteUnleash).
+		WithStatusSubresource(token).
+		Build()
+
+	reconciler := &ApiTokenReconciler{
+		Client:   fakeClient,
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(10),
+		Tracer:   otel.Tracer("test"),
+	}
+
+	apiTokenWaitingForInstance.Reset()
+	apiTokenWaitingForInstance.WithLabelValues("default", "late-token").Set(1.0)
+
+	// The RemoteUnleash exists but is not ready, so the reconcile stops shortly
+	// after the lookup — which is all this assertion needs.
+	_, _ = reconciler.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "late-token", Namespace: "default"},
+	})
+
+	gaugeVal, err := promGaugeVecVal(apiTokenWaitingForInstance, "default", "late-token")
+	require.NoError(t, err)
+	assert.Equal(t, 0.0, gaugeVal, "the waiting gauge must clear once the instance exists")
+}
+
+func countLogsContaining(logs []string, substr string) int {
+	count := 0
+	for _, line := range logs {
+		if strings.Contains(line, substr) {
+			count++
+		}
+	}
+	return count
+}
+
+// After an operator restart the gauge must be rebuilt from the stored condition,
+// otherwise a "blocked for > N minutes" alert silently resets on every rollout.
+func TestMetricsInitializerSeedsWaitingForInstanceGauge(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, unleashv1.AddToScheme(scheme))
+
+	blocked := &unleashv1.ApiToken{
+		ObjectMeta: metav1.ObjectMeta{Name: "blocked-token", Namespace: "default"},
+		Status: unleashv1.ApiTokenStatus{
+			Conditions: []metav1.Condition{{
+				Type:               unleashv1.ApiTokenStatusConditionTypeFailed,
+				Status:             metav1.ConditionTrue,
+				Reason:             "UnleashNotFound",
+				Message:            "RemoteUnleash resource with name gone not found in namespace default",
+				LastTransitionTime: metav1.Now(),
+			}},
+		},
+	}
+	// Failing for an unrelated reason is not the same state and must not be
+	// counted as waiting.
+	otherFailure := &unleashv1.ApiToken{
+		ObjectMeta: metav1.ObjectMeta{Name: "other-token", Namespace: "default"},
+		Status: unleashv1.ApiTokenStatus{
+			Conditions: []metav1.Condition{{
+				Type:               unleashv1.ApiTokenStatusConditionTypeFailed,
+				Status:             metav1.ConditionTrue,
+				Reason:             "TokenCreationFailed",
+				Message:            "boom",
+				LastTransitionTime: metav1.Now(),
+			}},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(blocked, otherFailure).
+		Build()
+
+	apiTokenWaitingForInstance.Reset()
+
+	initializer := &MetricsInitializer{Client: fakeClient}
+	require.NoError(t, initializer.initApiTokenMetrics(context.Background()))
+
+	blockedVal, err := promGaugeVecVal(apiTokenWaitingForInstance, "default", "blocked-token")
+	require.NoError(t, err)
+	assert.Equal(t, 1.0, blockedVal, "an ApiToken stored as UnleashNotFound must come back as waiting")
+
+	otherVal, err := promGaugeVecVal(apiTokenWaitingForInstance, "default", "other-token")
+	require.NoError(t, err)
+	assert.Equal(t, 0.0, otherVal, "an unrelated failure must not be reported as waiting for an instance")
 }

--- a/internal/controller/metrics_initializer.go
+++ b/internal/controller/metrics_initializer.go
@@ -5,6 +5,7 @@ import (
 
 	unleashv1 "github.com/nais/unleasherator/api/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -127,6 +128,15 @@ func (m *MetricsInitializer) initApiTokenMetrics(ctx context.Context) error {
 		} else {
 			apiTokenStatus.WithLabelValues(apiToken.Namespace, apiToken.Name, unleashv1.ApiTokenStatusConditionTypeFailed).Set(0)
 		}
+
+		// Seeded from the condition so an operator restart does not blank out
+		// the "blocked on a missing instance" series until the next slow
+		// requeue, which would silently reset any duration-based alert on it.
+		waiting := 0.0
+		if failedCond != nil && failedCond.Status == metav1.ConditionTrue && failedCond.Reason == "UnleashNotFound" {
+			waiting = 1.0
+		}
+		apiTokenWaitingForInstance.WithLabelValues(apiToken.Namespace, apiToken.Name).Set(waiting)
 	}
 
 	return nil

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -172,6 +172,7 @@ var _ = BeforeSuite(func() {
 	err = (&ApiTokenReconciler{
 		Client:                      k8sManager.GetClient(),
 		Scheme:                      k8sManager.GetScheme(),
+		Recorder:                    k8sManager.GetEventRecorderFor("apitoken-controller"),
 		OperatorNamespace:           namespace,
 		ApiTokenNameSuffix:          ApiTokenNameSuffix,
 		ApiTokenUpdateEnabled:       true,


### PR DESCRIPTION
Refs #804. Takes the noise down; does not fix the six orphaned ApiTokens, which still need clearing up.

## Why

ApiTokens are deployed by teams. The `RemoteUnleash` they reference is created asynchronously by federation — measured across the live fleet, **131 of 212 ApiTokens in nav-dev were created before their RemoteUnleash existed**. So "instance not there yet" is not an exceptional condition, it is the normal early state of a team's ApiToken.

The controller treated it as a reconciler error and returned it. That made controller-runtime log its own `Reconciler error` line on top of ours and drive a backoff-retry loop — **2000+ log lines per day from six resources**, the dominant error source in unleasherator's logs, loud enough to bury a real one.

## What

The `UnleashNotFound` branch now returns `ctrl.Result{RequeueAfter: …}, nil`:

- **10 min ± 2 min jitter.** Deliberately not the existing `apiTokenRequeueAfter = 1h`: `SetupWithManager` has no `Watches` on Unleash/RemoteUnleash, only `For(&ApiToken{})` with `GenerationChangedPredicate`, so this requeue is the *only* thing that can pick up a late-arriving RemoteUnleash. An hour would have been a real regression against the ~16.7 min controller-runtime backoff ceiling it replaces. Jitter because bulk-applied ApiTokens would otherwise requeue in lockstep.
- **Logs only when the state changes**, at info. `updateStatusFailed` always logged, so the status-writing half was extracted; the branch reads the previous condition before overwriting it.
- **The existing `UnleashNotFound` status condition is unchanged** — it was already the right surface, and it is where the team sees this in their own `kubectl get apitoken`.
- **A Kubernetes Event**, emitted every time rather than on change: the API server aggregates repeats into one event with a count, and events expire, so re-emitting keeps `kubectl describe` useful for as long as the token is actually stuck. The `Recorder` was never wired in `suite_test.go`; it is now.
- **A gauge**, `unleasherator_apitoken_waiting_for_instance{namespace,name}`. A gauge rather than a counter because a counter would tick at whatever rate we happen to poll — it would measure our own requeue interval, not the fleet. The alertable question is "how many are blocked right now, and for how long". Seeded in `metrics_initializer.go` from the stored condition, so an operator restart does not blank the series and silently reset a duration-based alert.

The ApiToken never gives up: a RemoteUnleash that arrives late is still picked up automatically.

## Test evidence

Each hunk reverted individually, test re-run, hunk restored:

| Test | Failure without the fix |
|---|---|
| `TestReconcileMissingUnleashInstanceIsAState` | `Received unexpected error: remoteunleashs… "missing-remote" not found` |
| same, log guard reverted | `expected: 0 / actual: 1` — *an unchanged missing-instance state must not log again* (×2, covering `updateStatusFailed` too) |
| same, Event removed | `expected an event to be recorded for the missing Unleash instance` |
| `TestReconcileClearsWaitingGaugeWhenInstanceAppears` | `expected: 0 / actual: 1` |
| `TestMetricsInitializerSeedsWaitingForInstanceGauge` | `expected: 1 / actual: 0` |

No test passes both before and after — every assertion is load-bearing.

## Verification

`go build ./...` ok · `go vet -tags integration_test ./...` ok · `make test` EXIT=0 · `gofmt -l` clean. Controller coverage 69.2% → 69.7%.

## Deliberately not included

Constraining `spec.environment` was scoped into this work and **stopped on evidence** — see the PR discussion. Short version: our own `apitoken_types_test.go` uses `staging`, a captured Unleash payload uses `*`, a stock Unleash seeds `default`, and a `RemoteUnleash` can point at an instance whose environments we do not own. An enum would have broken zero tests, so a green build would not have been evidence of safety.