### PR TITLE
fix/non blocking releasechannel rollouts

### DIFF
--- a/internal/controller/releasechannel_controller.go
+++ b/internal/controller/releasechannel_controller.go
@@ -1005,6 +1005,14 @@ func (r *ReleaseChannelReconciler) executeCanaryPhase(ctx context.Context, relea
 	r.recordMetrics(releaseChannel, labels)
 
 	// Check if canary deployment is complete
+	if err := r.terminalInstanceFailure(ctx, canaryInstances); err != nil {
+		newPhase := releasePhaseOnFailure(releaseChannel)
+		r.recordPhaseTransition(releaseChannel, newPhase)
+		releaseChannel.Status.Phase = newPhase
+		releaseChannel.Status.FailureReason = fmt.Sprintf("Canary deployment failed: %v", err)
+		r.recordMetrics(releaseChannel, labels)
+		return r.updateReleaseChannelStatus(ctx, releaseChannel)
+	}
 	canaryComplete := r.areInstancesReady(ctx, canaryInstances, string(releaseChannel.Spec.Image), true, log)
 	if !canaryComplete {
 		log.Info("Canary instances not ready yet")
@@ -1134,6 +1142,15 @@ func (r *ReleaseChannelReconciler) executeRollingPhase(ctx context.Context, rele
 		if targetImage == "" {
 			targetImage = string(releaseChannel.Spec.Image)
 		}
+		if err := r.terminalInstanceFailure(ctx, batch); err != nil {
+			newPhase := releasePhaseOnFailure(releaseChannel)
+			r.recordPhaseTransition(releaseChannel, newPhase)
+			releaseChannel.Status.Phase = newPhase
+			releaseChannel.Status.ActiveBatch = nil
+			releaseChannel.Status.FailureReason = fmt.Sprintf("Rolling deployment failed: %v", err)
+			r.recordMetrics(releaseChannel, labels)
+			return r.updateReleaseChannelStatus(ctx, releaseChannel)
+		}
 		if !r.areInstancesReady(ctx, batch, targetImage, true, log) {
 			log.Info("Active batch instances are not ready yet", "batchSize", len(batch))
 			return ctrl.Result{RequeueAfter: r.getBackoffDuration(releaseChannel)}, nil
@@ -1180,6 +1197,14 @@ func (r *ReleaseChannelReconciler) executeRollingPhase(ctx context.Context, rele
 	// Get instances that need updates (excluding already updated canary instances)
 	instancesToUpdate := r.getInstancesToUpdate(targetInstances, releaseChannel)
 	if len(instancesToUpdate) == 0 {
+		if err := r.terminalInstanceFailure(ctx, targetInstances); err != nil {
+			newPhase := releasePhaseOnFailure(releaseChannel)
+			r.recordPhaseTransition(releaseChannel, newPhase)
+			releaseChannel.Status.Phase = newPhase
+			releaseChannel.Status.FailureReason = fmt.Sprintf("Rolling deployment failed: %v", err)
+			r.recordMetrics(releaseChannel, labels)
+			return r.updateReleaseChannelStatus(ctx, releaseChannel)
+		}
 		if !r.areInstancesReady(ctx, targetInstances, string(releaseChannel.Spec.Image), true, log) {
 			log.Info("Instances have the target image but are not ready yet")
 			return ctrl.Result{RequeueAfter: r.getBackoffDuration(releaseChannel)}, nil
@@ -1312,6 +1337,12 @@ func (r *ReleaseChannelReconciler) executeRollingBackPhase(ctx context.Context, 
 	log.Info("Updated InstanceImages map with rollback image", "rollbackImage", rollbackImage)
 
 	// Check if rollback is complete by verifying instances are using the rollback image
+	if err := r.terminalInstanceFailure(ctx, targetInstances); err != nil {
+		releaseChannel.Status.Phase = unleashv1.ReleaseChannelPhaseFailed
+		releaseChannel.Status.FailureReason = fmt.Sprintf("Rollback failed: %v", err)
+		r.recordMetrics(releaseChannel, labels)
+		return r.updateReleaseChannelStatus(ctx, releaseChannel)
+	}
 	rollbackComplete := r.areInstancesReady(ctx, targetInstances, rollbackImage, false, log)
 
 	if !rollbackComplete {
@@ -1744,6 +1775,25 @@ func (r *ReleaseChannelReconciler) areInstancesReady(ctx context.Context, instan
 	}
 
 	return true
+}
+
+func (r *ReleaseChannelReconciler) terminalInstanceFailure(ctx context.Context, instances []unleashv1.Unleash) error {
+	for _, instance := range instances {
+		currentInstance := &unleashv1.Unleash{}
+		if err := r.Get(ctx, client.ObjectKeyFromObject(&instance), currentInstance); err != nil {
+			return nil
+		}
+
+		for _, condition := range currentInstance.Status.Conditions {
+			if condition.Type == unleashv1.UnleashStatusConditionTypeReconciled &&
+				condition.Status == metav1.ConditionFalse &&
+				condition.Reason == "Failed" {
+				return fmt.Errorf("instance %s failed: %s", currentInstance.Name, condition.Message)
+			}
+		}
+	}
+
+	return nil
 }
 
 // getExpectedImageForInstance determines correct image based on rollout phase.

--- a/internal/controller/releasechannel_controller_test.go
+++ b/internal/controller/releasechannel_controller_test.go
@@ -127,26 +127,14 @@ var _ = Describe("ReleaseChannel Controller", func() {
 							continue
 						}
 
-						isReady := false
-						for _, condition := range deployment.Status.Conditions {
-							if condition.Type == appsv1.DeploymentProgressing &&
-								condition.Status == corev1.ConditionTrue &&
-								condition.Reason == "NewReplicaSetAvailable" {
-								isReady = true
-								break
-							}
-						}
+						deploymentCopy := deployment.DeepCopy()
+						setDeploymentStatusAvailable(deploymentCopy)
 
-						if !isReady {
-							deploymentCopy := deployment.DeepCopy()
-							setDeploymentStatusAvailable(deploymentCopy)
-
-							if err := k8sClient.Status().Update(simCtx, deploymentCopy); err == nil {
-								processedGenerations[deploymentKey] = deployment.Generation
-								GinkgoWriter.Printf("[DEPLOYMENT-SIM] Made deployment %s ready (gen %d)\n", deploymentKey, deployment.Generation)
-							}
-						} else {
+						if err := k8sClient.Status().Update(simCtx, deploymentCopy); err == nil {
 							processedGenerations[deploymentKey] = deployment.Generation
+							GinkgoWriter.Printf("[DEPLOYMENT-SIM] Made deployment %s ready (gen %d)\n", deploymentKey, deployment.Generation)
+						} else {
+							continue
 						}
 					}
 				}
@@ -512,64 +500,6 @@ var _ = Describe("ReleaseChannel Controller", func() {
 			By("Step 4b: Setting up HTTP mocks for instance health checks")
 			registerHTTPMocksForInstance(canaryUnleash)
 			registerHTTPMocksForInstance(prodUnleash)
-
-			// Setup intelligent deployment readiness simulation using fast polling for phase changes
-			testCtx, cancel := context.WithCancel(ctx)
-			defer cancel()
-
-			canaryKey := canaryUnleash.NamespacedName()
-			prodKey := prodUnleash.NamespacedName()
-			rcKey := releaseChannel.NamespacedName()
-
-			go func() {
-				var lastPhase unleashv1.ReleaseChannelPhase
-				var lastGeneration int64
-
-				// Use very fast polling to catch phase transitions immediately
-				ticker := time.NewTicker(10 * time.Millisecond)
-				defer ticker.Stop()
-
-				for {
-					select {
-					case <-testCtx.Done():
-						return
-					case <-ticker.C:
-						var currentRC unleashv1.ReleaseChannel
-						if err := k8sClient.Get(testCtx, rcKey, &currentRC); err != nil {
-							continue
-						}
-
-						currentPhase := currentRC.Status.Phase
-						currentGeneration := currentRC.ObjectMeta.Generation
-
-						// React to phase transitions or generation changes (indicating spec updates)
-						if currentPhase != lastPhase || currentGeneration != lastGeneration {
-							GinkgoWriter.Printf("State change: phase %s -> %s, generation %d -> %d\n",
-								lastPhase, currentPhase, lastGeneration, currentGeneration)
-
-							switch currentPhase {
-							case unleashv1.ReleaseChannelPhaseIdle:
-								if lastPhase != "" {
-									GinkgoWriter.Printf("Returned to Idle - ensuring both deployments ready\n")
-									simulateDeploymentReady(canaryKey)
-									simulateDeploymentReady(prodKey)
-								}
-
-							case unleashv1.ReleaseChannelPhaseCanary:
-								GinkgoWriter.Printf("Simulating canary deployment readiness\n")
-								simulateDeploymentReady(canaryKey)
-
-							case unleashv1.ReleaseChannelPhaseRolling:
-								GinkgoWriter.Printf("Simulating production deployment readiness\n")
-								simulateDeploymentReady(prodKey)
-							}
-
-							lastPhase = currentPhase
-							lastGeneration = currentGeneration
-						}
-					}
-				}
-			}()
 
 			By("Step 5: Waiting for both Unleash instances to become ready")
 			// This ensures both instances exist and their controllers have processed them

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -54,9 +54,8 @@ func TestAPIs(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	// Speed up tests by setting shorter timeouts for all package-level timeout variables
-	// Keep some timeouts at expected values to match test assertions
-	unleashDeploymentTimeout = time.Second * 1 // Test expects "timed out after 1s"
+	// Speed up tests by setting shorter timeouts for all package-level timing variables.
+	unleashDeploymentRequeueAfter = time.Millisecond * 10
 	unleashControllerRequeueAfter = time.Millisecond * 100
 	unleashConnectionRetryDelay = time.Millisecond * 50
 

--- a/internal/controller/unleash_controller.go
+++ b/internal/controller/unleash_controller.go
@@ -21,7 +21,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -54,8 +53,8 @@ const (
 )
 
 var (
-	// Unleash controller timeouts - prefixed to avoid conflicts with other controllers
-	unleashDeploymentTimeout       = 5 * time.Minute
+	// Unleash controller timings - prefixed to avoid conflicts with other controllers
+	unleashDeploymentRequeueAfter  = 10 * time.Second
 	unleashControllerRequeueAfter  = 60 * time.Second // Poll ReleaseChannel status for image changes
 	unleashControllerRequeueJitter = 15 * time.Second // Jitter to spread reconciliations
 	unleashConnectionRetryDelay    = 5 * time.Second
@@ -334,16 +333,19 @@ func (r *UnleashReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return ctrl.Result{}, err
 	}
 
-	// Wait for Deployment rollout to finish before testing connection This is to
-	// avoid testing connection to the previous instance if the Deployment is not
-	// ready yet. Delay requeue to avoid tying up the reconciler since waiting is
-	// done in the same reconcile loop.
-	log.WithValues("timeout", unleashDeploymentTimeout).Info("Waiting for Deployment rollout to finish")
-	if err = r.waitForDeployment(ctx, unleashDeploymentTimeout, req.NamespacedName); err != nil {
-		if err := r.updateStatusReconcileFailed(ctx, unleash, err, fmt.Sprintf("Deployment rollout timed out after %s", unleashDeploymentTimeout)); err != nil {
-			return ctrl.Result{RequeueAfter: unleashDeploymentTimeout}, err
+	ready, err := r.deploymentIsReady(ctx, req.NamespacedName)
+	if err != nil {
+		if statusErr := r.updateStatusReconcileFailed(ctx, unleash, err, "Failed to get Deployment status"); statusErr != nil {
+			return ctrl.Result{}, statusErr
 		}
-		return ctrl.Result{RequeueAfter: unleashDeploymentTimeout}, err
+		return ctrl.Result{}, err
+	}
+	if !ready {
+		if err := r.updateStatusReconcileProgressing(ctx, unleash); err != nil {
+			return ctrl.Result{}, err
+		}
+		log.V(1).Info("Deployment rollout is still progressing")
+		return ctrl.Result{RequeueAfter: unleashDeploymentRequeueAfter}, nil
 	}
 
 	// Set the reconcile status of the Unleash instance to available
@@ -812,20 +814,15 @@ func (r *UnleashReconciler) reconcileDeployment(ctx context.Context, unleash *un
 			"currentStatus", unleash.Status.ResolvedReleaseChannelImage,
 			"releaseChannel", unleash.Spec.ReleaseChannel.Name)
 
-		// Update our own status to track what we resolved (for monitoring/debugging)
+		// Publish a new desired assignment and invalidate prior readiness in the
+		// same status update. ReleaseChannel must never treat a ready old
+		// Deployment as proof that this newly assigned image is ready.
 		if unleash.Status.ResolvedReleaseChannelImage != resolvedImage ||
 			unleash.Spec.ReleaseChannel.Name != unleash.Status.ReleaseChannelName {
 			log.Info("Updating Unleash status with new resolved image",
 				"oldImage", unleash.Status.ResolvedReleaseChannelImage,
 				"newImage", resolvedImage)
-			unleash.Status.ResolvedReleaseChannelImage = resolvedImage
-			unleash.Status.ReleaseChannelName = unleash.Spec.ReleaseChannel.Name
-			if err := r.Status().Update(ctx, unleash); err != nil {
-				if apierrors.IsConflict(err) {
-					log.V(1).Info("Conflict updating Unleash status, will retry with backoff", "Name", unleash.Name)
-					// Retry with exponential backoff to avoid tight reconciliation loop
-					return ctrl.Result{RequeueAfter: time.Millisecond * 50}, nil
-				}
+			if err := r.markReleaseChannelAssignmentPending(ctx, unleash, resolvedImage); err != nil {
 				log.Error(err, "Failed to update Unleash status")
 				return ctrl.Result{}, err
 			}
@@ -925,21 +922,13 @@ func (r *UnleashReconciler) reconcileService(ctx context.Context, unleash *unlea
 	return ctrl.Result{}, nil
 }
 
-// waitForDeployment will wait for the deployment to be available
-func (r *UnleashReconciler) waitForDeployment(ctx context.Context, timeout time.Duration, key types.NamespacedName) error {
-	ctx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
+func (r *UnleashReconciler) deploymentIsReady(ctx context.Context, key types.NamespacedName) (bool, error) {
+	deployment := &appsv1.Deployment{}
+	if err := r.Client.Get(ctx, key, deployment); err != nil {
+		return false, err
+	}
 
-	err := wait.PollUntilContextCancel(ctx, time.Second, true, func(ctx context.Context) (bool, error) {
-		deployment := &appsv1.Deployment{}
-		if err := r.Client.Get(ctx, key, deployment); err != nil {
-			return false, err
-		}
-
-		return utils.DeploymentIsReady(deployment), nil
-	})
-
-	return err
+	return utils.DeploymentIsReady(deployment), nil
 }
 
 // testConnection tests the connection to the Unleash instance with a single attempt.
@@ -987,6 +976,42 @@ func (r *UnleashReconciler) updateStatusReconcileSuccess(ctx context.Context, un
 		Status:  metav1.ConditionTrue,
 		Reason:  "Reconciling",
 		Message: "Reconciled successfully",
+	})
+}
+
+func (r *UnleashReconciler) updateStatusReconcileProgressing(ctx context.Context, unleash *unleashv1.Unleash) error {
+	return r.updateStatus(ctx, unleash, nil, metav1.Condition{
+		Type:    unleashv1.UnleashStatusConditionTypeReconciled,
+		Status:  metav1.ConditionUnknown,
+		Reason:  "DeploymentProgressing",
+		Message: "Waiting for the current Deployment generation to become available",
+	})
+}
+
+func (r *UnleashReconciler) markReleaseChannelAssignmentPending(ctx context.Context, unleash *unleashv1.Unleash, image string) error {
+	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		if err := r.Get(ctx, unleash.NamespacedName(), unleash); err != nil {
+			return err
+		}
+
+		unleash.Status.ResolvedReleaseChannelImage = image
+		unleash.Status.ReleaseChannelName = unleash.Spec.ReleaseChannel.Name
+		unleash.Status.Reconciled = false
+		unleash.Status.Connected = false
+		meta.SetStatusCondition(&unleash.Status.Conditions, metav1.Condition{
+			Type:    unleashv1.UnleashStatusConditionTypeReconciled,
+			Status:  metav1.ConditionUnknown,
+			Reason:  "DeploymentProgressing",
+			Message: "Waiting for the current Deployment generation to become available",
+		})
+		meta.SetStatusCondition(&unleash.Status.Conditions, metav1.Condition{
+			Type:    unleashv1.UnleashStatusConditionTypeConnected,
+			Status:  metav1.ConditionUnknown,
+			Reason:  "DeploymentProgressing",
+			Message: "Waiting for the current Deployment generation to become available",
+		})
+
+		return r.Status().Update(ctx, unleash)
 	})
 }
 
@@ -1089,14 +1114,20 @@ func (r *UnleashReconciler) updateStatus(ctx context.Context, unleash *unleashv1
 // SetupWithManager sets up the controller with the Manager.
 func (r *UnleashReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&unleashv1.Unleash{}).
+		For(
+			&unleashv1.Unleash{},
+			builder.WithPredicates(predicate.Or(
+				predicate.GenerationChangedPredicate{},
+				predicate.LabelChangedPredicate{},
+			)),
+		).
 		WithOptions(controller.Options{
 			MaxConcurrentReconciles: 4, // Process multiple instances in parallel
 		}).
-		WithEventFilter(predicate.Or(
-			predicate.GenerationChangedPredicate{}, // Spec changes (user updates)
-			predicate.LabelChangedPredicate{},      // Label changes (might affect ReleaseChannel matching)
-		)).
+		// Deployment status changes are the primary signal that an assigned
+		// image is ready. Owning the Deployment avoids blocking a worker while
+		// polling it for up to five minutes.
+		Owns(&appsv1.Deployment{}).
 		// Watch ReleaseChannel changes to trigger Unleash reconciliation when InstanceImages changes
 		Watches(
 			&unleashv1.ReleaseChannel{},

--- a/internal/controller/unleash_controller.go
+++ b/internal/controller/unleash_controller.go
@@ -343,7 +343,7 @@ func (r *UnleashReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 	if failureReason, failed := utils.DeploymentFailure(deployment); failed {
 		failure := fmt.Errorf("deployment reported failure: %s", failureReason)
-		if err := r.updateStatusReconcileFailed(ctx, unleash, failure, fmt.Sprintf("Deployment rollout failed: %s", failureReason)); err != nil {
+		if err := r.updateStatusDeploymentFailed(ctx, unleash, failure, fmt.Sprintf("Deployment rollout failed: %s", failureReason)); err != nil {
 			return ctrl.Result{}, err
 		}
 		return ctrl.Result{RequeueAfter: unleashControllerRequeueAfter}, nil
@@ -1012,6 +1012,16 @@ func (r *UnleashReconciler) markReleaseChannelAssignmentPending(ctx context.Cont
 		})
 
 		return r.Status().Update(ctx, unleash)
+	})
+}
+
+func (r *UnleashReconciler) updateStatusDeploymentFailed(ctx context.Context, unleash *unleashv1.Unleash, err error, message string) error {
+	log.FromContext(ctx).WithName("unleash").Error(err, message)
+	return r.updateStatus(ctx, unleash, nil, metav1.Condition{
+		Type:    unleashv1.UnleashStatusConditionTypeReconciled,
+		Status:  metav1.ConditionFalse,
+		Reason:  "Failed",
+		Message: message,
 	})
 }
 

--- a/internal/controller/unleash_controller.go
+++ b/internal/controller/unleash_controller.go
@@ -333,21 +333,23 @@ func (r *UnleashReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return ctrl.Result{}, err
 	}
 
-	ready, err := r.deploymentIsReady(ctx, req.NamespacedName)
-	if err != nil {
+	deployment := &appsv1.Deployment{}
+	if err := r.Client.Get(ctx, req.NamespacedName, deployment); err != nil {
 		if statusErr := r.updateStatusReconcileFailed(ctx, unleash, err, "Failed to get Deployment status"); statusErr != nil {
 			return ctrl.Result{}, statusErr
 		}
 		return ctrl.Result{}, err
 	}
-	if failureReason, failed := r.deploymentFailure(ctx, req.NamespacedName); failed {
+
+	if failureReason, failed := utils.DeploymentFailure(deployment); failed {
 		failure := fmt.Errorf("deployment reported failure: %s", failureReason)
 		if err := r.updateStatusReconcileFailed(ctx, unleash, failure, fmt.Sprintf("Deployment rollout failed: %s", failureReason)); err != nil {
 			return ctrl.Result{}, err
 		}
 		return ctrl.Result{RequeueAfter: unleashControllerRequeueAfter}, nil
 	}
-	if !ready {
+
+	if !utils.DeploymentIsReady(deployment) {
 		if err := r.updateStatusReconcileProgressing(ctx, unleash); err != nil {
 			return ctrl.Result{}, err
 		}
@@ -927,24 +929,6 @@ func (r *UnleashReconciler) reconcileService(ctx context.Context, unleash *unlea
 
 	log.Info("Skip reconcile: Service up to date", "Service.Namespace", existingSvc.Namespace, "Service.Name", existingSvc.Name)
 	return ctrl.Result{}, nil
-}
-
-func (r *UnleashReconciler) deploymentIsReady(ctx context.Context, key types.NamespacedName) (bool, error) {
-	deployment := &appsv1.Deployment{}
-	if err := r.Client.Get(ctx, key, deployment); err != nil {
-		return false, err
-	}
-
-	return utils.DeploymentIsReady(deployment), nil
-}
-
-func (r *UnleashReconciler) deploymentFailure(ctx context.Context, key types.NamespacedName) (string, bool) {
-	deployment := &appsv1.Deployment{}
-	if err := r.Client.Get(ctx, key, deployment); err != nil {
-		return "", false
-	}
-
-	return utils.DeploymentFailure(deployment)
 }
 
 // testConnection tests the connection to the Unleash instance with a single attempt.

--- a/internal/controller/unleash_controller.go
+++ b/internal/controller/unleash_controller.go
@@ -340,6 +340,13 @@ func (r *UnleashReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		}
 		return ctrl.Result{}, err
 	}
+	if failureReason, failed := r.deploymentFailure(ctx, req.NamespacedName); failed {
+		failure := fmt.Errorf("deployment reported failure: %s", failureReason)
+		if err := r.updateStatusReconcileFailed(ctx, unleash, failure, fmt.Sprintf("Deployment rollout failed: %s", failureReason)); err != nil {
+			return ctrl.Result{}, err
+		}
+		return ctrl.Result{RequeueAfter: unleashControllerRequeueAfter}, nil
+	}
 	if !ready {
 		if err := r.updateStatusReconcileProgressing(ctx, unleash); err != nil {
 			return ctrl.Result{}, err
@@ -862,7 +869,7 @@ func (r *UnleashReconciler) reconcileDeployment(ctx context.Context, unleash *un
 			return ctrl.Result{}, err
 		}
 
-		return ctrl.Result{}, nil
+		return ctrl.Result{RequeueAfter: unleashDeploymentRequeueAfter}, nil
 	} else if getErr != nil {
 		log.Error(getErr, "Failed to get Deployment")
 		return ctrl.Result{}, getErr
@@ -877,7 +884,7 @@ func (r *UnleashReconciler) reconcileDeployment(ctx context.Context, unleash *un
 			return ctrl.Result{}, err
 		}
 
-		return ctrl.Result{}, nil
+		return ctrl.Result{RequeueAfter: unleashDeploymentRequeueAfter}, nil
 	} else {
 		log.Info("Skip reconcile: Deployment already up to date", "Deployment.Namespace", found.Namespace, "Deployment.Name", found.Name)
 		return ctrl.Result{}, nil
@@ -929,6 +936,15 @@ func (r *UnleashReconciler) deploymentIsReady(ctx context.Context, key types.Nam
 	}
 
 	return utils.DeploymentIsReady(deployment), nil
+}
+
+func (r *UnleashReconciler) deploymentFailure(ctx context.Context, key types.NamespacedName) (string, bool) {
+	deployment := &appsv1.Deployment{}
+	if err := r.Client.Get(ctx, key, deployment); err != nil {
+		return "", false
+	}
+
+	return utils.DeploymentFailure(deployment)
 }
 
 // testConnection tests the connection to the Unleash instance with a single attempt.

--- a/internal/controller/unleash_controller_test.go
+++ b/internal/controller/unleash_controller_test.go
@@ -49,6 +49,7 @@ func getDeployment(k8sClient client.Client, ctx context.Context, namespacedName 
 }
 
 func setDeploymentStatusFailed(deployment *appsv1.Deployment) {
+	deployment.Status.ObservedGeneration = deployment.Generation
 	deployment.Status.Conditions = []appsv1.DeploymentCondition{
 		{
 			Type:    appsv1.DeploymentProgressing,
@@ -238,7 +239,7 @@ var _ = Describe("Unleash Controller", func() {
 			Expect(k8sClient.Delete(ctx, createdUnleash)).Should(Succeed())
 		})
 
-		It("Should report a progressing Deployment without blocking a worker", func() {
+		It("Should report a terminal Deployment failure without blocking a worker", func() {
 			ctx := context.Background()
 
 			By("By creating a new Unleash")
@@ -256,13 +257,13 @@ var _ = Describe("Unleash Controller", func() {
 			setDeploymentStatusFailed(createdDeployment)
 			Expect(k8sClient.Status().Update(ctx, createdDeployment)).Should(Succeed())
 
-			By("By checking that Unleash is progressing")
+			By("By checking that Unleash is failed")
 			createdUnleash := &unleashv1.Unleash{ObjectMeta: unleash.ObjectMeta}
 			Eventually(getUnleash, timeout, interval).WithArguments(k8sClient, ctx, createdUnleash).Should(ContainElement(metav1.Condition{
 				Type:    unleashv1.UnleashStatusConditionTypeReconciled,
-				Status:  metav1.ConditionUnknown,
-				Reason:  "DeploymentProgressing",
-				Message: "Waiting for the current Deployment generation to become available",
+				Status:  metav1.ConditionFalse,
+				Reason:  "Reconciling",
+				Message: "Deployment rollout failed: Progress deadline exceeded.",
 			}))
 			Expect(createdUnleash.IsReady()).To(BeFalse())
 			Expect(createdUnleash.Status.Reconciled).To(BeFalse())

--- a/internal/controller/unleash_controller_test.go
+++ b/internal/controller/unleash_controller_test.go
@@ -72,6 +72,7 @@ func setDeploymentStatusAvailable(deployment *appsv1.Deployment) {
 		replicas = *deployment.Spec.Replicas
 	}
 	deployment.Status.ObservedGeneration = deployment.Generation
+	deployment.Status.Replicas = replicas
 	deployment.Status.UpdatedReplicas = replicas
 	deployment.Status.ReadyReplicas = replicas
 	deployment.Status.AvailableReplicas = replicas
@@ -333,8 +334,8 @@ var _ = Describe("Unleash Controller", func() {
 			serviceMonitor := &monitoringv1.ServiceMonitor{}
 			Expect(k8sClient.Get(ctx, createdUnleash.NamespacedName(), serviceMonitor)).Should(Succeed())
 
-			// Reconciled metric uses "unknown" version because stats is nil during reconcile status update
-			val, err := promGaugeVecVal(unleashStatus, createdUnleash.Name, unleashv1.UnleashStatusConditionTypeReconciled, "unknown", "none")
+			// Reconciliation now completes after the connection check, so it carries the resolved version.
+			val, err := promGaugeVecVal(unleashStatus, createdUnleash.Name, unleashv1.UnleashStatusConditionTypeReconciled, UnleashVersion, "none")
 			Expect(err).To(BeNil())
 			Expect(val).To(Equal(float64(1)))
 
@@ -433,9 +434,10 @@ var _ = Describe("Unleash Controller", func() {
 
 			By("By checking that the pending assignment invalidates stale readiness")
 			Eventually(getUnleash, coordinationTimeout, interval).WithArguments(k8sClient, ctx, createdUnleash).Should(ContainElement(metav1.Condition{
-				Type:   unleashv1.UnleashStatusConditionTypeReconciled,
-				Status: metav1.ConditionUnknown,
-				Reason: "DeploymentProgressing",
+				Type:    unleashv1.UnleashStatusConditionTypeReconciled,
+				Status:  metav1.ConditionUnknown,
+				Reason:  "DeploymentProgressing",
+				Message: "Waiting for the current Deployment generation to become available",
 			}))
 			Expect(createdUnleash.Status.Connected).To(BeFalse())
 
@@ -456,7 +458,7 @@ var _ = Describe("Unleash Controller", func() {
 				if err := k8sClient.Get(ctx, unleash.NamespacedName(), createdUnleash); err != nil {
 					return ""
 				}
-				if !createdUnleash.Reconciled || !createdUnleash.Connected {
+				if !createdUnleash.Status.Reconciled || !createdUnleash.Status.Connected {
 					return ""
 				}
 				return createdUnleash.Status.ResolvedReleaseChannelImage

--- a/internal/controller/unleash_controller_test.go
+++ b/internal/controller/unleash_controller_test.go
@@ -66,6 +66,15 @@ func setDeploymentStatusFailed(deployment *appsv1.Deployment) {
 }
 
 func setDeploymentStatusAvailable(deployment *appsv1.Deployment) {
+	replicas := int32(1)
+	if deployment.Spec.Replicas != nil {
+		replicas = *deployment.Spec.Replicas
+	}
+	deployment.Status.ObservedGeneration = deployment.Generation
+	deployment.Status.UpdatedReplicas = replicas
+	deployment.Status.ReadyReplicas = replicas
+	deployment.Status.AvailableReplicas = replicas
+	deployment.Status.UnavailableReplicas = 0
 	deployment.Status.Conditions = []appsv1.DeploymentCondition{
 		{
 			Type:    appsv1.DeploymentProgressing,
@@ -229,7 +238,7 @@ var _ = Describe("Unleash Controller", func() {
 			Expect(k8sClient.Delete(ctx, createdUnleash)).Should(Succeed())
 		})
 
-		It("Should fail if Deployment rollout is not complete", func() {
+		It("Should report a progressing Deployment without blocking a worker", func() {
 			ctx := context.Background()
 
 			By("By creating a new Unleash")
@@ -247,13 +256,13 @@ var _ = Describe("Unleash Controller", func() {
 			setDeploymentStatusFailed(createdDeployment)
 			Expect(k8sClient.Status().Update(ctx, createdDeployment)).Should(Succeed())
 
-			By("By checking that Unleash is failed")
+			By("By checking that Unleash is progressing")
 			createdUnleash := &unleashv1.Unleash{ObjectMeta: unleash.ObjectMeta}
 			Eventually(getUnleash, timeout, interval).WithArguments(k8sClient, ctx, createdUnleash).Should(ContainElement(metav1.Condition{
 				Type:    unleashv1.UnleashStatusConditionTypeReconciled,
-				Status:  metav1.ConditionFalse,
-				Reason:  "Reconciling",
-				Message: "Deployment rollout timed out after 1s",
+				Status:  metav1.ConditionUnknown,
+				Reason:  "DeploymentProgressing",
+				Message: "Waiting for the current Deployment generation to become available",
 			}))
 			Expect(createdUnleash.IsReady()).To(BeFalse())
 			Expect(createdUnleash.Status.Reconciled).To(BeFalse())
@@ -411,43 +420,49 @@ var _ = Describe("Unleash Controller", func() {
 			})
 			Expect(k8sClient.Create(ctx, unleash)).Should(Succeed())
 
-			By("By verifying ReleaseChannel controller does NOT interfere during initial creation")
+			By("By verifying the Deployment receives the ReleaseChannel image")
 			createdUnleash := &unleashv1.Unleash{ObjectMeta: unleash.ObjectMeta}
-			// Wait for initial reconciliation to complete
-			// Use coordinationTimeout because in CI, controller workqueues can get backed up
+			createdDeployment := &appsv1.Deployment{}
 			Eventually(func() bool {
-				if err := k8sClient.Get(ctx, unleash.NamespacedName(), createdUnleash); err != nil {
+				if err := k8sClient.Get(ctx, unleash.NamespacedName(), createdDeployment); err != nil {
 					return false
 				}
-				return createdUnleash.Status.ResolvedReleaseChannelImage != ""
+				return createdDeployment.Spec.Template.Spec.Containers[0].Image == releaseChannelImage
 			}, coordinationTimeout, interval).Should(BeTrue())
 
-			// In the new status-based architecture, coordination happens through status fields
-			// rather than annotations, so we expect no coordination-related annotations
+			By("By checking that the pending assignment invalidates stale readiness")
+			Eventually(getUnleash, coordinationTimeout, interval).WithArguments(k8sClient, ctx, createdUnleash).Should(ContainElement(metav1.Condition{
+				Type:   unleashv1.UnleashStatusConditionTypeReconciled,
+				Status: metav1.ConditionUnknown,
+				Reason: "DeploymentProgressing",
+			}))
+			Expect(createdUnleash.Status.Connected).To(BeFalse())
+
+			// Coordination happens through status fields rather than annotations.
 			if createdUnleash.Annotations != nil {
-				// Check that no legacy ReleaseChannel coordination annotations exist
 				for key := range createdUnleash.Annotations {
 					Expect(key).ToNot(ContainSubstring("releasechannel.unleash.nais.io/"),
 						"Legacy ReleaseChannel coordination annotations should not be present")
 				}
 			}
 
-			By("By checking that the Unleash has the resolved ReleaseChannel image in status")
+			By("By faking Deployment status as available")
+			setDeploymentStatusAvailable(createdDeployment)
+			Expect(k8sClient.Status().Update(ctx, createdDeployment)).Should(Succeed())
+
+			By("By checking that the ready Deployment is reflected in ReleaseChannel status")
 			Eventually(func() string {
 				if err := k8sClient.Get(ctx, unleash.NamespacedName(), createdUnleash); err != nil {
 					return ""
 				}
+				if !createdUnleash.Reconciled || !createdUnleash.Connected {
+					return ""
+				}
 				return createdUnleash.Status.ResolvedReleaseChannelImage
-			}, timeout, interval).Should(Equal(releaseChannelImage))
+			}, coordinationTimeout, interval).Should(Equal(releaseChannelImage))
 
 			By("By verifying CustomImage is NOT set during initial creation")
 			Expect(createdUnleash.Spec.CustomImage).Should(BeEmpty(), "CustomImage should not be set during initial creation")
-
-			By("By faking Deployment status as available")
-			createdDeployment := &appsv1.Deployment{}
-			Eventually(getDeployment, timeout, interval).WithArguments(k8sClient, ctx, unleash.NamespacedName(), createdDeployment).Should(Succeed())
-			setDeploymentStatusAvailable(createdDeployment)
-			Expect(k8sClient.Status().Update(ctx, createdDeployment)).Should(Succeed())
 
 			By("By checking that the deployment uses the ReleaseChannel image")
 			Eventually(func() string {

--- a/internal/controller/unleash_controller_test.go
+++ b/internal/controller/unleash_controller_test.go
@@ -263,7 +263,7 @@ var _ = Describe("Unleash Controller", func() {
 			Eventually(getUnleash, timeout, interval).WithArguments(k8sClient, ctx, createdUnleash).Should(ContainElement(metav1.Condition{
 				Type:    unleashv1.UnleashStatusConditionTypeReconciled,
 				Status:  metav1.ConditionFalse,
-				Reason:  "Reconciling",
+				Reason:  "Failed",
 				Message: "Deployment rollout failed: Progress deadline exceeded.",
 			}))
 			Expect(createdUnleash.IsReady()).To(BeFalse())

--- a/internal/resources/unleash.go
+++ b/internal/resources/unleash.go
@@ -598,22 +598,11 @@ func ResolveReleaseChannelImage(ctx context.Context, k8sClient client.Client, un
 			return unleash.Status.ResolvedReleaseChannelImage, false, nil
 		}
 
-		// An unassigned instance must not take the target during an active
-		// rollout. This includes a first rollout, where PreviousImage is empty:
-		// otherwise every newly reconciled instance bypasses maxParallel.
-		if releaseChannel.Status.Phase != unleashv1.ReleaseChannelPhaseIdle &&
-			releaseChannel.Status.Phase != unleashv1.ReleaseChannelPhaseCompleted {
-			return "", false, fmt.Errorf("ReleaseChannel %s has not assigned an image to %s during %s",
-				releaseChannel.Name, unleash.Name, releaseChannel.Status.Phase)
-		}
-
-		// Outside a rollout an instance that has never resolved an image has
-		// nothing to hold, so the current target is safe.
-		if releaseChannel.Spec.Image != "" {
-			return string(releaseChannel.Spec.Image), false, nil
-		}
-
-		return "", false, fmt.Errorf("ReleaseChannel %s has no image specified", unleash.Spec.ReleaseChannel.Name)
+		// InstanceImages is the authority for a first assignment. Returning
+		// spec.image here would let instances that reconcile before their
+		// ReleaseChannel batch bypass maxParallel and its safety checks.
+		return "", false, fmt.Errorf("ReleaseChannel %s has not assigned an image to %s during %s",
+			releaseChannel.Name, unleash.Name, releaseChannel.Status.Phase)
 	}
 
 	// Priority 3: Use environment variable or default

--- a/internal/resources/unleash.go
+++ b/internal/resources/unleash.go
@@ -598,8 +598,17 @@ func ResolveReleaseChannelImage(ctx context.Context, k8sClient client.Client, un
 			return unleash.Status.ResolvedReleaseChannelImage, false, nil
 		}
 
-		// An instance that has never resolved an image has nothing to hold and no
-		// running workload to protect, so the target is safe for it.
+		// An unassigned instance must not take the target during an active
+		// rollout. This includes a first rollout, where PreviousImage is empty:
+		// otherwise every newly reconciled instance bypasses maxParallel.
+		if releaseChannel.Status.Phase != unleashv1.ReleaseChannelPhaseIdle &&
+			releaseChannel.Status.Phase != unleashv1.ReleaseChannelPhaseCompleted {
+			return "", false, fmt.Errorf("ReleaseChannel %s has not assigned an image to %s during %s",
+				releaseChannel.Name, unleash.Name, releaseChannel.Status.Phase)
+		}
+
+		// Outside a rollout an instance that has never resolved an image has
+		// nothing to hold, so the current target is safe.
 		if releaseChannel.Spec.Image != "" {
 			return string(releaseChannel.Spec.Image), false, nil
 		}

--- a/internal/resources/unleash_test.go
+++ b/internal/resources/unleash_test.go
@@ -619,19 +619,9 @@ func TestResolveReleaseChannelImageHoldsUntrackedInstances(t *testing.T) {
 		})
 	}
 
-	t.Run("an instance that never resolved an image still gets the target", func(t *testing.T) {
-		k8sClient := fake.NewClientBuilder().
-			WithScheme(testScheme).
-			WithObjects(newChannel(unleashv1.ReleaseChannelPhaseIdle)).
-			Build()
-
-		image, modified, err := ResolveReleaseChannelImage(context.Background(), k8sClient, newInstance(""))
-		assert.NoError(t, err)
-		assert.False(t, modified)
-		assert.Equal(t, "test:v2", image)
-	})
-
 	for _, phase := range []unleashv1.ReleaseChannelPhase{
+		unleashv1.ReleaseChannelPhaseIdle,
+		unleashv1.ReleaseChannelPhaseCompleted,
 		unleashv1.ReleaseChannelPhaseValidating,
 		unleashv1.ReleaseChannelPhaseCanary,
 		unleashv1.ReleaseChannelPhaseRolling,

--- a/internal/resources/unleash_test.go
+++ b/internal/resources/unleash_test.go
@@ -631,6 +631,27 @@ func TestResolveReleaseChannelImageHoldsUntrackedInstances(t *testing.T) {
 		assert.Equal(t, "test:v2", image)
 	})
 
+	for _, phase := range []unleashv1.ReleaseChannelPhase{
+		unleashv1.ReleaseChannelPhaseValidating,
+		unleashv1.ReleaseChannelPhaseCanary,
+		unleashv1.ReleaseChannelPhaseRolling,
+		unleashv1.ReleaseChannelPhaseRollingBack,
+		unleashv1.ReleaseChannelPhaseFailed,
+	} {
+		t.Run("an unassigned initial instance waits during "+string(phase), func(t *testing.T) {
+			k8sClient := fake.NewClientBuilder().
+				WithScheme(testScheme).
+				WithObjects(newChannel(phase)).
+				Build()
+
+			image, modified, err := ResolveReleaseChannelImage(context.Background(), k8sClient, newInstance(""))
+			assert.Error(t, err)
+			assert.False(t, modified)
+			assert.Empty(t, image)
+			assert.Contains(t, err.Error(), "has not assigned an image")
+		})
+	}
+
 	t.Run("a tracked instance still resolves from the map", func(t *testing.T) {
 		tracked := newInstance("test:v1")
 		tracked.Name = "tracked-instance"

--- a/internal/utils/k8s.go
+++ b/internal/utils/k8s.go
@@ -36,12 +36,19 @@ func SecretEnvVar(name, secretName, secretKey string) corev1.EnvVar {
 
 // DeploymentIsReady returns true if the rollout of the given deployment has completed successfully.
 func DeploymentIsReady(deployment *appsv1.Deployment) bool {
-	for _, condition := range deployment.Status.Conditions {
-		if condition.Type == appsv1.DeploymentProgressing && condition.Status == corev1.ConditionTrue && condition.Reason == "NewReplicaSetAvailable" {
-			return true
-		}
+	if deployment.Status.ObservedGeneration < deployment.Generation {
+		return false
 	}
-	return false
+
+	replicas := int32(1)
+	if deployment.Spec.Replicas != nil {
+		replicas = *deployment.Spec.Replicas
+	}
+
+	return deployment.Status.UpdatedReplicas == replicas &&
+		deployment.Status.ReadyReplicas == replicas &&
+		deployment.Status.AvailableReplicas == replicas &&
+		deployment.Status.UnavailableReplicas == 0
 }
 
 // UpsertObject upserts the given object in Kubernetes. If the object already exists, it is updated.

--- a/internal/utils/k8s.go
+++ b/internal/utils/k8s.go
@@ -62,14 +62,22 @@ func DeploymentFailure(deployment *appsv1.Deployment) (string, bool) {
 		if condition.Type == appsv1.DeploymentProgressing &&
 			condition.Status == corev1.ConditionFalse &&
 			condition.Reason == "ProgressDeadlineExceeded" {
-			return condition.Message, true
+			return deploymentFailureMessage(condition), true
 		}
 		if condition.Type == appsv1.DeploymentReplicaFailure && condition.Status == corev1.ConditionTrue {
-			return condition.Message, true
+			return deploymentFailureMessage(condition), true
 		}
 	}
 
 	return "", false
+}
+
+func deploymentFailureMessage(condition appsv1.DeploymentCondition) string {
+	if condition.Message != "" {
+		return condition.Message
+	}
+
+	return condition.Reason
 }
 
 // UpsertObject upserts the given object in Kubernetes. If the object already exists, it is updated.

--- a/internal/utils/k8s.go
+++ b/internal/utils/k8s.go
@@ -76,8 +76,11 @@ func deploymentFailureMessage(condition appsv1.DeploymentCondition) string {
 	if condition.Message != "" {
 		return condition.Message
 	}
+	if condition.Reason != "" {
+		return condition.Reason
+	}
 
-	return condition.Reason
+	return "Deployment reported a terminal failure"
 }
 
 // UpsertObject upserts the given object in Kubernetes. If the object already exists, it is updated.

--- a/internal/utils/k8s.go
+++ b/internal/utils/k8s.go
@@ -46,9 +46,30 @@ func DeploymentIsReady(deployment *appsv1.Deployment) bool {
 	}
 
 	return deployment.Status.UpdatedReplicas == replicas &&
+		deployment.Status.Replicas == replicas &&
 		deployment.Status.ReadyReplicas == replicas &&
 		deployment.Status.AvailableReplicas == replicas &&
 		deployment.Status.UnavailableReplicas == 0
+}
+
+// DeploymentFailure returns terminal failure reported for the current deployment generation.
+func DeploymentFailure(deployment *appsv1.Deployment) (string, bool) {
+	if deployment.Status.ObservedGeneration < deployment.Generation {
+		return "", false
+	}
+
+	for _, condition := range deployment.Status.Conditions {
+		if condition.Type == appsv1.DeploymentProgressing &&
+			condition.Status == corev1.ConditionFalse &&
+			condition.Reason == "ProgressDeadlineExceeded" {
+			return condition.Message, true
+		}
+		if condition.Type == appsv1.DeploymentReplicaFailure && condition.Status == corev1.ConditionTrue {
+			return condition.Message, true
+		}
+	}
+
+	return "", false
 }
 
 // UpsertObject upserts the given object in Kubernetes. If the object already exists, it is updated.

--- a/internal/utils/k8s_test.go
+++ b/internal/utils/k8s_test.go
@@ -203,9 +203,10 @@ func TestDeploymentIsReady(t *testing.T) {
 
 func TestDeploymentFailure(t *testing.T) {
 	tests := []struct {
-		name       string
-		deployment *appsv1.Deployment
-		expected   bool
+		name           string
+		deployment     *appsv1.Deployment
+		expectedReason string
+		expected       bool
 	}{
 		{
 			name: "progress deadline for current generation",
@@ -221,7 +222,24 @@ func TestDeploymentFailure(t *testing.T) {
 					}},
 				},
 			},
-			expected: true,
+			expectedReason: "progress deadline exceeded",
+			expected:       true,
+		},
+		{
+			name: "empty failure message falls back to reason",
+			deployment: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{Generation: 2},
+				Status: appsv1.DeploymentStatus{
+					ObservedGeneration: 2,
+					Conditions: []appsv1.DeploymentCondition{{
+						Type:   appsv1.DeploymentProgressing,
+						Status: corev1.ConditionFalse,
+						Reason: "ProgressDeadlineExceeded",
+					}},
+				},
+			},
+			expectedReason: "ProgressDeadlineExceeded",
+			expected:       true,
 		},
 		{
 			name: "failure from stale generation",
@@ -242,9 +260,12 @@ func TestDeploymentFailure(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, got := DeploymentFailure(tt.deployment)
+			reason, got := DeploymentFailure(tt.deployment)
 			if got != tt.expected {
 				t.Errorf("DeploymentFailure() = %v, want %v", got, tt.expected)
+			}
+			if reason != tt.expectedReason {
+				t.Errorf("DeploymentFailure() reason = %q, want %q", reason, tt.expectedReason)
 			}
 		})
 	}

--- a/internal/utils/k8s_test.go
+++ b/internal/utils/k8s_test.go
@@ -119,6 +119,7 @@ func TestDeploymentIsReady(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Generation: 2},
 				Status: appsv1.DeploymentStatus{
 					ObservedGeneration:  2,
+					Replicas:            1,
 					UpdatedReplicas:     1,
 					ReadyReplicas:       1,
 					AvailableReplicas:   1,
@@ -140,6 +141,7 @@ func TestDeploymentIsReady(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Generation: 2},
 				Status: appsv1.DeploymentStatus{
 					ObservedGeneration: 1,
+					Replicas:           1,
 					UpdatedReplicas:    1,
 					ReadyReplicas:      1,
 					AvailableReplicas:  1,
@@ -160,6 +162,7 @@ func TestDeploymentIsReady(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Generation: 2},
 				Status: appsv1.DeploymentStatus{
 					ObservedGeneration: 2,
+					Replicas:           1,
 					Conditions: []appsv1.DeploymentCondition{
 						{
 							Type:   appsv1.DeploymentProgressing,
@@ -177,6 +180,7 @@ func TestDeploymentIsReady(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Generation: 2},
 				Status: appsv1.DeploymentStatus{
 					ObservedGeneration:  2,
+					Replicas:            2,
 					UpdatedReplicas:     1,
 					ReadyReplicas:       1,
 					AvailableReplicas:   1,
@@ -192,6 +196,55 @@ func TestDeploymentIsReady(t *testing.T) {
 			got := DeploymentIsReady(tt.deployment)
 			if got != tt.expected {
 				t.Errorf("DeploymentIsReady() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestDeploymentFailure(t *testing.T) {
+	tests := []struct {
+		name       string
+		deployment *appsv1.Deployment
+		expected   bool
+	}{
+		{
+			name: "progress deadline for current generation",
+			deployment: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{Generation: 2},
+				Status: appsv1.DeploymentStatus{
+					ObservedGeneration: 2,
+					Conditions: []appsv1.DeploymentCondition{{
+						Type:    appsv1.DeploymentProgressing,
+						Status:  corev1.ConditionFalse,
+						Reason:  "ProgressDeadlineExceeded",
+						Message: "progress deadline exceeded",
+					}},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "failure from stale generation",
+			deployment: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{Generation: 2},
+				Status: appsv1.DeploymentStatus{
+					ObservedGeneration: 1,
+					Conditions: []appsv1.DeploymentCondition{{
+						Type:   appsv1.DeploymentProgressing,
+						Status: corev1.ConditionFalse,
+						Reason: "ProgressDeadlineExceeded",
+					}},
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, got := DeploymentFailure(tt.deployment)
+			if got != tt.expected {
+				t.Errorf("DeploymentFailure() = %v, want %v", got, tt.expected)
 			}
 		})
 	}

--- a/internal/utils/k8s_test.go
+++ b/internal/utils/k8s_test.go
@@ -7,6 +7,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestRemoveEmptyErrs(t *testing.T) {
@@ -115,7 +116,13 @@ func TestDeploymentIsReady(t *testing.T) {
 		{
 			name: "Deployment is ready",
 			deployment: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{Generation: 2},
 				Status: appsv1.DeploymentStatus{
+					ObservedGeneration:  2,
+					UpdatedReplicas:     1,
+					ReadyReplicas:       1,
+					AvailableReplicas:   1,
+					UnavailableReplicas: 0,
 					Conditions: []appsv1.DeploymentCondition{
 						{
 							Type:   appsv1.DeploymentProgressing,
@@ -128,9 +135,14 @@ func TestDeploymentIsReady(t *testing.T) {
 			expected: true,
 		},
 		{
-			name: "Deployment is not ready",
+			name: "Deployment has stale observed generation",
 			deployment: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{Generation: 2},
 				Status: appsv1.DeploymentStatus{
+					ObservedGeneration: 1,
+					UpdatedReplicas:    1,
+					ReadyReplicas:      1,
+					AvailableReplicas:  1,
 					Conditions: []appsv1.DeploymentCondition{
 						{
 							Type:   appsv1.DeploymentProgressing,
@@ -145,7 +157,9 @@ func TestDeploymentIsReady(t *testing.T) {
 		{
 			name: "Deployment failed",
 			deployment: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{Generation: 2},
 				Status: appsv1.DeploymentStatus{
+					ObservedGeneration: 2,
 					Conditions: []appsv1.DeploymentCondition{
 						{
 							Type:   appsv1.DeploymentProgressing,
@@ -158,10 +172,15 @@ func TestDeploymentIsReady(t *testing.T) {
 			expected: false,
 		},
 		{
-			name: "No conditions",
+			name: "Deployment has not updated all replicas",
 			deployment: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{Generation: 2},
 				Status: appsv1.DeploymentStatus{
-					Conditions: []appsv1.DeploymentCondition{},
+					ObservedGeneration:  2,
+					UpdatedReplicas:     1,
+					ReadyReplicas:       1,
+					AvailableReplicas:   1,
+					UnavailableReplicas: 1,
 				},
 			},
 			expected: false,


### PR DESCRIPTION
## Summary
 - Replace synchronous Deployment polling with short, event-driven reconciliation and owned Deployment watches.
 - Require current-generation replica readiness before a ReleaseChannel batch can advance.
 - Keep `status.instanceImages` authoritative so unassigned instances cannot bypass batch gates.
 - Treat terminal Deployment errors as immediate ReleaseChannel failures in Canary, Rolling, and RollingBack, rather than waiting for `maxUpgradeTime`.
 - a non-empty Kubernetes failure reason when a condition has no message.                    


## Validation
- `mise exec go@1.26.6 -- make test`
- GPT-5.6 Sol adversarial review, including the terminal-failure propagation follow-up