### PR TITLE
fix(releasechannel): recover timed out rollouts

### DIFF
--- a/api/v1/releasechannel_types.go
+++ b/api/v1/releasechannel_types.go
@@ -31,6 +31,14 @@ type ReleaseChannelSpec struct {
 	// where the older image genuinely is the intended target.
 	// +kubebuilder:default=false
 	AllowDowngrade bool `json:"allowDowngrade,omitempty"`
+
+	// BreakGlassImage assigns this exact target image to every remaining
+	// instance immediately, bypassing canary, maxParallel, batch interval, and
+	// health gates between assignments. Readiness and health status are still
+	// observed after assignment. The value must equal spec.image, which binds
+	// the emergency approval to one image and prevents it carrying into the
+	// next rollout. Clear it after the fleet has recovered.
+	BreakGlassImage UnleashImage `json:"breakGlassImage,omitempty"`
 }
 
 type ReleaseChannelStrategy struct {
@@ -289,7 +297,8 @@ func (rc *ReleaseChannel) ValidateUpdate(old runtime.Object) error {
 	if oldRC.Status.Phase != ReleaseChannelPhaseIdle &&
 		oldRC.Status.Phase != ReleaseChannelPhaseCompleted &&
 		oldRC.Status.Phase != ReleaseChannelPhaseFailed &&
-		rc.Spec.Image != oldRC.Spec.Image {
+		rc.Spec.Image != oldRC.Spec.Image &&
+		(rc.Spec.BreakGlassImage == "" || rc.Spec.BreakGlassImage != rc.Spec.Image) {
 		return fmt.Errorf("cannot change image during active rollout (current phase: %s)", oldRC.Status.Phase)
 	}
 
@@ -315,6 +324,10 @@ func (rc *ReleaseChannel) validate() error {
 	// Validate image format (basic validation)
 	if string(rc.Spec.Image) == "" {
 		return fmt.Errorf("image cannot be empty")
+	}
+
+	if rc.Spec.BreakGlassImage != "" && rc.Spec.BreakGlassImage != rc.Spec.Image {
+		return fmt.Errorf("breakGlassImage must equal image")
 	}
 
 	// Validate maxParallel bounds

--- a/api/v1/releasechannel_types_test.go
+++ b/api/v1/releasechannel_types_test.go
@@ -161,3 +161,66 @@ func TestShouldUpdate(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateBreakGlassImage(t *testing.T) {
+	testCases := []struct {
+		name            string
+		image           UnleashImage
+		breakGlassImage UnleashImage
+		wantError       bool
+	}{
+		{
+			name:            "accepts break glass for the target image",
+			image:           "registry.example/unleash:v2",
+			breakGlassImage: "registry.example/unleash:v2",
+		},
+		{
+			name:            "rejects break glass for another image",
+			image:           "registry.example/unleash:v2",
+			breakGlassImage: "registry.example/unleash:v1",
+			wantError:       true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			releaseChannel := &ReleaseChannel{
+				Spec: ReleaseChannelSpec{
+					Image:           testCase.image,
+					BreakGlassImage: testCase.breakGlassImage,
+					Strategy:        ReleaseChannelStrategy{MaxParallel: 1},
+				},
+			}
+
+			err := releaseChannel.ValidateCreate()
+			if testCase.wantError && err == nil {
+				t.Fatal("ValidateCreate() error = nil, want error")
+			}
+			if !testCase.wantError && err != nil {
+				t.Fatalf("ValidateCreate() error = %v, want nil", err)
+			}
+		})
+	}
+}
+
+func TestValidateUpdateAllowsImageChangeOnlyWithBreakGlassDuringRollout(t *testing.T) {
+	oldReleaseChannel := &ReleaseChannel{
+		Spec: ReleaseChannelSpec{
+			Image:    "registry.example/unleash:v1",
+			Strategy: ReleaseChannelStrategy{MaxParallel: 1},
+		},
+		Status: ReleaseChannelStatus{Phase: ReleaseChannelPhaseRolling},
+	}
+
+	normalUpdate := oldReleaseChannel.DeepCopy()
+	normalUpdate.Spec.Image = "registry.example/unleash:v2"
+	if err := normalUpdate.ValidateUpdate(oldReleaseChannel); err == nil {
+		t.Fatal("ValidateUpdate() error = nil for an unapproved image change during rollout")
+	}
+
+	breakGlassUpdate := normalUpdate.DeepCopy()
+	breakGlassUpdate.Spec.BreakGlassImage = breakGlassUpdate.Spec.Image
+	if err := breakGlassUpdate.ValidateUpdate(oldReleaseChannel); err != nil {
+		t.Fatalf("ValidateUpdate() error = %v for a matching break-glass image", err)
+	}
+}

--- a/charts/unleasherator-crds/templates/releasechannel-crd.yaml
+++ b/charts/unleasherator-crds/templates/releasechannel-crd.yaml
@@ -69,6 +69,15 @@ spec:
                   reverts belong in rollback; this is the escape hatch for the rare case
                   where the older image genuinely is the intended target.
                 type: boolean
+              breakGlassImage:
+                description: |-
+                  BreakGlassImage assigns this exact target image to every remaining
+                  instance immediately, bypassing canary, maxParallel, batch interval, and
+                  health gates between assignments. Readiness and health status are still
+                  observed after assignment. The value must equal spec.image, which binds
+                  the emergency approval to one image and prevents it carrying into the
+                  next rollout. Clear it after the fleet has recovered.
+                type: string
               healthChecks:
                 description: HealthChecks defines health validation configuration
                 properties:

--- a/config/crd/bases/unleash.nais.io_releasechannels.yaml
+++ b/config/crd/bases/unleash.nais.io_releasechannels.yaml
@@ -68,6 +68,15 @@ spec:
                   reverts belong in rollback; this is the escape hatch for the rare case
                   where the older image genuinely is the intended target.
                 type: boolean
+              breakGlassImage:
+                description: |-
+                  BreakGlassImage assigns this exact target image to every remaining
+                  instance immediately, bypassing canary, maxParallel, batch interval, and
+                  health gates between assignments. Readiness and health status are still
+                  observed after assignment. The value must equal spec.image, which binds
+                  the emergency approval to one image and prevents it carrying into the
+                  next rollout. Clear it after the fleet has recovered.
+                type: string
               healthChecks:
                 description: HealthChecks defines health validation configuration
                 properties:

--- a/docs/releasechannel.md
+++ b/docs/releasechannel.md
@@ -156,6 +156,70 @@ spec:
 
 The manual override takes precedence, but the ReleaseChannel connection is preserved for when you remove the override.
 
+### Break-glass roll-forward
+
+Use `spec.breakGlassImage` only when waiting for canaries, batches, or health
+gates causes more harm than deploying a known-good image immediately. The
+controller assigns the image to every remaining instance in the first assignment
+reconciliation. It continues to report readiness and health after assignment,
+but it does not wait for one batch before assigning the next. Break glass also
+ignores `maxUpgradeTime` while assignments are being made; it does not disable
+readiness or configured health checks after assignment.
+
+`breakGlassImage` must exactly match `spec.image`. This binds the override to one
+image and prevents it from applying to a later release. Downgrade protection
+remains active; add `allowDowngrade: true` only when the emergency target is
+older than the image most instances run.
+
+Before using break glass:
+
+1. Confirm the target image exists and is signed.
+2. Confirm required environment variables, secrets, service accounts, and
+   network policies are present on every target instance.
+3. Record the current image and `status.previousImage`.
+4. Have another maintainer approve the command and monitor the rollout.
+
+Assign a new image to the whole channel immediately:
+
+```bash
+namespace=bifrost-unleash
+channel=stable-v7
+image=europe-north1-docker.pkg.dev/nais-io/nais/images/nais-unleash:v7-7.5.1-example
+
+kubectl patch releasechannel "$channel" -n "$namespace" --type=merge \
+  -p "{\"spec\":{\"image\":\"$image\",\"breakGlassImage\":\"$image\"}}"
+```
+
+For an intentional downgrade, include the separate downgrade acknowledgement:
+
+```bash
+kubectl patch releasechannel "$channel" -n "$namespace" --type=merge \
+  -p "{\"spec\":{\"image\":\"$image\",\"breakGlassImage\":\"$image\",\"allowDowngrade\":true}}"
+```
+
+Monitor assignments and availability until all instances report the target:
+
+```bash
+kubectl get releasechannel "$channel" -n "$namespace" -w
+kubectl get unleash -n "$namespace" \
+  -o custom-columns=NAME:.metadata.name,IMAGE:.status.resolvedReleaseChannelImage,READY:.status.reconciled,CONNECTED:.status.connected
+```
+
+Clear the override as soon as the fleet has recovered. Also restore
+`allowDowngrade` if it was enabled:
+
+```bash
+kubectl patch releasechannel "$channel" -n "$namespace" --type=json \
+  -p='[
+    {"op":"remove","path":"/spec/breakGlassImage"},
+    {"op":"replace","path":"/spec/allowDowngrade","value":false}
+  ]'
+```
+
+If `allowDowngrade` was absent before the incident, omit the second operation.
+Do not edit `status.instanceImages` directly. The controller owns that map and
+will overwrite manual status changes.
+
 ## kubectl Apply Safety
 
 One of the key benefits of ReleaseChannels is protection against accidental configuration loss during `kubectl apply` operations.
@@ -329,6 +393,18 @@ kubectl get unleash -l releaseChannel=beta
 kubectl patch releasechannel stable --type='merge' -p='{\"spec\":{\"image\":\"quay.io/unleash/unleash-server:6.4.0\"}}'
 ```
 
+For changes that introduce a required dependency or credential, deploy
+compatibility in separate releases:
+
+1. Provision the new environment variables, secrets, and network policies while
+   the old application still ignores them.
+2. Verify those resources across the full fleet.
+3. Roll out an application version that can use the new dependency.
+4. Remove the old path only after every instance is healthy on the new version.
+
+Never merge the provisioning and mandatory-consumer changes into a rollout that
+can reach production in either order.
+
 ## Troubleshooting
 
 ### Common Issues
@@ -424,8 +500,10 @@ limit nobody configured.
 When `spec.strategy.maxUpgradeTime` is unset the budget is derived from the work
 the rollout actually has to do: `ceil(instances / maxParallel)` batches, each
 allowed `healthChecks.initialDelay + healthChecks.timeout + strategy.batchInterval`
-(6 minutes on the defaults). A flat wall clock is generous for three instances and
-impossible for sixty-five, which is why it scales.
+(6 minutes on the defaults). The controller adds 30 seconds per batch and one
+final 30-second allowance for reconciliation and completion observation. A
+three-instance rollout with `maxParallel: 1` therefore gets 20 minutes rather
+than failing at the exact 18-minute batch boundary.
 
 The derivation is floored at 10 minutes so small fleets never get less budget than
 before, and capped at 2 hours so a wedged rollout is still caught rather than
@@ -447,6 +525,10 @@ that advances no instance at all stops. Channels with `spec.rollback.enabled` an
 a known baseline roll back on a timeout instead, which is what that setting asks
 for.
 
+Increasing `spec.strategy.maxUpgradeTime` beyond the elapsed rollout time also
+restarts a channel that already stopped in `Failed`. This makes the override
+named in the failure message an effective recovery action.
+
 **Solutions:**
 
 1. See what the rollout was given and why:
@@ -455,7 +537,7 @@ for.
    kubectl get releasechannel stable -o jsonpath='{.status.failureReason}'
    ```
 
-2. Raise `maxParallel` — fewer batches means a larger budget and a faster rollout:
+2. Raise `maxParallel` to reduce the number of batches and rollout duration:
 
    ```bash
    kubectl patch releasechannel stable --type='merge' -p='{"spec":{"strategy":{"maxParallel":5}}}'
@@ -466,6 +548,11 @@ for.
    ```bash
    kubectl patch releasechannel stable --type='merge' -p='{"spec":{"strategy":{"maxUpgradeTime":"3h"}}}'
    ```
+
+For managed tenants, set the matching per-version `maxUpgradeTime` Fasit value
+instead of patching the resource directly. Fasit preserves the override across
+chart reconciliations and provides the audit trail. Clear the value after the
+rollout completes to return to the derived default.
 
 #### Rollout Cannot Be Rolled Back
 

--- a/internal/controller/releasechannel_controller.go
+++ b/internal/controller/releasechannel_controller.go
@@ -931,18 +931,6 @@ func (r *ReleaseChannelReconciler) executeValidatingPhase(ctx context.Context, r
 func (r *ReleaseChannelReconciler) executeCanaryPhase(ctx context.Context, releaseChannel *unleashv1.ReleaseChannel, log logr.Logger) (ctrl.Result, error) {
 	log.Info("Executing canary phase")
 
-	// Check if we've exceeded maxUpgradeTime
-	if exceeded, reason := r.checkMaxUpgradeTimeExceeded(releaseChannel); exceeded && !breakGlassEnabled(releaseChannel) {
-		budget, derivation := upgradeTimeBudget(releaseChannel)
-		log.Info("Canary phase exceeded maxUpgradeTime", "reason", reason, "budget", budget, "derivation", derivation)
-		newPhase := releasePhaseOnFailure(releaseChannel)
-		r.recordPhaseTransition(releaseChannel, newPhase)
-		releaseChannel.Status.Phase = newPhase
-		releaseChannel.Status.FailureReason = reason
-		r.Recorder.Event(releaseChannel, "Warning", "RolloutTimeout", reason)
-		return r.updateReleaseChannelStatus(ctx, releaseChannel)
-	}
-
 	targetInstances, err := r.getTargetInstances(ctx, releaseChannel)
 	if err != nil {
 		releaseChannel.Status.Phase = unleashv1.ReleaseChannelPhaseFailed
@@ -952,6 +940,18 @@ func (r *ReleaseChannelReconciler) executeCanaryPhase(ctx context.Context, relea
 
 	if result, refused, err := r.refuseDowngrade(ctx, releaseChannel, targetInstances, log); refused {
 		return result, err
+	}
+
+	// Break glass bypasses the timeout only until every pending assignment is made.
+	if exceeded, reason := r.checkMaxUpgradeTimeExceeded(releaseChannel); exceeded && !breakGlassAssignmentsNeeded(targetInstances, releaseChannel) {
+		budget, derivation := upgradeTimeBudget(releaseChannel)
+		log.Info("Canary phase exceeded maxUpgradeTime", "reason", reason, "budget", budget, "derivation", derivation)
+		newPhase := releasePhaseOnFailure(releaseChannel)
+		r.recordPhaseTransition(releaseChannel, newPhase)
+		releaseChannel.Status.Phase = newPhase
+		releaseChannel.Status.FailureReason = reason
+		r.Recorder.Event(releaseChannel, "Warning", "RolloutTimeout", reason)
+		return r.updateReleaseChannelStatus(ctx, releaseChannel)
 	}
 
 	// Check for target image changes during canary phase and track previous image
@@ -1051,19 +1051,6 @@ func (r *ReleaseChannelReconciler) executeCanaryPhase(ctx context.Context, relea
 func (r *ReleaseChannelReconciler) executeRollingPhase(ctx context.Context, releaseChannel *unleashv1.ReleaseChannel, log logr.Logger) (ctrl.Result, error) {
 	log.Info("Executing rolling phase")
 
-	// Check if we've exceeded maxUpgradeTime
-	if exceeded, reason := r.checkMaxUpgradeTimeExceeded(releaseChannel); exceeded && !breakGlassEnabled(releaseChannel) {
-		budget, derivation := upgradeTimeBudget(releaseChannel)
-		log.Info("Rolling phase exceeded maxUpgradeTime", "reason", reason, "budget", budget, "derivation", derivation)
-		newPhase := releasePhaseOnFailure(releaseChannel)
-		r.recordPhaseTransition(releaseChannel, newPhase)
-		releaseChannel.Status.Phase = newPhase
-		releaseChannel.Status.ActiveBatch = nil
-		releaseChannel.Status.FailureReason = reason
-		r.Recorder.Event(releaseChannel, "Warning", "RolloutTimeout", reason)
-		return r.updateReleaseChannelStatus(ctx, releaseChannel)
-	}
-
 	targetInstances, err := r.getTargetInstances(ctx, releaseChannel)
 	if err != nil {
 		newPhase := unleashv1.ReleaseChannelPhaseFailed
@@ -1082,6 +1069,19 @@ func (r *ReleaseChannelReconciler) executeRollingPhase(ctx context.Context, rele
 
 	if result, refused, err := r.refuseDowngrade(ctx, releaseChannel, targetInstances, log); refused {
 		return result, err
+	}
+
+	// Break glass bypasses the timeout only until every pending assignment is made.
+	if exceeded, reason := r.checkMaxUpgradeTimeExceeded(releaseChannel); exceeded && !breakGlassAssignmentsNeeded(targetInstances, releaseChannel) {
+		budget, derivation := upgradeTimeBudget(releaseChannel)
+		log.Info("Rolling phase exceeded maxUpgradeTime", "reason", reason, "budget", budget, "derivation", derivation)
+		newPhase := releasePhaseOnFailure(releaseChannel)
+		r.recordPhaseTransition(releaseChannel, newPhase)
+		releaseChannel.Status.Phase = newPhase
+		releaseChannel.Status.ActiveBatch = nil
+		releaseChannel.Status.FailureReason = reason
+		r.Recorder.Event(releaseChannel, "Warning", "RolloutTimeout", reason)
+		return r.updateReleaseChannelStatus(ctx, releaseChannel)
 	}
 
 	// A rollout that starts here rather than in Idle still needs a rollback

--- a/internal/controller/releasechannel_controller.go
+++ b/internal/controller/releasechannel_controller.go
@@ -40,6 +40,9 @@ const (
 	// upgradeTimeoutReasonPrefix opens every failure reason written when the
 	// upgrade budget runs out, and is how that cause is recognised later.
 	upgradeTimeoutReasonPrefix = "Rollout exceeded maxUpgradeTime"
+	// releaseChannelReconciliationAllowance leaves room for one normal
+	// controller wake-up per batch and one final completion observation.
+	releaseChannelReconciliationAllowance = 30 * time.Second
 )
 
 var (
@@ -662,6 +665,24 @@ func (r *ReleaseChannelReconciler) executeFailedPhase(ctx context.Context, relea
 	// timeout — releasePhaseOnFailure sends those to RollingBack, which is the
 	// behaviour they asked for.
 	if isUpgradeTimeout(releaseChannel.Status.FailureReason) {
+		if releaseChannel.Status.StartTime != nil {
+			if exceeded, _ := r.checkMaxUpgradeTimeExceeded(releaseChannel); !exceeded {
+				log.Info("Resuming rollout after upgrade budget was increased",
+					"instancesUpToDate", releaseChannel.Status.InstancesUpToDate,
+					"previousFailure", releaseChannel.Status.FailureReason)
+				r.Recorder.Event(releaseChannel, "Normal", "RolloutBudgetIncreased",
+					"Resuming rollout because spec.strategy.maxUpgradeTime now exceeds the elapsed rollout time")
+				r.recordPhaseTransition(releaseChannel, unleashv1.ReleaseChannelPhaseIdle)
+				releaseChannel.Status.Phase = unleashv1.ReleaseChannelPhaseIdle
+				releaseChannel.Status.FailureReason = ""
+				releaseChannel.Status.FailedImage = ""
+				releaseChannel.Status.RetryCount = 0
+				releaseChannel.Status.LastFailureTime = nil
+				releaseChannel.Status.StartTime = nil
+				return r.updateReleaseChannelStatus(ctx, releaseChannel)
+			}
+		}
+
 		if releaseChannel.Status.InstancesUpToDate > releaseChannel.Status.ResumeProgress {
 			log.Info("Resuming rollout that ran out of budget but is still progressing",
 				"instancesUpToDate", releaseChannel.Status.InstancesUpToDate,
@@ -911,7 +932,7 @@ func (r *ReleaseChannelReconciler) executeCanaryPhase(ctx context.Context, relea
 	log.Info("Executing canary phase")
 
 	// Check if we've exceeded maxUpgradeTime
-	if exceeded, reason := r.checkMaxUpgradeTimeExceeded(releaseChannel); exceeded {
+	if exceeded, reason := r.checkMaxUpgradeTimeExceeded(releaseChannel); exceeded && !breakGlassEnabled(releaseChannel) {
 		budget, derivation := upgradeTimeBudget(releaseChannel)
 		log.Info("Canary phase exceeded maxUpgradeTime", "reason", reason, "budget", budget, "derivation", derivation)
 		newPhase := releasePhaseOnFailure(releaseChannel)
@@ -936,6 +957,15 @@ func (r *ReleaseChannelReconciler) executeCanaryPhase(ctx context.Context, relea
 	// Check for target image changes during canary phase and track previous image
 	if _, err := r.ensurePreviousImageTracked(ctx, releaseChannel, targetInstances, log); err != nil {
 		return ctrl.Result{RequeueAfter: releaseChannelErrorRetryDelay}, err
+	}
+
+	if breakGlassAssignmentsNeeded(targetInstances, releaseChannel) {
+		log.Info("Break-glass rollout requested during canary; assigning target image to every remaining instance",
+			"targetImage", releaseChannel.Spec.Image,
+			"instances", len(targetInstances))
+		r.Recorder.Event(releaseChannel, "Warning", "BreakGlassRollout",
+			fmt.Sprintf("Assigning %s to all %d instances without progressive rollout gates", releaseChannel.Spec.Image, len(targetInstances)))
+		return r.deployToInstances(ctx, releaseChannel, targetInstances, log)
 	}
 
 	// Identify canary instances
@@ -1022,7 +1052,7 @@ func (r *ReleaseChannelReconciler) executeRollingPhase(ctx context.Context, rele
 	log.Info("Executing rolling phase")
 
 	// Check if we've exceeded maxUpgradeTime
-	if exceeded, reason := r.checkMaxUpgradeTimeExceeded(releaseChannel); exceeded {
+	if exceeded, reason := r.checkMaxUpgradeTimeExceeded(releaseChannel); exceeded && !breakGlassEnabled(releaseChannel) {
 		budget, derivation := upgradeTimeBudget(releaseChannel)
 		log.Info("Rolling phase exceeded maxUpgradeTime", "reason", reason, "budget", budget, "derivation", derivation)
 		newPhase := releasePhaseOnFailure(releaseChannel)
@@ -1062,6 +1092,15 @@ func (r *ReleaseChannelReconciler) executeRollingPhase(ctx context.Context, rele
 	// so calling this once a batch has moved on is a no-op.
 	if _, err := r.ensurePreviousImageTracked(ctx, releaseChannel, targetInstances, log); err != nil {
 		return ctrl.Result{RequeueAfter: releaseChannelErrorRetryDelay}, err
+	}
+
+	if breakGlassAssignmentsNeeded(targetInstances, releaseChannel) {
+		log.Info("Break-glass rollout requested; assigning target image to every remaining instance",
+			"targetImage", releaseChannel.Spec.Image,
+			"instances", len(targetInstances))
+		r.Recorder.Event(releaseChannel, "Warning", "BreakGlassRollout",
+			fmt.Sprintf("Assigning %s to all %d instances without rollout gates", releaseChannel.Spec.Image, len(targetInstances)))
+		return r.deployToInstances(ctx, releaseChannel, targetInstances, log)
 	}
 
 	if releaseChannel.Status.ActiveBatch == nil {
@@ -1544,6 +1583,24 @@ func activeBatchInstances(instances []unleashv1.Unleash, batch *unleashv1.Releas
 	return active
 }
 
+func breakGlassEnabled(releaseChannel *unleashv1.ReleaseChannel) bool {
+	return releaseChannel.Spec.BreakGlassImage != "" &&
+		releaseChannel.Spec.BreakGlassImage == releaseChannel.Spec.Image
+}
+
+func breakGlassAssignmentsNeeded(instances []unleashv1.Unleash, releaseChannel *unleashv1.ReleaseChannel) bool {
+	if !breakGlassEnabled(releaseChannel) {
+		return false
+	}
+	targetImage := string(releaseChannel.Spec.Image)
+	for _, instance := range instances {
+		if releaseChannel.Status.InstanceImages[instance.Name] != targetImage {
+			return true
+		}
+	}
+	return false
+}
+
 // recoverActiveBatch preserves rollout safety when upgrading from a controller
 // version that assigned InstanceImages before ActiveBatch existed.
 func recoverActiveBatch(instances []unleashv1.Unleash, releaseChannel *unleashv1.ReleaseChannel) *unleashv1.ReleaseChannelActiveBatch {
@@ -1601,7 +1658,8 @@ func (r *ReleaseChannelReconciler) deployToInstances(ctx context.Context, releas
 		if fresh.Status.LastTargetImages == nil {
 			fresh.Status.LastTargetImages = make(map[string]string)
 		}
-		if fresh.Status.Phase == unleashv1.ReleaseChannelPhaseRolling && fresh.Status.ActiveBatch == nil {
+		if fresh.Status.Phase == unleashv1.ReleaseChannelPhaseRolling &&
+			(fresh.Status.ActiveBatch == nil || breakGlassEnabled(fresh)) {
 			instanceNames := make([]string, 0, len(instances))
 			for _, instance := range instances {
 				instanceNames = append(instanceNames, instance.Name)
@@ -1708,6 +1766,10 @@ func (r *ReleaseChannelReconciler) getExpectedImageForInstance(ctx context.Conte
 	}, releaseChannel)
 	if err != nil {
 		// If we can't get the release channel, expect the target image
+		return targetImage
+	}
+
+	if breakGlassEnabled(releaseChannel) {
 		return targetImage
 	}
 
@@ -2059,7 +2121,12 @@ func upgradeTimeBudget(releaseChannel *unleashv1.ReleaseChannel) (time.Duration,
 	batches := (instances + maxParallel - 1) / maxParallel
 
 	allowance := batchAllowance(releaseChannel)
-	budget := time.Duration(batches) * allowance
+	// Every batch needs at least one controller wake-up after its nominal
+	// allowance, and the rollout needs one final wake-up to observe completion.
+	// Without this control-plane margin a healthy rollout can exceed an exact
+	// N*allowance boundary by a second and fail before completion is recorded.
+	reconciliationAllowance := time.Duration(batches+1) * releaseChannelReconciliationAllowance
+	budget := time.Duration(batches)*allowance + reconciliationAllowance
 
 	if budget < releaseChannelDefaultMaxUpgradeTime {
 		budget = releaseChannelDefaultMaxUpgradeTime
@@ -2068,8 +2135,8 @@ func upgradeTimeBudget(releaseChannel *unleashv1.ReleaseChannel) (time.Duration,
 		budget = releaseChannelMaxDerivedUpgradeTime
 	}
 
-	derivation := fmt.Sprintf("derived from %d batch(es) of %s for %d instance(s) at maxParallel %d, capped at %s",
-		batches, allowance, instances, maxParallel, releaseChannelMaxDerivedUpgradeTime)
+	derivation := fmt.Sprintf("derived from %d batch(es) of %s plus %s reconciliation allowance for %d instance(s) at maxParallel %d, capped at %s",
+		batches, allowance, reconciliationAllowance, instances, maxParallel, releaseChannelMaxDerivedUpgradeTime)
 	if legacyDefault {
 		derivation += fmt.Sprintf("; the stored %s came from a removed CRD default and was treated as unset", releaseChannelLegacyDefaultMaxUpgradeTime)
 	}

--- a/internal/controller/releasechannel_controller.go
+++ b/internal/controller/releasechannel_controller.go
@@ -1769,13 +1769,13 @@ func (r *ReleaseChannelReconciler) getExpectedImageForInstance(ctx context.Conte
 		return targetImage
 	}
 
-	if breakGlassEnabled(releaseChannel) {
-		return targetImage
-	}
-
 	if releaseChannel.Status.Phase == unleashv1.ReleaseChannelPhaseRollingBack &&
 		releaseChannel.Spec.Rollback.PreviousImage != "" {
 		return releaseChannel.Spec.Rollback.PreviousImage
+	}
+
+	if breakGlassEnabled(releaseChannel) {
+		return targetImage
 	}
 
 	previousImage := string(releaseChannel.Status.PreviousImage)

--- a/internal/controller/releasechannel_controller_unit_test.go
+++ b/internal/controller/releasechannel_controller_unit_test.go
@@ -301,6 +301,27 @@ func TestGetExpectedImageForInstance(t *testing.T) {
 			expectedImage:        "test:v1.5",
 			releaseChannelExists: true,
 		},
+		{
+			name: "rollback phase takes precedence over break glass",
+			instance: &unleashv1.Unleash{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-unleash", Namespace: "default"},
+				Spec: unleashv1.UnleashSpec{
+					ReleaseChannel: unleashv1.UnleashReleaseChannelConfig{Name: "test-channel"},
+				},
+			},
+			targetImage: "test:v2",
+			releaseChannel: &unleashv1.ReleaseChannel{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-channel", Namespace: "default"},
+				Spec: unleashv1.ReleaseChannelSpec{
+					Image:           "test:v2",
+					BreakGlassImage: "test:v2",
+					Rollback:       unleashv1.RollbackConfig{PreviousImage: "test:v1.5"},
+				},
+				Status: unleashv1.ReleaseChannelStatus{Phase: unleashv1.ReleaseChannelPhaseRollingBack},
+			},
+			expectedImage:        "test:v1.5",
+			releaseChannelExists: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/controller/releasechannel_initial_deploy_test.go
+++ b/internal/controller/releasechannel_initial_deploy_test.go
@@ -125,6 +125,95 @@ func TestClearedInstanceStatusDoesNotBypassBatching(t *testing.T) {
 		"clearing instance status must not push the target image to the whole fleet at once")
 }
 
+func TestBreakGlassAssignsTargetToEntireFleet(t *testing.T) {
+	releaseChannel := &unleashv1.ReleaseChannel{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-rc", Namespace: "default"},
+		Spec: unleashv1.ReleaseChannelSpec{
+			Image:           unleashv1.UnleashImage(newerImage),
+			BreakGlassImage: unleashv1.UnleashImage(newerImage),
+			Strategy:        unleashv1.ReleaseChannelStrategy{MaxParallel: 1},
+		},
+		Status: unleashv1.ReleaseChannelStatus{
+			Phase: unleashv1.ReleaseChannelPhaseIdle,
+		},
+	}
+
+	updated := runIdleThenRolling(t, releaseChannel, newUnresolvedFleet(3))
+
+	assert.Len(t, updated.Status.InstanceImages, 3)
+	for _, image := range updated.Status.InstanceImages {
+		assert.Equal(t, newerImage, image)
+	}
+	require.NotNil(t, updated.Status.ActiveBatch)
+	assert.Len(t, updated.Status.ActiveBatch.InstanceNames, 3)
+}
+
+func TestBreakGlassReplacesActiveBatch(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, unleashv1.AddToScheme(scheme))
+
+	releaseChannel := &unleashv1.ReleaseChannel{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-rc", Namespace: "default"},
+		Spec: unleashv1.ReleaseChannelSpec{
+			Image:           unleashv1.UnleashImage(newerImage),
+			BreakGlassImage: unleashv1.UnleashImage(newerImage),
+			Strategy:        unleashv1.ReleaseChannelStrategy{MaxParallel: 1},
+		},
+		Status: unleashv1.ReleaseChannelStatus{
+			Phase: unleashv1.ReleaseChannelPhaseRolling,
+			InstanceImages: map[string]string{
+				"instance-0": deployedImage,
+				"instance-1": deployedImage,
+				"instance-2": deployedImage,
+			},
+			ActiveBatch: &unleashv1.ReleaseChannelActiveBatch{
+				InstanceNames: []string{"instance-0"},
+				TargetImage:   deployedImage,
+				StartTime:     metav1.Now(),
+			},
+		},
+	}
+	instances := newUnresolvedFleet(3)
+	objects := []client.Object{releaseChannel}
+	for i := range instances {
+		objects = append(objects, &instances[i])
+	}
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(objects...).
+		WithStatusSubresource(releaseChannel).
+		Build()
+	reconciler := &ReleaseChannelReconciler{
+		Client:   fakeClient,
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(20),
+	}
+
+	_, err := reconciler.executeRollingPhase(context.Background(), releaseChannel, ctrl.Log.WithName("test"))
+	require.NoError(t, err)
+
+	updated := &unleashv1.ReleaseChannel{}
+	require.NoError(t, fakeClient.Get(context.Background(), releaseChannel.NamespacedName(), updated))
+	assert.Len(t, updated.Status.InstanceImages, 3)
+	for _, image := range updated.Status.InstanceImages {
+		assert.Equal(t, newerImage, image)
+	}
+	require.NotNil(t, updated.Status.ActiveBatch)
+	assert.Len(t, updated.Status.ActiveBatch.InstanceNames, 3)
+	assert.Equal(t, newerImage, updated.Status.ActiveBatch.TargetImage)
+}
+
+func TestBreakGlassDoesNotPermitDowngrade(t *testing.T) {
+	releaseChannel, instance := newDowngradeFixture(olderImage, false)
+	releaseChannel.Spec.BreakGlassImage = unleashv1.UnleashImage(olderImage)
+
+	updated := runIdleThenRolling(t, releaseChannel, []unleashv1.Unleash{*instance})
+
+	assert.Equal(t, unleashv1.ReleaseChannelPhaseIdle, updated.Status.Phase,
+		"downgrade protection refuses the rollout and returns the channel to Idle")
+	assert.NotEqual(t, olderImage, updated.Status.InstanceImages[instance.Name])
+}
+
 func TestUpToDateInstancesAreAdoptedIntoInstanceImages(t *testing.T) {
 	scheme := runtime.NewScheme()
 	require.NoError(t, unleashv1.AddToScheme(scheme))

--- a/internal/controller/releasechannel_timeout_test.go
+++ b/internal/controller/releasechannel_timeout_test.go
@@ -16,9 +16,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
-// newBudgetChannel pins every input to batchAllowance so the expected budget does
-// not depend on package-level timing vars, which the envtest suite rewrites.
-// settle 1m + verify 4m + interval 1m gives a 6m allowance per batch.
+// newBudgetChannel pins every configurable input to batchAllowance so the
+// expected budget does not depend on package-level timing vars, which the
+// envtest suite rewrites. Settle 1m + verify 4m + interval 1m gives a 6m
+// allowance per batch before the fixed reconciliation allowance is added.
 func newBudgetChannel(instances, maxParallel int, maxUpgradeTime *metav1.Duration) *unleashv1.ReleaseChannel {
 	return &unleashv1.ReleaseChannel{
 		ObjectMeta: metav1.ObjectMeta{Name: "test-rc", Namespace: "default"},
@@ -62,7 +63,14 @@ func TestUpgradeTimeBudget(t *testing.T) {
 			name:          "scales with the number of batches",
 			instances:     5,
 			maxParallel:   1,
-			expected:      30 * time.Minute,
+			expected:      33 * time.Minute,
+			expectDerived: true,
+		},
+		{
+			name:          "includes reconciliation margin for three serial batches",
+			instances:     3,
+			maxParallel:   1,
+			expected:      20 * time.Minute,
 			expectDerived: true,
 		},
 		{
@@ -70,7 +78,7 @@ func TestUpgradeTimeBudget(t *testing.T) {
 			name:          "maxParallel divides the work",
 			instances:     65,
 			maxParallel:   10,
-			expected:      42 * time.Minute,
+			expected:      46 * time.Minute,
 			expectDerived: true,
 		},
 		{
@@ -116,7 +124,8 @@ func TestUpgradeTimeBudget(t *testing.T) {
 func TestCheckMaxUpgradeTimeExceededReportsDerivation(t *testing.T) {
 	r := &ReleaseChannelReconciler{}
 
-	// 5 batches of 6m is a 30m budget, so a rollout 20 minutes in is still fine
+	// 5 batches of 6m plus reconciliation allowance is a 33m budget, so a
+	// rollout 20 minutes in is still fine
 	// where the old flat 10m default would already have failed it.
 	releaseChannel := newBudgetChannel(5, 1, nil)
 	releaseChannel.Status.StartTime = &metav1.Time{Time: time.Now().Add(-20 * time.Minute)}
@@ -125,7 +134,7 @@ func TestCheckMaxUpgradeTimeExceededReportsDerivation(t *testing.T) {
 	assert.False(t, exceeded, "a five batch rollout must get more than the flat default")
 	assert.Empty(t, reason)
 
-	releaseChannel.Status.StartTime = &metav1.Time{Time: time.Now().Add(-31 * time.Minute)}
+	releaseChannel.Status.StartTime = &metav1.Time{Time: time.Now().Add(-34 * time.Minute)}
 	exceeded, reason = r.checkMaxUpgradeTimeExceeded(releaseChannel)
 	require.True(t, exceeded)
 	// An operator seeing a limit they never set needs the arithmetic and the
@@ -352,7 +361,10 @@ func timedOutChannel(t *testing.T, instancesUpToDate, resumeProgress int) (*Rele
 	releaseChannel := &unleashv1.ReleaseChannel{
 		ObjectMeta: metav1.ObjectMeta{Name: "test-rc", Namespace: "default"},
 		Spec: unleashv1.ReleaseChannelSpec{
-			Image:    unleashv1.UnleashImage(newerImage),
+			Image: unleashv1.UnleashImage(newerImage),
+			Strategy: unleashv1.ReleaseChannelStrategy{
+				MaxUpgradeTime: &metav1.Duration{Duration: releaseChannelLegacyDefaultMaxUpgradeTime},
+			},
 			Rollback: unleashv1.RollbackConfig{Enabled: false},
 		},
 		Status: unleashv1.ReleaseChannelStatus{
@@ -408,6 +420,20 @@ func TestExecuteFailedPhaseStopsARolloutThatIsNotProgressing(t *testing.T) {
 
 	assert.Equal(t, unleashv1.ReleaseChannelPhaseFailed, reload().Status.Phase,
 		"a rollout that advanced nothing must stop rather than resume forever")
+}
+
+func TestExecuteFailedPhaseResumesAfterBudgetIncrease(t *testing.T) {
+	reconciler, releaseChannel, reload := timedOutChannel(t, 7, 7)
+	releaseChannel.Spec.Strategy.MaxUpgradeTime = &metav1.Duration{Duration: 2 * time.Hour}
+
+	_, err := reconciler.executeFailedPhase(context.Background(), releaseChannel, ctrl.Log.WithName("test"))
+	require.NoError(t, err)
+
+	updated := reload()
+	assert.Equal(t, unleashv1.ReleaseChannelPhaseIdle, updated.Status.Phase,
+		"increasing maxUpgradeTime beyond elapsed time must apply the remedy named in the failure message")
+	assert.Empty(t, updated.Status.FailureReason)
+	assert.Nil(t, updated.Status.StartTime)
 }
 
 func TestTimeoutRollsBackOnSpecOnlyRollbackImage(t *testing.T) {

--- a/internal/controller/releasechannel_timeout_test.go
+++ b/internal/controller/releasechannel_timeout_test.go
@@ -363,7 +363,7 @@ func timedOutChannel(t *testing.T, instancesUpToDate, resumeProgress int) (*Rele
 		Spec: unleashv1.ReleaseChannelSpec{
 			Image: unleashv1.UnleashImage(newerImage),
 			Strategy: unleashv1.ReleaseChannelStrategy{
-				MaxUpgradeTime: &metav1.Duration{Duration: releaseChannelLegacyDefaultMaxUpgradeTime},
+				MaxUpgradeTime: &metav1.Duration{Duration: 9 * time.Minute},
 			},
 			Rollback: unleashv1.RollbackConfig{Enabled: false},
 		},


### PR DESCRIPTION
Adds reconciliation margin to derived rollout budgets, resumes timed-out channels after an explicit budget increase, and adds image-scoped break-glass rollout support with CRD, tests, and runbook updates.