### PR TITLE
fix(federation): close the path traversal, pin federated URLs to https, and refuse non-tenant namespaces

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -93,6 +93,21 @@ The answer lies in the **Separation of Concerns** between the Management Cluster
 
 **Conclusion:** A tenant can only successfully provision API tokens if a Cluster Admin has explicitly authorized their namespace on the central Management Cluster. Authorization is enforced by the operator-stamped annotation, not by trusting the requested secret name.
 
+### Where the admin token may be sent
+
+The server URL is the single field that decides where the operator sends an Unleash admin token, so it is part of the trust boundary rather than a detail of the payload.
+
+On the federation receive path the URL is checked before anything is provisioned: an instance is only ever published with its public API URL, which is `https://<ingress host>` by construction, so a message carrying a plaintext `http://` URL is refused and counted as `unleasherator_federation_received_total{state="provisioned",status="insecure_url"}`. Removals are deliberately **not** checked — they authenticate against what is already stored, and refusing them would orphan exactly what the removal path exists to clean up.
+
+Two controls that this check is often confused with are deliberately **not** implemented:
+
+* **A `^https://` pattern on the CRD.** Plaintext HTTP is legitimate and load-bearing elsewhere: the management cluster reaches its own Unleash instances over the cluster-internal service name (`http://<name>.<namespace>`). Tightening the pattern would break the operator's own reconciliation and would make existing `RemoteUnleash` resources unpatchable.
+* **A host allowlist, or blocking private and loopback ranges in a custom dialer.** Tenants run their own instances on their own hostnames, so there is no list to compare against. Blocking by resolved address would refuse the addresses the operator legitimately talks to — cluster-internal service addresses on the management cluster — and it would not see the real target at all on on-prem clusters, which reach everything through `HTTPS_PROXY`; the only address such a check would ever inspect there is the proxy's.
+
+For tenant-authored `RemoteUnleash` resources the effective control is the admin secret rather than the URL: every operator-managed secret carries a `url` key, and the controller requires `spec.unleashInstance.url` to equal it. A tenant therefore cannot redirect a managed credential to a host of its choosing, whatever the CRD pattern allows.
+
+Dynamic path segments — a token name, a token secret — are escaped and kept out of `path.Join`, so a value containing `/` or `..` addresses an item under the endpoint instead of resolving to a different one; a segment that is nothing but dots is refused outright.
+
 ### Which namespaces a message may name
 
 The payload is also the only statement of *where* an instance belongs, and the subscriber has no independent inventory to check it against. Tenant namespaces are created and retired continuously, so an operator-side allowlist of served namespaces would go stale and start dropping legitimate messages — including removals, which is how `RemoteUnleash` resources are orphaned. The list stays authoritative.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -93,6 +93,18 @@ The answer lies in the **Separation of Concerns** between the Management Cluster
 
 **Conclusion:** A tenant can only successfully provision API tokens if a Cluster Admin has explicitly authorized their namespace on the central Management Cluster. Authorization is enforced by the operator-stamped annotation, not by trusting the requested secret name.
 
+### Which namespaces a message may name
+
+The payload is also the only statement of *where* an instance belongs, and the subscriber has no independent inventory to check it against. Tenant namespaces are created and retired continuously, so an operator-side allowlist of served namespaces would go stale and start dropping legitimate messages — including removals, which is how `RemoteUnleash` resources are orphaned. The list stays authoritative.
+
+What the subscriber does refuse, without any configuration, are the namespaces that are never a tenant:
+
+* **The operator namespace.** Managed admin secrets live there precisely because tenants cannot read them. A `RemoteUnleash` created there would reference its admin secret in the same namespace, which never crosses a privilege boundary and therefore skips the authorized-namespace check entirely. In the legacy layout it is worse: the secret name is assembled from publisher-supplied fields, so a message naming the operator namespace can write a chosen credential over another tenant's managed secret, under a name that no `RemoteUnleash` of its own guards.
+* **Namespaces with the reserved `kube-` prefix.**
+* **Blank entries and names Kubernetes cannot accept.** Blanks are trimmed and ignored the same way cluster list entries are; invalid names are dropped rather than sent to the API server, where they would fail on every redelivery.
+
+Refused namespaces are counted by `unleasherator_federation_rejected_namespaces_total` with the reason as a label. A message left with no namespaces at all is acknowledged and does nothing; it is never read as a removal.
+
 ## Legacy Formats, The "Nonce", and Migration
 
 ### Where Legacy Federation Secrets Live

--- a/internal/controller/remoteunleash_controller.go
+++ b/internal/controller/remoteunleash_controller.go
@@ -5,6 +5,7 @@ import (
 	"crypto/subtle"
 	"errors"
 	"fmt"
+	"net/url"
 	"strings"
 	"time"
 
@@ -785,6 +786,25 @@ func (r *RemoteUnleashReconciler) FederationSubscribe(ctx context.Context) error
 				supersededSecrets := make(map[client.ObjectKey]*corev1.Secret)
 
 				for i, ru := range remoteUnleashes {
+					// The credential on a federation message is the management
+					// cluster's own admin token, and the URL is the single field
+					// that decides where the operator sends it. The only URL an
+					// instance is ever published with is its public API URL,
+					// which is https by construction, so a plaintext one is not
+					// an instance this operator can reach safely — it is the
+					// admin token on the wire in the clear.
+					//
+					// Only provisioning is checked. A removal has to keep
+					// working against whatever is already stored, or a resource
+					// federated before this check could never be deleted again,
+					// which is the orphan the removal path exists to prevent.
+					if !federationServerURLIsSecure(ru.Spec.Server.URL) {
+						remoteUnleashReceived.WithLabelValues("provisioned", "insecure_url").Inc()
+						log.Info("Refusing to provision RemoteUnleash from a message that does not carry an https URL",
+							"name", ru.Name, "namespace", ru.Namespace, "url", ru.Spec.Server.URL)
+						continue
+					}
+
 					existingRU := &unleashv1.RemoteUnleash{}
 					err := r.APIReader.Get(ctx, client.ObjectKeyFromObject(ru), existingRU)
 					if err != nil && !apierrors.IsNotFound(err) {
@@ -1029,6 +1049,25 @@ func setFederationPublishTime(remoteUnleash *unleashv1.RemoteUnleash, publishTim
 		remoteUnleash.Annotations = map[string]string{}
 	}
 	remoteUnleash.Annotations[unleashv1.RemoteUnleashFederationPublishTimeAnnotation] = publishTime.UTC().Format(time.RFC3339Nano)
+}
+
+// federationServerURLIsSecure reports whether a federated server URL is one the
+// operator may send the admin token to.
+//
+// This is deliberately a scheme check and not a host allowlist. Tenants run
+// their own Unleash instances on their own hostnames, so the operator has no
+// list of legitimate hosts to compare against, and blocking hosts by resolved
+// address would refuse the addresses the operator legitimately talks to: the
+// management cluster reaches its own instances over cluster-internal service
+// names, and on-prem clusters reach everything through an HTTP proxy whose
+// address is the only one such a check would ever see.
+func federationServerURLIsSecure(serverURL string) bool {
+	parsed, err := url.Parse(serverURL)
+	if err != nil {
+		return false
+	}
+
+	return parsed.Scheme == "https" && parsed.Host != ""
 }
 
 func federationAdminSecret(ctx context.Context, k8sClient client.Reader, remoteUnleash *unleashv1.RemoteUnleash) (*corev1.Secret, error) {

--- a/internal/controller/remoteunleash_federation_unit_test.go
+++ b/internal/controller/remoteunleash_federation_unit_test.go
@@ -759,3 +759,47 @@ func TestFederationRemovalWithMissingAdminSecretIsSkipped(t *testing.T) {
 	require.NoError(t, c.Get(ctx, client.ObjectKeyFromObject(existing), &unleashv1.RemoteUnleash{}),
 		"a RemoteUnleash whose token could not be verified must not be deleted")
 }
+
+// Provisioning is where a credential substitution pays off: a message that keeps
+// the public URL but carries a different token would, if only the URL were
+// checked, replace the admin credential of a live tenant with one the publisher
+// chose. The URL is public information, so matching it proves nothing about who
+// sent the message; only the credential already bound to the resource does.
+func TestFederationProvisionRefusesTokenSubstitution(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	existing, secret := federationFixture("aura", "tenant", "https://unleash.example.com", "token")
+
+	scheme := federationTestScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existing, secret).Build()
+
+	reconciler := &RemoteUnleashReconciler{
+		Client:     c,
+		APIReader:  c,
+		Scheme:     scheme,
+		Federation: RemoteUnleashFederation{Enabled: true, ClusterName: "cluster-a"},
+	}
+	handler := startFederationHandler(ctx, t, reconciler)
+
+	incoming := existing.DeepCopy()
+	incoming.ResourceVersion = ""
+	substituted := secret.DeepCopy()
+	substituted.ResourceVersion = ""
+	substituted.Data[unleashv1.UnleashSecretTokenKey] = []byte("attacker-controlled-token")
+
+	// The cluster list names this cluster, so the message is a provisioning
+	// message for it and nothing else diverts it into the removal path.
+	require.NoError(t, handler(ctx,
+		[]*unleashv1.RemoteUnleash{incoming},
+		[]*corev1.Secret{substituted},
+		[]string{"cluster-a"},
+		pb.Status_Provisioned,
+		time.Now(),
+	))
+
+	stored := &corev1.Secret{}
+	require.NoError(t, c.Get(ctx, client.ObjectKeyFromObject(secret), stored))
+	assert.Equal(t, []byte("token"), stored.Data[unleashv1.UnleashSecretTokenKey],
+		"a provisioning message that only matches the URL must not rotate the stored admin token")
+}

--- a/internal/controller/remoteunleash_federation_unit_test.go
+++ b/internal/controller/remoteunleash_federation_unit_test.go
@@ -803,3 +803,65 @@ func TestFederationProvisionRefusesTokenSubstitution(t *testing.T) {
 	assert.Equal(t, []byte("token"), stored.Data[unleashv1.UnleashSecretTokenKey],
 		"a provisioning message that only matches the URL must not rotate the stored admin token")
 }
+
+// The URL decides where the operator sends the management cluster's admin
+// token, so a message carrying a plaintext one asks it to put that credential
+// on the wire in the clear. Provisioning refuses it; a removal must not, or a
+// resource federated before the check could never be deleted again.
+func TestFederationRefusesInsecureServerURL(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	scheme := federationTestScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	reconciler := &RemoteUnleashReconciler{
+		Client:     c,
+		APIReader:  c,
+		Scheme:     scheme,
+		Federation: RemoteUnleashFederation{Enabled: true, ClusterName: "cluster-a"},
+	}
+	handler := startFederationHandler(ctx, t, reconciler)
+
+	for _, serverURL := range []string{
+		"http://unleash.example.com",
+		"http://169.254.169.254/computeMetadata/v1/",
+		"://not-a-url",
+	} {
+		insecure, insecureSecret := federationFixture("aura", "tenant", serverURL, "token")
+		require.NoError(t, handler(ctx,
+			[]*unleashv1.RemoteUnleash{insecure},
+			[]*corev1.Secret{insecureSecret},
+			[]string{"cluster-a"},
+			pb.Status_Provisioned,
+			time.Now(),
+		))
+
+		err := c.Get(ctx, client.ObjectKeyFromObject(insecure), &unleashv1.RemoteUnleash{})
+		assert.True(t, apierrors.IsNotFound(err),
+			"a message carrying %q must not provision a RemoteUnleash", serverURL)
+		err = c.Get(ctx, client.ObjectKeyFromObject(insecureSecret), &corev1.Secret{})
+		assert.True(t, apierrors.IsNotFound(err),
+			"a message carrying %q must not write an admin secret", serverURL)
+	}
+
+	// A resource that predates the check is still removable: the removal path
+	// authenticates against what is stored, and refusing it here would orphan
+	// exactly what the removal path exists to clean up.
+	stored, storedSecret := federationFixture("legacy", "tenant", "http://unleash.example.com", "token")
+	require.NoError(t, c.Create(ctx, stored))
+	require.NoError(t, c.Create(ctx, storedSecret))
+
+	incoming, incomingSecret := federationFixture("legacy", "tenant", "http://unleash.example.com", "token")
+	require.NoError(t, handler(ctx,
+		[]*unleashv1.RemoteUnleash{incoming},
+		[]*corev1.Secret{incomingSecret},
+		[]string{"cluster-a"},
+		pb.Status_Removed,
+		time.Now(),
+	))
+
+	err := c.Get(ctx, client.ObjectKeyFromObject(stored), &unleashv1.RemoteUnleash{})
+	assert.True(t, apierrors.IsNotFound(err),
+		"an authenticated removal must still delete a resource that carries a plaintext URL")
+}

--- a/internal/controller/utils_test.go
+++ b/internal/controller/utils_test.go
@@ -212,11 +212,13 @@ func remoteUnleashSuccessCondition() metav1.Condition {
 	}
 }
 
-// mockRemoteUnleashURL generates a unique URL for RemoteUnleash based on name and namespace.
-// This mirrors the Unleash.URL() pattern: http://<name>.<namespace>
+// mockRemoteUnleashURL generates a unique URL for RemoteUnleash based on name
+// and namespace. It is https because a federated instance is published with its
+// public API URL, which always is, and the receive path refuses to provision
+// from anything else.
 // Using unique URLs per test ensures httpmock isolation between concurrent tests.
 func mockRemoteUnleashURL(name, namespace string) string {
-	return fmt.Sprintf("http://%s.%s", name, namespace)
+	return fmt.Sprintf("https://%s.%s", name, namespace)
 }
 
 // registerHTTPMocksForRemoteUnleash registers httpmock responders for a RemoteUnleash instance.

--- a/internal/federation/subscriber.go
+++ b/internal/federation/subscriber.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"cloud.google.com/go/pubsub"
@@ -19,6 +20,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/protobuf/proto"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/validation"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 
@@ -53,8 +55,16 @@ var federationPoisonMessages = prometheus.NewCounterVec(
 	[]string{"subscription"},
 )
 
+var federationRejectedNamespaces = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "unleasherator_federation_rejected_namespaces_total",
+		Help: "Number of federation message namespaces refused before any resource was built",
+	},
+	[]string{"reason"},
+)
+
 func init() {
-	metrics.Registry.MustRegister(federationPoisonMessages)
+	metrics.Registry.MustRegister(federationPoisonMessages, federationRejectedNamespaces)
 }
 
 type Subscriber interface {
@@ -184,6 +194,12 @@ func (s *subscriber) handleMessage(ctx context.Context, msg *pubsub.Message, han
 		log.Info("secret nonce not set, derived stable nonce")
 	}
 
+	// The payload names the namespaces to serve, and the operator has no
+	// independent inventory to check them against. What it does know is which
+	// namespaces are not tenants at all, so those are dropped here, before a
+	// single object is built from them.
+	namespaces := s.tenantNamespaces(ctx, instance.GetNamespaces())
+
 	var (
 		adminSecrets    []*corev1.Secret
 		remoteUnleashes []*unleashv1.RemoteUnleash
@@ -195,7 +211,7 @@ func (s *subscriber) handleMessage(ctx context.Context, msg *pubsub.Message, han
 		// authorized-namespace annotation. The controller uses that annotation as the
 		// primary confused-deputy defense, so it cannot be bypassed by crafting a
 		// RemoteUnleash name.
-		for _, namespace := range instance.GetNamespaces() {
+		for _, namespace := range namespaces {
 			secretName := fmt.Sprintf("unleasherator-%s-%s-admin-key-%s", instance.GetName(), namespace, secretNonce)
 			adminSecret := resources.OperatorSecretForUnleash(instance.GetName(), secretName, s.namespace, instance.SecretToken, instance.GetUrl())
 			setAuthorizedNamespace(adminSecret, namespace)
@@ -212,18 +228,75 @@ func (s *subscriber) handleMessage(ctx context.Context, msg *pubsub.Message, han
 		// secrets in the operator namespace. Same-namespace references do not hit the
 		// cross-namespace authorization path in the controller.
 		secretName := fmt.Sprintf("unleasherator-%s-%s", instance.GetName(), secretNonce)
-		for _, namespace := range instance.GetNamespaces() {
+		for _, namespace := range namespaces {
 			adminSecret := resources.OperatorSecretForUnleash(instance.GetName(), secretName, namespace, instance.SecretToken, instance.GetUrl())
 			setAuthorizedNamespace(adminSecret, namespace)
 			adminSecrets = append(adminSecrets, adminSecret)
 		}
 
-		remoteUnleashes = resources.RemoteunleashInstances(instance.GetName(), instance.GetUrl(), instance.GetNamespaces(), secretName, "")
+		remoteUnleashes = resources.RemoteunleashInstances(instance.GetName(), instance.GetUrl(), namespaces, secretName, "")
 	}
 
 	ctx, subspan := otel.Tracer("subscribe").Start(ctx, "Process PubSub", spanOps...)
 	defer subspan.End()
 	return handler(ctx, remoteUnleashes, adminSecrets, instance.Clusters, instance.Status, msg.PublishTime)
+}
+
+// tenantNamespaces filters the namespaces a federation message asks the
+// operator to serve down to the ones that can be a tenant at all.
+//
+// The publisher decides which namespaces get an instance, and the subscriber
+// cannot second-guess that: tenant namespaces are created and retired
+// continuously, so an operator-side list of "the namespaces we serve" would go
+// stale and start dropping legitimate messages — including removals, which is
+// how resources are orphaned. What the operator does know, without any
+// configuration, is which namespaces are never a tenant. Those are refused
+// here, before any object is built from them.
+//
+// Refusing the operator's own namespace is the one that matters. Managed admin
+// secrets live there precisely because tenants cannot read them, and a
+// RemoteUnleash created there would reference its admin secret in the same
+// namespace — which never crosses a privilege boundary, so it skips the
+// authorized-namespace check that is the primary confused-deputy control. In
+// the legacy layout it is worse still: the secret name is built from
+// publisher-supplied fields, so a message naming the operator namespace can
+// write an attacker-chosen credential over a managed secret belonging to
+// another tenant, under a name no RemoteUnleash of its own guards.
+//
+// Entries are trimmed and blanks ignored, the same way cluster list entries
+// are: a stray space in a team's federation config is a typo, not a namespace.
+// Names that Kubernetes cannot accept are dropped rather than sent to the API
+// server, where they would fail on every redelivery.
+func (s *subscriber) tenantNamespaces(ctx context.Context, namespaces []string) []string {
+	log := log.FromContext(ctx).WithName("subscribe")
+
+	accepted := make([]string, 0, len(namespaces))
+	for _, namespace := range namespaces {
+		namespace = strings.TrimSpace(namespace)
+
+		reason := ""
+		switch {
+		case namespace == "":
+			reason = "blank"
+		case namespace == s.namespace:
+			reason = "operator_namespace"
+		case strings.HasPrefix(namespace, "kube-"):
+			// Kubernetes reserves the kube- prefix for system namespaces.
+			reason = "reserved_namespace"
+		case len(validation.IsDNS1123Label(namespace)) > 0:
+			reason = "invalid_name"
+		}
+
+		if reason != "" {
+			federationRejectedNamespaces.WithLabelValues(reason).Inc()
+			log.Info("Refusing federation namespace", "namespace", namespace, "reason", reason)
+			continue
+		}
+
+		accepted = append(accepted, namespace)
+	}
+
+	return accepted
 }
 
 func stableNonce(instance *pb.Instance) (string, error) {

--- a/internal/federation/subscriber_test.go
+++ b/internal/federation/subscriber_test.go
@@ -433,3 +433,108 @@ func TestSubscriberRedeliversTransientHandlerError(t *testing.T) {
 	assert.Eventually(t, func() bool { return calls.Load() >= 2 }, 30*time.Second, 50*time.Millisecond,
 		"transient errors must be nacked and redelivered")
 }
+
+// The publisher decides which namespaces an instance is federated to, and the
+// subscriber acts on that list without any local authorization step. It can
+// still refuse the namespaces that are never a tenant, and it must: the
+// operator namespace holds every managed admin secret, and in the legacy
+// layout the secret name is assembled from publisher-supplied fields, so a
+// message naming it writes a chosen credential into that namespace under a
+// chosen name.
+func TestSubscriberRefusesNonTenantNamespaces(t *testing.T) {
+	ctx := context.Background()
+	operatorNamespace := "unleasherator-system"
+
+	for _, namespaceBound := range []bool{false, true} {
+		name := "legacy"
+		if namespaceBound {
+			name = "namespace-bound"
+		}
+
+		t.Run(name, func(t *testing.T) {
+			s := &subscriber{namespace: operatorNamespace, namespaceBoundSecrets: namespaceBound}
+
+			instance := &pb.Instance{
+				Name:        "unleash",
+				Url:         "https://unleash.example.com",
+				SecretToken: "token",
+				SecretNonce: "nonce",
+				Status:      pb.Status_Provisioned,
+				Clusters:    []string{"cluster-a"},
+				Namespaces: []string{
+					"team-a",
+					"",
+					"   ",
+					operatorNamespace,
+					"kube-system",
+					"Not A Namespace",
+					" team-b ",
+				},
+			}
+			payload, err := proto.Marshal(instance)
+			assert.NoError(t, err)
+
+			var (
+				gotRemoteUnleashes []*unleashv1.RemoteUnleash
+				gotSecrets         []*corev1.Secret
+			)
+			err = s.handleMessage(ctx, &pubsub.Message{Data: payload, PublishTime: time.Now()},
+				func(_ context.Context, remoteUnleashes []*unleashv1.RemoteUnleash, secrets []*corev1.Secret, _ []string, _ pb.Status, _ time.Time) error {
+					gotRemoteUnleashes = remoteUnleashes
+					gotSecrets = secrets
+					return nil
+				})
+			assert.NoError(t, err)
+
+			namespaces := []string{}
+			for _, ru := range gotRemoteUnleashes {
+				namespaces = append(namespaces, ru.Namespace)
+			}
+			assert.Equal(t, []string{"team-a", "team-b"}, namespaces,
+				"only tenant namespaces may reach the handler, and padded entries are the same tenant")
+
+			// The invariant the removal and provisioning paths index on: one
+			// admin secret per RemoteUnleash, in the same order.
+			assert.Len(t, gotSecrets, len(gotRemoteUnleashes))
+
+			for _, secret := range gotSecrets {
+				assert.NotEqual(t, operatorNamespace, secret.Annotations[unleashv1.UnleashSecretAuthorizedNamespaceAnnotation],
+					"no secret may be authorized for the operator namespace")
+				if !namespaceBound {
+					assert.NotEqual(t, operatorNamespace, secret.Namespace,
+						"a legacy tenant secret must never be written into the operator namespace")
+				}
+			}
+		})
+	}
+}
+
+// A message that names nothing the operator will serve must not reach the
+// handler with resources built from it; it is a no-op, not a removal.
+func TestSubscriberRefusesEveryNamespace(t *testing.T) {
+	ctx := context.Background()
+	s := &subscriber{namespace: "unleasherator-system"}
+
+	instance := &pb.Instance{
+		Name:        "unleash",
+		Url:         "https://unleash.example.com",
+		SecretToken: "token",
+		SecretNonce: "nonce",
+		Status:      pb.Status_Provisioned,
+		Clusters:    []string{"cluster-a"},
+		Namespaces:  []string{"unleasherator-system", "kube-public"},
+	}
+	payload, err := proto.Marshal(instance)
+	assert.NoError(t, err)
+
+	handlerCalled := false
+	err = s.handleMessage(ctx, &pubsub.Message{Data: payload, PublishTime: time.Now()},
+		func(_ context.Context, remoteUnleashes []*unleashv1.RemoteUnleash, secrets []*corev1.Secret, _ []string, _ pb.Status, _ time.Time) error {
+			handlerCalled = true
+			assert.Empty(t, remoteUnleashes)
+			assert.Empty(t, secrets)
+			return nil
+		})
+	assert.NoError(t, err)
+	assert.True(t, handlerCalled, "the message is acknowledged, so the handler still runs and finds nothing to do")
+}

--- a/internal/unleashclient/admin_api.go
+++ b/internal/unleashclient/admin_api.go
@@ -2,7 +2,6 @@ package unleashclient
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 )
 
@@ -133,7 +132,7 @@ func (c *Client) GetAllAPITokens(ctx context.Context) (*ApiTokenResult, error) {
 func (c *Client) GetAPITokensByName(ctx context.Context, userName string) (*ApiTokenResult, error) {
 	res := &ApiTokenResult{Tokens: []ApiToken{}}
 
-	_, err := c.HTTPGet(ctx, fmt.Sprintf("%s/%s", ApiTokensEndpoint, userName), res)
+	_, err := c.HTTPGetItem(ctx, ApiTokensEndpoint, userName, res)
 	if err != nil {
 		return res, err
 	}

--- a/internal/unleashclient/client.go
+++ b/internal/unleashclient/client.go
@@ -202,8 +202,45 @@ func (c *Client) requestURL(requestPath string) *url.URL {
 	return req
 }
 
+// itemURL addresses a single item under an endpoint, where the item is data
+// that reached the client from outside it — a token name derived from an
+// ApiToken resource, or a token secret returned by the server.
+//
+// The item is escaped and kept out of path.Join. Both matter, and for
+// different reasons: without escaping, an item containing "/" adds path
+// segments and re-points the request at another endpoint, and path.Join
+// resolves a ".." away silently rather than treating it as the traversal it
+// is. An item that is nothing but dots is refused outright, because there is
+// no name it could be — only a relative path element.
+func (c *Client) itemURL(requestPath, item string) (*url.URL, error) {
+	if item == "" || strings.Trim(item, ".") == "" {
+		return nil, fmt.Errorf("invalid path segment %q", item)
+	}
+
+	req := c.requestURL(requestPath)
+	req.RawPath = req.EscapedPath() + "/" + url.PathEscape(item)
+	req.Path = req.Path + "/" + item
+
+	return req, nil
+}
+
 func (c *Client) HTTPGet(ctx context.Context, requestPath string, v any) (*http.Response, error) {
-	requestURL := c.requestURL(requestPath).String()
+	return c.httpGet(ctx, c.requestURL(requestPath), v)
+}
+
+// HTTPGetItem fetches a single item under an endpoint. The item is treated as
+// data, not as part of the request path; see itemURL.
+func (c *Client) HTTPGetItem(ctx context.Context, requestPath, item string, v any) (*http.Response, error) {
+	itemURL, err := c.itemURL(requestPath, item)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.httpGet(ctx, itemURL, v)
+}
+
+func (c *Client) httpGet(ctx context.Context, url *url.URL, v any) (*http.Response, error) {
+	requestURL := url.String()
 	requestMethod := "GET"
 
 	req, err := http.NewRequestWithContext(ctx, requestMethod, requestURL, nil)
@@ -239,17 +276,24 @@ func (c *Client) HTTPGet(ctx context.Context, requestPath string, v any) (*http.
 }
 
 func (c *Client) HTTPDelete(ctx context.Context, requestPath string, item string) error {
-	requestURL := c.requestURL(fmt.Sprintf("%s/%s", requestPath, item)).String()
+	itemURL, err := c.itemURL(requestPath, item)
+	if err != nil {
+		return err
+	}
+	requestURL := itemURL.String()
 	requestMethod := "DELETE"
 
 	// The Unleash admin API identifies the token to delete by its secret, and
 	// only accepts it as a path segment, so it cannot move to a header the way
 	// the admin credential does. Hand the transport chain a redacted URL to
 	// hold up to instrumentation instead.
-	ctx = withRedactedURL(ctx, c.requestURL(fmt.Sprintf("%s/%s", requestPath, redactedPathSegment)).String())
+	redactedURL, err := c.itemURL(requestPath, redactedPathSegment)
+	if err != nil {
+		return err
+	}
+	ctx = withRedactedURL(ctx, redactedURL.String())
 
 	req, err := http.NewRequestWithContext(ctx, requestMethod, requestURL, nil)
-
 	if err != nil {
 		return err
 	}

--- a/internal/unleashclient/client_test.go
+++ b/internal/unleashclient/client_test.go
@@ -262,3 +262,58 @@ func TestHTTPGetClosesResponseBody(t *testing.T) {
 		})
 	}
 }
+
+// The token name and the token secret are the only parts of a request path the
+// client does not control. Escaping them keeps them data: a name carrying "/"
+// must address an item under the endpoint, not a different endpoint, and a
+// name that is only dots is not a name at all.
+func TestItemPathSegmentsAreData(t *testing.T) {
+	tests := []struct {
+		name     string
+		item     string
+		wantPath string
+		wantErr  bool
+	}{
+		{name: "ordinary name", item: "team-a-unleash", wantPath: "/api/admin/api-tokens/team-a-unleash"},
+		{name: "token secret", item: "project:development.5ec4e7", wantPath: "/api/admin/api-tokens/project:development.5ec4e7"},
+		{name: "traversal", item: "../../../api/admin/user", wantPath: "/api/admin/api-tokens/..%2F..%2F..%2Fapi%2Fadmin%2Fuser"},
+		{name: "query separator", item: "name?x=1", wantPath: "/api/admin/api-tokens/name%3Fx=1"},
+		{name: "fragment separator", item: "name#frag", wantPath: "/api/admin/api-tokens/name%23frag"},
+		{name: "relative element", item: "..", wantErr: true},
+		{name: "current element", item: ".", wantErr: true},
+		{name: "empty", item: "", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var requestURI string
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				requestURI = r.URL.EscapedPath()
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer server.Close()
+
+			client, err := NewClientWithHttpClient(server.URL, "admin-token", server.Client())
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			err = client.HTTPDelete(context.Background(), ApiTokensEndpoint, tt.item)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected %q to be refused as a path segment", tt.item)
+				}
+				if requestURI != "" {
+					t.Fatalf("refused segment still reached the server as %q", requestURI)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if requestURI != tt.wantPath {
+				t.Errorf("expected request path %q, got %q", tt.wantPath, requestURI)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Addresses #749 and #750. **#747 turned out to be already fixed** — see below.

## The real finding: path traversal with the admin token attached

`#749` claimed `?` and `#` could alter the endpoint. **That claim is wrong** — Go escapes both when the path is set via `url.URL.Path`, confirmed by a table test that passes identically before and after.

What was real is `..`. The item was appended with `path.Join`, which *resolves* a `..` silently rather than treating it as the traversal it is. Verified by mutation:

```
expected "/api/admin/api-tokens/..%2F..%2F..%2Fapi%2Fadmin%2Fuser"
got      "/api/admin/user"
```

A token name reaching a different admin endpoint, with the admin token on the request. `itemURL` now escapes the segment, keeps it out of `path.Join`, and refuses an item that is nothing but dots — there is no name it could be.

## https required on the federation provisioning path

Federated URLs come from `Unleash.PublicApiURL()`, which is `https://%s` by construction, so nothing legitimate is refused. Without the check, `http://169.254.169.254/computeMetadata/v1/` provisioned a RemoteUnleash and wrote an admin secret — verified.

Placed **inside** the effective-`Provisioned` branch, after the cluster-list logic, so a dropped-cluster deprovision still happens. Removals are deliberately not checked: a resource federated before this shipped could otherwise never be deleted, which is the orphan bug #801 just closed.

## #750 — the allowlist was declined, deliberately

The issue asks for an allowlist of served namespaces. **Not shipped.** Tenant namespaces are created and retired continuously, so an operator-side list goes stale and starts dropping legitimate messages — *including removals*, which reintroduces #800. That is worse than the threat it addresses.

What is enforced instead: namespaces that can never be a tenant — the operator's own namespace, the reserved `kube-` prefix, blank/whitespace entries (mirroring #801's cluster-list trimming), and names Kubernetes cannot accept. Counted by `unleasherator_federation_rejected_namespaces_total{reason}`.

**The operator namespace is the one that mattered**, and it was a concrete break of the documented confused-deputy control. A RemoteUnleash created there references its admin secret *same-namespace*, skipping the authorized-namespace gate entirely. In the legacy layout the secret name is `unleasherator-<name>-<nonce>` with **both fields publisher-supplied**, so `name="foo-teamb-admin"` + `nonce="key-abc"` yields `unleasherator-foo-teamb-admin-key-abc` — the exact shape of another tenant's namespace-bound managed secret in the operator namespace. That secret was upserted with no guard at all, because the credential check only runs when a RemoteUnleash already exists at the incoming key, and none does.

Namespace-bound mode is structurally safe from this: the collision requires the victim's own name/namespace tuple, which the RemoteUnleash then guards.

## #747 — the claim no longer holds

The code the issue describes is gone. Both federation branches already compare the stored credential after the URL check, on provisioning and removal; `SECURITY.md:162` documents it. The guard predates #801 — it arrived with #782/#785.

Nothing was restated. One direct unit test was added because the only coverage of the *provisioning* side was an envtest case where removing the guard fails for several reasons at once. **It is a guard, not evidence of a new fix — it passes on unmodified main**, and is labelled as such.

## Three controls judged too risky to ship

Documented in `SECURITY.md` rather than left as folklore:

- **`^https://` on the Unleash CRD.** The management cluster reaches its own instances at `http://<name>.<namespace>` and builds a client with the admin token there. Plaintext is load-bearing, and the change would make existing resources unpatchable.
- **An IP denylist in the dialer.** That same in-cluster path is a private ClusterIP, so blocking RFC1918 breaks the operator outright. And on-prem sets `HTTPS_PROXY=http://webproxy-nais.nav.no:8088`, where the dialer only ever sees the proxy — the control would be simultaneously ineffective and liable to block the proxy itself.
- **A host allowlist.** No such list exists; tenants use their own hostnames.

Worth recording: for tenant-authored RemoteUnleash the real control already exists. Every operator-managed secret carries a `url` key and validation requires the spec URL to equal it, so a tenant cannot redirect a managed credential regardless of the CRD pattern.

## Verification

`go build ./...` exit 0 · `go vet -tags integration_test ./...` exit 0 · `make test` exit 0 (controller cov 70.1%, federation 89.2%, unleashclient 72.0%).

Every #801 guard re-run explicitly and passing: token rotation, URL mismatch, staleness, empty cluster name, missing admin secret, removal reaching unnamed clusters, deprovisioning a dropped cluster, blank/padded cluster entries.

Also flips `mockRemoteUnleashURL` to https — three envtest federation cases used http.