### PR TITLE
feat(observability): add Unleash tenant fleet dashboard

### DIFF
--- a/charts/unleasherator/dashboards/tenant-overview-dashboard.json
+++ b/charts/unleasherator/dashboards/tenant-overview-dashboard.json
@@ -1,0 +1,109 @@
+{
+  "title": "Nais Tenant Overview",
+  "uid": "nais-tenant-overview",
+  "editable": true,
+  "schemaVersion": 41,
+  "time": { "from": "now-6h", "to": "now" },
+  "templating": {
+    "list": [
+      {
+        "name": "tenant",
+        "label": "Tenant",
+        "type": "datasource",
+        "query": "prometheus",
+        "pluginId": "prometheus",
+        "multi": true,
+        "includeAll": true,
+        "current": {
+          "text": ["atil-metrics", "ldir-metrics", "nav-metrics", "ssb-metrics"],
+          "value": ["PF7D5629ECC453C64", "P73126C2103EBFC69", "P91A6F0B3584B90E7", "PE607B8DC11CE4E99"]
+        },
+        "description": "Select tenants. Panels repeat once per selected Mimir datasource."
+      },
+      {
+        "name": "cluster",
+        "label": "Cluster",
+        "type": "query",
+        "datasource": { "type": "prometheus", "uid": "${tenant}" },
+        "query": "label_values(up, k8s_cluster_name)",
+        "multi": true,
+        "includeAll": true,
+        "allValue": ".*",
+        "current": { "text": ["prod"], "value": ["prod"] },
+        "description": "Filter by Kubernetes cluster."
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1, "type": "row", "title": "Bifrost reconciler", "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 }, "panels": []
+    },
+    {
+      "id": 2, "type": "stat", "title": "Census age", "repeat": "tenant",
+      "datasource": { "type": "prometheus", "uid": "${tenant}" },
+      "gridPos": { "h": 5, "w": 4, "x": 0, "y": 1 },
+      "targets": [{ "refId": "A", "expr": "time() - max(bifrost_reconciler_instances_updated_timestamp_seconds{k8s_cluster_name=~\"$cluster\"})", "legendFormat": "{{__field.name}}" }],
+      "fieldConfig": { "defaults": { "unit": "s", "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": 0 }, { "color": "yellow", "value": 900 }, { "color": "red", "value": 1800 }] } }, "overrides": [] },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"], "values": false }, "colorMode": "background", "graphMode": "none" }
+    },
+    {
+      "id": 3, "type": "timeseries", "title": "Managed and unmanaged instances", "repeat": "tenant",
+      "datasource": { "type": "prometheus", "uid": "${tenant}" },
+      "gridPos": { "h": 7, "w": 8, "x": 4, "y": 1 },
+      "targets": [
+        { "refId": "A", "expr": "bifrost_reconciler_managed_instances{k8s_cluster_name=~\"$cluster\"}", "legendFormat": "managed" },
+        { "refId": "B", "expr": "bifrost_reconciler_unmanaged_instances{k8s_cluster_name=~\"$cluster\"}", "legendFormat": "unmanaged" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+      "options": { "legend": { "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi" } }
+    },
+    {
+      "id": 4, "type": "stat", "title": "Adoption halted", "repeat": "tenant",
+      "datasource": { "type": "prometheus", "uid": "${tenant}" },
+      "gridPos": { "h": 5, "w": 4, "x": 12, "y": 1 },
+      "targets": [{ "refId": "A", "expr": "max(bifrost_reconciler_adoption_halted{k8s_cluster_name=~\"$cluster\"})" }],
+      "fieldConfig": { "defaults": { "mappings": [{ "type": "value", "options": { "0": { "text": "Running", "color": "green" }, "1": { "text": "Halted", "color": "red" } } }] }, "overrides": [] },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"], "values": false }, "colorMode": "background", "graphMode": "none" }
+    },
+    {
+      "id": 5, "type": "timeseries", "title": "Reconciler actions by reason", "repeat": "tenant",
+      "datasource": { "type": "prometheus", "uid": "${tenant}" },
+      "gridPos": { "h": 7, "w": 8, "x": 16, "y": 1 },
+      "targets": [{ "refId": "A", "expr": "sum by (action, reason) (rate(bifrost_reconciler_actions_total{k8s_cluster_name=~\"$cluster\"}[5m]))", "legendFormat": "{{action}} / {{reason}}" }],
+      "fieldConfig": { "defaults": { "unit": "ops" }, "overrides": [] },
+      "options": { "legend": { "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi" } }
+    },
+    {
+      "id": 6, "type": "row", "title": "Unleasherator rollouts", "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 8 }, "panels": []
+    },
+    {
+      "id": 7, "type": "stat", "title": "ReleaseChannel health", "repeat": "tenant",
+      "datasource": { "type": "prometheus", "uid": "${tenant}" },
+      "gridPos": { "h": 5, "w": 4, "x": 0, "y": 9 },
+      "targets": [{ "refId": "A", "expr": "min(unleasherator_releasechannel_status{k8s_cluster_name=~\"$cluster\"})" }],
+      "fieldConfig": { "defaults": { "mappings": [{ "type": "value", "options": { "0": { "text": "Failed", "color": "red" }, "0.5": { "text": "Rolling", "color": "yellow" }, "1": { "text": "Healthy", "color": "green" } } }] }, "overrides": [] },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"], "values": false }, "colorMode": "background", "graphMode": "none" }
+    },
+    {
+      "id": 8, "type": "timeseries", "title": "ReleaseChannel progress", "repeat": "tenant",
+      "datasource": { "type": "prometheus", "uid": "${tenant}" },
+      "gridPos": { "h": 7, "w": 8, "x": 4, "y": 9 },
+      "targets": [
+        { "refId": "A", "expr": "sum(unleasherator_releasechannel_instances_up_to_date{k8s_cluster_name=~\"$cluster\"})", "legendFormat": "up to date" },
+        { "refId": "B", "expr": "sum(unleasherator_releasechannel_instances_total{k8s_cluster_name=~\"$cluster\"})", "legendFormat": "total" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+      "options": { "legend": { "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi" } }
+    },
+    {
+      "id": 9, "type": "timeseries", "title": "Controller workqueue depth", "repeat": "tenant",
+      "datasource": { "type": "prometheus", "uid": "${tenant}" },
+      "gridPos": { "h": 7, "w": 12, "x": 12, "y": 9 },
+      "targets": [{ "refId": "A", "expr": "max by (name) (workqueue_depth{name=~\".*unleash.*|.*releasechannel.*\", k8s_cluster_name=~\"$cluster\"})", "legendFormat": "{{name}}" }],
+      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+      "options": { "legend": { "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi" } }
+    }
+  ]
+}

--- a/charts/unleasherator/dashboards/tenant-overview-dashboard.json
+++ b/charts/unleasherator/dashboards/tenant-overview-dashboard.json
@@ -1,1149 +1,1125 @@
 {
-  "apiVersion": "dashboard.grafana.app/v2",
-  "kind": "Dashboard",
-  "metadata": {
-    "name": "unleash-overview",
-    "namespace": "default",
-    "uid": "3c6207aa-9c67-4fdb-9406-67fd0f915362",
-    "resourceVersion": "1788810569968991",
-    "generation": 2,
-    "creationTimestamp": "2026-09-07T19:49:02Z",
-    "labels": {
-      "grafana.app/deprecatedInternalID": "2875698210541568"
+  "annotations": [
+    {
+      "kind": "AnnotationQuery",
+      "spec": {
+        "query": {
+          "kind": "DataQuery",
+          "group": "grafana",
+          "version": "v0",
+          "datasource": {
+            "name": "-- Grafana --"
+          },
+          "spec": {}
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "builtIn": true
+      }
+    }
+  ],
+  "cursorSync": "Off",
+  "editable": true,
+  "elements": {
+    "panel-2": {
+      "kind": "Panel",
+      "spec": {
+        "id": 2,
+        "title": "Census age",
+        "description": "",
+        "links": [],
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "query": {
+                    "kind": "DataQuery",
+                    "group": "prometheus",
+                    "version": "v0",
+                    "datasource": {
+                      "name": "${tenant}"
+                    },
+                    "spec": {
+                      "expr": "time() - max(bifrost_reconciler_instances_updated_timestamp_seconds{k8s_cluster_name=~\"$cluster\"})",
+                      "legendFormat": "{{__field.name}}"
+                    }
+                  },
+                  "refId": "A",
+                  "hidden": false
+                }
+              }
+            ],
+            "transformations": [],
+            "queryOptions": {}
+          }
+        },
+        "vizConfig": {
+          "kind": "VizConfig",
+          "group": "stat",
+          "version": "13.0.1+security-01",
+          "spec": {
+            "options": {
+              "colorMode": "background",
+              "graphMode": "none",
+              "justifyMode": "auto",
+              "orientation": "auto",
+              "percentChangeColorMode": "standard",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": false
+              },
+              "showPercentChange": false,
+              "textMode": "auto",
+              "wideLayout": true
+            },
+            "fieldConfig": {
+              "defaults": {
+                "unit": "s",
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "value": 0,
+                      "color": "green"
+                    },
+                    {
+                      "value": 900,
+                      "color": "yellow"
+                    },
+                    {
+                      "value": 1800,
+                      "color": "red"
+                    }
+                  ]
+                }
+              },
+              "overrides": []
+            }
+          }
+        }
+      }
     },
-    "annotations": {
-      "grafana.app/createdBy": "user:u000000003",
-      "grafana.app/folder": "2-RVnOUVz",
-      "grafana.app/saved-from-ui": "Grafana v13.0.1+security-01 (9bbe672d)",
-      "grafana.app/updatedBy": "user:u000000003",
-      "grafana.app/updatedTimestamp": "2026-09-07T19:49:29Z",
-      "grafana.app/folderTitle": "Unleash",
-      "grafana.app/folderUrl": "/dashboards/f/2-RVnOUVz/unleash"
+    "panel-3": {
+      "kind": "Panel",
+      "spec": {
+        "id": 3,
+        "title": "Managed and unmanaged instances",
+        "description": "",
+        "links": [],
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "query": {
+                    "kind": "DataQuery",
+                    "group": "prometheus",
+                    "version": "v0",
+                    "datasource": {
+                      "name": "${tenant}"
+                    },
+                    "spec": {
+                      "expr": "bifrost_reconciler_managed_instances{k8s_cluster_name=~\"$cluster\"}",
+                      "legendFormat": "managed"
+                    }
+                  },
+                  "refId": "A",
+                  "hidden": false
+                }
+              },
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "query": {
+                    "kind": "DataQuery",
+                    "group": "prometheus",
+                    "version": "v0",
+                    "datasource": {
+                      "name": "${tenant}"
+                    },
+                    "spec": {
+                      "expr": "bifrost_reconciler_unmanaged_instances{k8s_cluster_name=~\"$cluster\"}",
+                      "legendFormat": "unmanaged"
+                    }
+                  },
+                  "refId": "B",
+                  "hidden": false
+                }
+              }
+            ],
+            "transformations": [],
+            "queryOptions": {}
+          }
+        },
+        "vizConfig": {
+          "kind": "VizConfig",
+          "group": "timeseries",
+          "version": "13.0.1+security-01",
+          "spec": {
+            "options": {
+              "annotations": {
+                "clustering": -1,
+                "multiLane": false
+              },
+              "legend": {
+                "calcs": [],
+                "displayMode": "table",
+                "placement": "bottom",
+                "showLegend": true
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "mode": "multi",
+                "sort": "none"
+              }
+            },
+            "fieldConfig": {
+              "defaults": {
+                "unit": "short",
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "value": 0,
+                      "color": "green"
+                    },
+                    {
+                      "value": 80,
+                      "color": "red"
+                    }
+                  ]
+                },
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "barWidthFactor": 0.6,
+                  "drawStyle": "line",
+                  "fillOpacity": 0,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 1,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "auto",
+                  "showValues": false,
+                  "spanNulls": false,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                }
+              },
+              "overrides": []
+            }
+          }
+        }
+      }
+    },
+    "panel-4": {
+      "kind": "Panel",
+      "spec": {
+        "id": 4,
+        "title": "Adoption halted",
+        "description": "",
+        "links": [],
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "query": {
+                    "kind": "DataQuery",
+                    "group": "prometheus",
+                    "version": "v0",
+                    "datasource": {
+                      "name": "${tenant}"
+                    },
+                    "spec": {
+                      "expr": "max(bifrost_reconciler_adoption_halted{k8s_cluster_name=~\"$cluster\"})"
+                    }
+                  },
+                  "refId": "A",
+                  "hidden": false
+                }
+              }
+            ],
+            "transformations": [],
+            "queryOptions": {}
+          }
+        },
+        "vizConfig": {
+          "kind": "VizConfig",
+          "group": "stat",
+          "version": "13.0.1+security-01",
+          "spec": {
+            "options": {
+              "colorMode": "background",
+              "graphMode": "none",
+              "justifyMode": "auto",
+              "orientation": "auto",
+              "percentChangeColorMode": "standard",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": false
+              },
+              "showPercentChange": false,
+              "textMode": "auto",
+              "wideLayout": true
+            },
+            "fieldConfig": {
+              "defaults": {
+                "mappings": [
+                  {
+                    "type": "value",
+                    "options": {
+                      "0": {
+                        "text": "Running",
+                        "color": "green"
+                      },
+                      "1": {
+                        "text": "Halted",
+                        "color": "red"
+                      }
+                    }
+                  }
+                ],
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "value": 0,
+                      "color": "green"
+                    },
+                    {
+                      "value": 80,
+                      "color": "red"
+                    }
+                  ]
+                }
+              },
+              "overrides": []
+            }
+          }
+        }
+      }
+    },
+    "panel-5": {
+      "kind": "Panel",
+      "spec": {
+        "id": 5,
+        "title": "Reconciler actions by reason",
+        "description": "",
+        "links": [],
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "query": {
+                    "kind": "DataQuery",
+                    "group": "prometheus",
+                    "version": "v0",
+                    "datasource": {
+                      "name": "${tenant}"
+                    },
+                    "spec": {
+                      "expr": "sum by (action, reason) (rate(bifrost_reconciler_actions_total{k8s_cluster_name=~\"$cluster\"}[5m]))",
+                      "legendFormat": "{{action}} / {{reason}}"
+                    }
+                  },
+                  "refId": "A",
+                  "hidden": false
+                }
+              }
+            ],
+            "transformations": [],
+            "queryOptions": {}
+          }
+        },
+        "vizConfig": {
+          "kind": "VizConfig",
+          "group": "timeseries",
+          "version": "13.0.1+security-01",
+          "spec": {
+            "options": {
+              "annotations": {
+                "clustering": -1,
+                "multiLane": false
+              },
+              "legend": {
+                "calcs": [],
+                "displayMode": "table",
+                "placement": "bottom",
+                "showLegend": true
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "mode": "multi",
+                "sort": "none"
+              }
+            },
+            "fieldConfig": {
+              "defaults": {
+                "unit": "ops",
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "value": 0,
+                      "color": "green"
+                    },
+                    {
+                      "value": 80,
+                      "color": "red"
+                    }
+                  ]
+                },
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "barWidthFactor": 0.6,
+                  "drawStyle": "line",
+                  "fillOpacity": 0,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 1,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "auto",
+                  "showValues": false,
+                  "spanNulls": false,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                }
+              },
+              "overrides": []
+            }
+          }
+        }
+      }
+    },
+    "panel-7": {
+      "kind": "Panel",
+      "spec": {
+        "id": 7,
+        "title": "ReleaseChannel health",
+        "description": "",
+        "links": [],
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "query": {
+                    "kind": "DataQuery",
+                    "group": "prometheus",
+                    "version": "v0",
+                    "datasource": {
+                      "name": "${tenant}"
+                    },
+                    "spec": {
+                      "expr": "min(unleasherator_releasechannel_status{k8s_cluster_name=~\"$cluster\"})"
+                    }
+                  },
+                  "refId": "A",
+                  "hidden": false
+                }
+              }
+            ],
+            "transformations": [],
+            "queryOptions": {}
+          }
+        },
+        "vizConfig": {
+          "kind": "VizConfig",
+          "group": "stat",
+          "version": "13.0.1+security-01",
+          "spec": {
+            "options": {
+              "colorMode": "background",
+              "graphMode": "none",
+              "justifyMode": "auto",
+              "orientation": "auto",
+              "percentChangeColorMode": "standard",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": false
+              },
+              "showPercentChange": false,
+              "textMode": "auto",
+              "wideLayout": true
+            },
+            "fieldConfig": {
+              "defaults": {
+                "mappings": [
+                  {
+                    "type": "value",
+                    "options": {
+                      "0": {
+                        "text": "Failed",
+                        "color": "red"
+                      },
+                      "1": {
+                        "text": "Healthy",
+                        "color": "green"
+                      },
+                      "0.5": {
+                        "text": "Rolling",
+                        "color": "yellow"
+                      }
+                    }
+                  }
+                ],
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "value": 0,
+                      "color": "green"
+                    },
+                    {
+                      "value": 80,
+                      "color": "red"
+                    }
+                  ]
+                }
+              },
+              "overrides": []
+            }
+          }
+        }
+      }
+    },
+    "panel-8": {
+      "kind": "Panel",
+      "spec": {
+        "id": 8,
+        "title": "ReleaseChannel progress",
+        "description": "",
+        "links": [],
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "query": {
+                    "kind": "DataQuery",
+                    "group": "prometheus",
+                    "version": "v0",
+                    "datasource": {
+                      "name": "${tenant}"
+                    },
+                    "spec": {
+                      "expr": "sum(unleasherator_releasechannel_instances_up_to_date{k8s_cluster_name=~\"$cluster\"})",
+                      "legendFormat": "up to date"
+                    }
+                  },
+                  "refId": "A",
+                  "hidden": false
+                }
+              },
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "query": {
+                    "kind": "DataQuery",
+                    "group": "prometheus",
+                    "version": "v0",
+                    "datasource": {
+                      "name": "${tenant}"
+                    },
+                    "spec": {
+                      "expr": "sum(unleasherator_releasechannel_instances_total{k8s_cluster_name=~\"$cluster\"})",
+                      "legendFormat": "total"
+                    }
+                  },
+                  "refId": "B",
+                  "hidden": false
+                }
+              }
+            ],
+            "transformations": [],
+            "queryOptions": {}
+          }
+        },
+        "vizConfig": {
+          "kind": "VizConfig",
+          "group": "timeseries",
+          "version": "13.0.1+security-01",
+          "spec": {
+            "options": {
+              "annotations": {
+                "clustering": -1,
+                "multiLane": false
+              },
+              "legend": {
+                "calcs": [],
+                "displayMode": "table",
+                "placement": "bottom",
+                "showLegend": true
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "mode": "multi",
+                "sort": "none"
+              }
+            },
+            "fieldConfig": {
+              "defaults": {
+                "unit": "short",
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "value": 0,
+                      "color": "green"
+                    },
+                    {
+                      "value": 80,
+                      "color": "red"
+                    }
+                  ]
+                },
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "barWidthFactor": 0.6,
+                  "drawStyle": "line",
+                  "fillOpacity": 0,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 1,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "auto",
+                  "showValues": false,
+                  "spanNulls": false,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                }
+              },
+              "overrides": []
+            }
+          }
+        }
+      }
+    },
+    "panel-9": {
+      "kind": "Panel",
+      "spec": {
+        "id": 9,
+        "title": "Controller workqueue depth",
+        "description": "",
+        "links": [],
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "query": {
+                    "kind": "DataQuery",
+                    "group": "prometheus",
+                    "version": "v0",
+                    "datasource": {
+                      "name": "${tenant}"
+                    },
+                    "spec": {
+                      "expr": "max by (name) (workqueue_depth{name=~\".*unleash.*|.*releasechannel.*\", k8s_cluster_name=~\"$cluster\"})",
+                      "legendFormat": "{{name}}"
+                    }
+                  },
+                  "refId": "A",
+                  "hidden": false
+                }
+              }
+            ],
+            "transformations": [],
+            "queryOptions": {}
+          }
+        },
+        "vizConfig": {
+          "kind": "VizConfig",
+          "group": "timeseries",
+          "version": "13.0.1+security-01",
+          "spec": {
+            "options": {
+              "annotations": {
+                "clustering": -1,
+                "multiLane": false
+              },
+              "legend": {
+                "calcs": [],
+                "displayMode": "table",
+                "placement": "bottom",
+                "showLegend": true
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "mode": "multi",
+                "sort": "none"
+              }
+            },
+            "fieldConfig": {
+              "defaults": {
+                "unit": "short",
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "value": 0,
+                      "color": "green"
+                    },
+                    {
+                      "value": 80,
+                      "color": "red"
+                    }
+                  ]
+                },
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "barWidthFactor": 0.6,
+                  "drawStyle": "line",
+                  "fillOpacity": 0,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 1,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "auto",
+                  "showValues": false,
+                  "spanNulls": false,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                }
+              },
+              "overrides": []
+            }
+          }
+        }
+      }
     }
   },
-  "spec": {
-    "annotations": [
-      {
-        "kind": "AnnotationQuery",
-        "spec": {
-          "query": {
-            "kind": "DataQuery",
-            "group": "grafana",
-            "version": "v0",
-            "datasource": {
-              "name": "-- Grafana --"
-            },
-            "spec": {}
-          },
-          "enable": true,
-          "hide": true,
-          "iconColor": "rgba(0, 211, 255, 1)",
-          "name": "Annotations & Alerts",
-          "builtIn": true
+  "layout": {
+    "kind": "RowsLayout",
+    "spec": {
+      "rows": [
+        {
+          "kind": "RowsLayoutRow",
+          "spec": {
+            "title": "Bifrost census age by tenant",
+            "collapse": false,
+            "layout": {
+              "kind": "GridLayout",
+              "spec": {
+                "items": [
+                  {
+                    "kind": "GridLayoutItem",
+                    "spec": {
+                      "x": 0,
+                      "y": 0,
+                      "width": 6,
+                      "height": 5,
+                      "element": {
+                        "kind": "ElementReference",
+                        "name": "panel-2"
+                      },
+                      "repeat": {
+                        "mode": "variable",
+                        "value": "tenant"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "kind": "RowsLayoutRow",
+          "spec": {
+            "title": "Bifrost managed instances by tenant",
+            "collapse": false,
+            "layout": {
+              "kind": "GridLayout",
+              "spec": {
+                "items": [
+                  {
+                    "kind": "GridLayoutItem",
+                    "spec": {
+                      "x": 0,
+                      "y": 0,
+                      "width": 6,
+                      "height": 7,
+                      "element": {
+                        "kind": "ElementReference",
+                        "name": "panel-3"
+                      },
+                      "repeat": {
+                        "mode": "variable",
+                        "value": "tenant"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "kind": "RowsLayoutRow",
+          "spec": {
+            "title": "Bifrost adoption state by tenant",
+            "collapse": false,
+            "layout": {
+              "kind": "GridLayout",
+              "spec": {
+                "items": [
+                  {
+                    "kind": "GridLayoutItem",
+                    "spec": {
+                      "x": 0,
+                      "y": 0,
+                      "width": 6,
+                      "height": 5,
+                      "element": {
+                        "kind": "ElementReference",
+                        "name": "panel-4"
+                      },
+                      "repeat": {
+                        "mode": "variable",
+                        "value": "tenant"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "kind": "RowsLayoutRow",
+          "spec": {
+            "title": "Bifrost reconciler actions by tenant",
+            "collapse": false,
+            "layout": {
+              "kind": "GridLayout",
+              "spec": {
+                "items": [
+                  {
+                    "kind": "GridLayoutItem",
+                    "spec": {
+                      "x": 0,
+                      "y": 0,
+                      "width": 6,
+                      "height": 7,
+                      "element": {
+                        "kind": "ElementReference",
+                        "name": "panel-5"
+                      },
+                      "repeat": {
+                        "mode": "variable",
+                        "value": "tenant"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "kind": "RowsLayoutRow",
+          "spec": {
+            "title": "ReleaseChannel health by tenant",
+            "collapse": false,
+            "layout": {
+              "kind": "GridLayout",
+              "spec": {
+                "items": [
+                  {
+                    "kind": "GridLayoutItem",
+                    "spec": {
+                      "x": 0,
+                      "y": 0,
+                      "width": 6,
+                      "height": 5,
+                      "element": {
+                        "kind": "ElementReference",
+                        "name": "panel-7"
+                      },
+                      "repeat": {
+                        "mode": "variable",
+                        "value": "tenant"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "kind": "RowsLayoutRow",
+          "spec": {
+            "title": "ReleaseChannel progress by tenant",
+            "collapse": false,
+            "layout": {
+              "kind": "GridLayout",
+              "spec": {
+                "items": [
+                  {
+                    "kind": "GridLayoutItem",
+                    "spec": {
+                      "x": 0,
+                      "y": 0,
+                      "width": 6,
+                      "height": 7,
+                      "element": {
+                        "kind": "ElementReference",
+                        "name": "panel-8"
+                      },
+                      "repeat": {
+                        "mode": "variable",
+                        "value": "tenant"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "kind": "RowsLayoutRow",
+          "spec": {
+            "title": "Unleasherator workqueue depth by tenant",
+            "collapse": false,
+            "layout": {
+              "kind": "GridLayout",
+              "spec": {
+                "items": [
+                  {
+                    "kind": "GridLayoutItem",
+                    "spec": {
+                      "x": 0,
+                      "y": 0,
+                      "width": 6,
+                      "height": 7,
+                      "element": {
+                        "kind": "ElementReference",
+                        "name": "panel-9"
+                      },
+                      "repeat": {
+                        "mode": "variable",
+                        "value": "tenant"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
         }
-      }
+      ]
+    }
+  },
+  "links": [],
+  "liveNow": false,
+  "preload": false,
+  "tags": [],
+  "timeSettings": {
+    "timezone": "browser",
+    "from": "now-6h",
+    "to": "now",
+    "autoRefresh": "",
+    "autoRefreshIntervals": [
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
     ],
-    "cursorSync": "Off",
-    "editable": true,
-    "elements": {
-      "panel-2": {
-        "kind": "Panel",
-        "spec": {
-          "id": 2,
-          "title": "Census age",
-          "description": "",
-          "links": [],
-          "data": {
-            "kind": "QueryGroup",
-            "spec": {
-              "queries": [
-                {
-                  "kind": "PanelQuery",
-                  "spec": {
-                    "query": {
-                      "kind": "DataQuery",
-                      "group": "prometheus",
-                      "version": "v0",
-                      "datasource": {
-                        "name": "${tenant}"
-                      },
-                      "spec": {
-                        "expr": "time() - max(bifrost_reconciler_instances_updated_timestamp_seconds{k8s_cluster_name=~\"$cluster\"})",
-                        "legendFormat": "{{__field.name}}"
-                      }
-                    },
-                    "refId": "A",
-                    "hidden": false
-                  }
-                }
-              ],
-              "transformations": [],
-              "queryOptions": {}
-            }
-          },
-          "vizConfig": {
-            "kind": "VizConfig",
-            "group": "stat",
-            "version": "13.0.1+security-01",
-            "spec": {
-              "options": {
-                "colorMode": "background",
-                "graphMode": "none",
-                "justifyMode": "auto",
-                "orientation": "auto",
-                "percentChangeColorMode": "standard",
-                "reduceOptions": {
-                  "calcs": [
-                    "lastNotNull"
-                  ],
-                  "fields": "",
-                  "values": false
-                },
-                "showPercentChange": false,
-                "textMode": "auto",
-                "wideLayout": true
-              },
-              "fieldConfig": {
-                "defaults": {
-                  "unit": "s",
-                  "thresholds": {
-                    "mode": "absolute",
-                    "steps": [
-                      {
-                        "value": 0,
-                        "color": "green"
-                      },
-                      {
-                        "value": 900,
-                        "color": "yellow"
-                      },
-                      {
-                        "value": 1800,
-                        "color": "red"
-                      }
-                    ]
-                  }
-                },
-                "overrides": []
-              }
-            }
-          }
-        }
-      },
-      "panel-3": {
-        "kind": "Panel",
-        "spec": {
-          "id": 3,
-          "title": "Managed and unmanaged instances",
-          "description": "",
-          "links": [],
-          "data": {
-            "kind": "QueryGroup",
-            "spec": {
-              "queries": [
-                {
-                  "kind": "PanelQuery",
-                  "spec": {
-                    "query": {
-                      "kind": "DataQuery",
-                      "group": "prometheus",
-                      "version": "v0",
-                      "datasource": {
-                        "name": "${tenant}"
-                      },
-                      "spec": {
-                        "expr": "bifrost_reconciler_managed_instances{k8s_cluster_name=~\"$cluster\"}",
-                        "legendFormat": "managed"
-                      }
-                    },
-                    "refId": "A",
-                    "hidden": false
-                  }
-                },
-                {
-                  "kind": "PanelQuery",
-                  "spec": {
-                    "query": {
-                      "kind": "DataQuery",
-                      "group": "prometheus",
-                      "version": "v0",
-                      "datasource": {
-                        "name": "${tenant}"
-                      },
-                      "spec": {
-                        "expr": "bifrost_reconciler_unmanaged_instances{k8s_cluster_name=~\"$cluster\"}",
-                        "legendFormat": "unmanaged"
-                      }
-                    },
-                    "refId": "B",
-                    "hidden": false
-                  }
-                }
-              ],
-              "transformations": [],
-              "queryOptions": {}
-            }
-          },
-          "vizConfig": {
-            "kind": "VizConfig",
-            "group": "timeseries",
-            "version": "13.0.1+security-01",
-            "spec": {
-              "options": {
-                "annotations": {
-                  "clustering": -1,
-                  "multiLane": false
-                },
-                "legend": {
-                  "calcs": [],
-                  "displayMode": "table",
-                  "placement": "bottom",
-                  "showLegend": true
-                },
-                "tooltip": {
-                  "hideZeros": false,
-                  "mode": "multi",
-                  "sort": "none"
-                }
-              },
-              "fieldConfig": {
-                "defaults": {
-                  "unit": "short",
-                  "thresholds": {
-                    "mode": "absolute",
-                    "steps": [
-                      {
-                        "value": 0,
-                        "color": "green"
-                      },
-                      {
-                        "value": 80,
-                        "color": "red"
-                      }
-                    ]
-                  },
-                  "color": {
-                    "mode": "palette-classic"
-                  },
-                  "custom": {
-                    "axisBorderShow": false,
-                    "axisCenteredZero": false,
-                    "axisColorMode": "text",
-                    "axisLabel": "",
-                    "axisPlacement": "auto",
-                    "barAlignment": 0,
-                    "barWidthFactor": 0.6,
-                    "drawStyle": "line",
-                    "fillOpacity": 0,
-                    "gradientMode": "none",
-                    "hideFrom": {
-                      "legend": false,
-                      "tooltip": false,
-                      "viz": false
-                    },
-                    "insertNulls": false,
-                    "lineInterpolation": "linear",
-                    "lineWidth": 1,
-                    "pointSize": 5,
-                    "scaleDistribution": {
-                      "type": "linear"
-                    },
-                    "showPoints": "auto",
-                    "showValues": false,
-                    "spanNulls": false,
-                    "stacking": {
-                      "group": "A",
-                      "mode": "none"
-                    },
-                    "thresholdsStyle": {
-                      "mode": "off"
-                    }
-                  }
-                },
-                "overrides": []
-              }
-            }
-          }
-        }
-      },
-      "panel-4": {
-        "kind": "Panel",
-        "spec": {
-          "id": 4,
-          "title": "Adoption halted",
-          "description": "",
-          "links": [],
-          "data": {
-            "kind": "QueryGroup",
-            "spec": {
-              "queries": [
-                {
-                  "kind": "PanelQuery",
-                  "spec": {
-                    "query": {
-                      "kind": "DataQuery",
-                      "group": "prometheus",
-                      "version": "v0",
-                      "datasource": {
-                        "name": "${tenant}"
-                      },
-                      "spec": {
-                        "expr": "max(bifrost_reconciler_adoption_halted{k8s_cluster_name=~\"$cluster\"})"
-                      }
-                    },
-                    "refId": "A",
-                    "hidden": false
-                  }
-                }
-              ],
-              "transformations": [],
-              "queryOptions": {}
-            }
-          },
-          "vizConfig": {
-            "kind": "VizConfig",
-            "group": "stat",
-            "version": "13.0.1+security-01",
-            "spec": {
-              "options": {
-                "colorMode": "background",
-                "graphMode": "none",
-                "justifyMode": "auto",
-                "orientation": "auto",
-                "percentChangeColorMode": "standard",
-                "reduceOptions": {
-                  "calcs": [
-                    "lastNotNull"
-                  ],
-                  "fields": "",
-                  "values": false
-                },
-                "showPercentChange": false,
-                "textMode": "auto",
-                "wideLayout": true
-              },
-              "fieldConfig": {
-                "defaults": {
-                  "mappings": [
-                    {
-                      "type": "value",
-                      "options": {
-                        "0": {
-                          "text": "Running",
-                          "color": "green"
-                        },
-                        "1": {
-                          "text": "Halted",
-                          "color": "red"
-                        }
-                      }
-                    }
-                  ],
-                  "thresholds": {
-                    "mode": "absolute",
-                    "steps": [
-                      {
-                        "value": 0,
-                        "color": "green"
-                      },
-                      {
-                        "value": 80,
-                        "color": "red"
-                      }
-                    ]
-                  }
-                },
-                "overrides": []
-              }
-            }
-          }
-        }
-      },
-      "panel-5": {
-        "kind": "Panel",
-        "spec": {
-          "id": 5,
-          "title": "Reconciler actions by reason",
-          "description": "",
-          "links": [],
-          "data": {
-            "kind": "QueryGroup",
-            "spec": {
-              "queries": [
-                {
-                  "kind": "PanelQuery",
-                  "spec": {
-                    "query": {
-                      "kind": "DataQuery",
-                      "group": "prometheus",
-                      "version": "v0",
-                      "datasource": {
-                        "name": "${tenant}"
-                      },
-                      "spec": {
-                        "expr": "sum by (action, reason) (rate(bifrost_reconciler_actions_total{k8s_cluster_name=~\"$cluster\"}[5m]))",
-                        "legendFormat": "{{action}} / {{reason}}"
-                      }
-                    },
-                    "refId": "A",
-                    "hidden": false
-                  }
-                }
-              ],
-              "transformations": [],
-              "queryOptions": {}
-            }
-          },
-          "vizConfig": {
-            "kind": "VizConfig",
-            "group": "timeseries",
-            "version": "13.0.1+security-01",
-            "spec": {
-              "options": {
-                "annotations": {
-                  "clustering": -1,
-                  "multiLane": false
-                },
-                "legend": {
-                  "calcs": [],
-                  "displayMode": "table",
-                  "placement": "bottom",
-                  "showLegend": true
-                },
-                "tooltip": {
-                  "hideZeros": false,
-                  "mode": "multi",
-                  "sort": "none"
-                }
-              },
-              "fieldConfig": {
-                "defaults": {
-                  "unit": "ops",
-                  "thresholds": {
-                    "mode": "absolute",
-                    "steps": [
-                      {
-                        "value": 0,
-                        "color": "green"
-                      },
-                      {
-                        "value": 80,
-                        "color": "red"
-                      }
-                    ]
-                  },
-                  "color": {
-                    "mode": "palette-classic"
-                  },
-                  "custom": {
-                    "axisBorderShow": false,
-                    "axisCenteredZero": false,
-                    "axisColorMode": "text",
-                    "axisLabel": "",
-                    "axisPlacement": "auto",
-                    "barAlignment": 0,
-                    "barWidthFactor": 0.6,
-                    "drawStyle": "line",
-                    "fillOpacity": 0,
-                    "gradientMode": "none",
-                    "hideFrom": {
-                      "legend": false,
-                      "tooltip": false,
-                      "viz": false
-                    },
-                    "insertNulls": false,
-                    "lineInterpolation": "linear",
-                    "lineWidth": 1,
-                    "pointSize": 5,
-                    "scaleDistribution": {
-                      "type": "linear"
-                    },
-                    "showPoints": "auto",
-                    "showValues": false,
-                    "spanNulls": false,
-                    "stacking": {
-                      "group": "A",
-                      "mode": "none"
-                    },
-                    "thresholdsStyle": {
-                      "mode": "off"
-                    }
-                  }
-                },
-                "overrides": []
-              }
-            }
-          }
-        }
-      },
-      "panel-7": {
-        "kind": "Panel",
-        "spec": {
-          "id": 7,
-          "title": "ReleaseChannel health",
-          "description": "",
-          "links": [],
-          "data": {
-            "kind": "QueryGroup",
-            "spec": {
-              "queries": [
-                {
-                  "kind": "PanelQuery",
-                  "spec": {
-                    "query": {
-                      "kind": "DataQuery",
-                      "group": "prometheus",
-                      "version": "v0",
-                      "datasource": {
-                        "name": "${tenant}"
-                      },
-                      "spec": {
-                        "expr": "min(unleasherator_releasechannel_status{k8s_cluster_name=~\"$cluster\"})"
-                      }
-                    },
-                    "refId": "A",
-                    "hidden": false
-                  }
-                }
-              ],
-              "transformations": [],
-              "queryOptions": {}
-            }
-          },
-          "vizConfig": {
-            "kind": "VizConfig",
-            "group": "stat",
-            "version": "13.0.1+security-01",
-            "spec": {
-              "options": {
-                "colorMode": "background",
-                "graphMode": "none",
-                "justifyMode": "auto",
-                "orientation": "auto",
-                "percentChangeColorMode": "standard",
-                "reduceOptions": {
-                  "calcs": [
-                    "lastNotNull"
-                  ],
-                  "fields": "",
-                  "values": false
-                },
-                "showPercentChange": false,
-                "textMode": "auto",
-                "wideLayout": true
-              },
-              "fieldConfig": {
-                "defaults": {
-                  "mappings": [
-                    {
-                      "type": "value",
-                      "options": {
-                        "0": {
-                          "text": "Failed",
-                          "color": "red"
-                        },
-                        "1": {
-                          "text": "Healthy",
-                          "color": "green"
-                        },
-                        "0.5": {
-                          "text": "Rolling",
-                          "color": "yellow"
-                        }
-                      }
-                    }
-                  ],
-                  "thresholds": {
-                    "mode": "absolute",
-                    "steps": [
-                      {
-                        "value": 0,
-                        "color": "green"
-                      },
-                      {
-                        "value": 80,
-                        "color": "red"
-                      }
-                    ]
-                  }
-                },
-                "overrides": []
-              }
-            }
-          }
-        }
-      },
-      "panel-8": {
-        "kind": "Panel",
-        "spec": {
-          "id": 8,
-          "title": "ReleaseChannel progress",
-          "description": "",
-          "links": [],
-          "data": {
-            "kind": "QueryGroup",
-            "spec": {
-              "queries": [
-                {
-                  "kind": "PanelQuery",
-                  "spec": {
-                    "query": {
-                      "kind": "DataQuery",
-                      "group": "prometheus",
-                      "version": "v0",
-                      "datasource": {
-                        "name": "${tenant}"
-                      },
-                      "spec": {
-                        "expr": "sum(unleasherator_releasechannel_instances_up_to_date{k8s_cluster_name=~\"$cluster\"})",
-                        "legendFormat": "up to date"
-                      }
-                    },
-                    "refId": "A",
-                    "hidden": false
-                  }
-                },
-                {
-                  "kind": "PanelQuery",
-                  "spec": {
-                    "query": {
-                      "kind": "DataQuery",
-                      "group": "prometheus",
-                      "version": "v0",
-                      "datasource": {
-                        "name": "${tenant}"
-                      },
-                      "spec": {
-                        "expr": "sum(unleasherator_releasechannel_instances_total{k8s_cluster_name=~\"$cluster\"})",
-                        "legendFormat": "total"
-                      }
-                    },
-                    "refId": "B",
-                    "hidden": false
-                  }
-                }
-              ],
-              "transformations": [],
-              "queryOptions": {}
-            }
-          },
-          "vizConfig": {
-            "kind": "VizConfig",
-            "group": "timeseries",
-            "version": "13.0.1+security-01",
-            "spec": {
-              "options": {
-                "annotations": {
-                  "clustering": -1,
-                  "multiLane": false
-                },
-                "legend": {
-                  "calcs": [],
-                  "displayMode": "table",
-                  "placement": "bottom",
-                  "showLegend": true
-                },
-                "tooltip": {
-                  "hideZeros": false,
-                  "mode": "multi",
-                  "sort": "none"
-                }
-              },
-              "fieldConfig": {
-                "defaults": {
-                  "unit": "short",
-                  "thresholds": {
-                    "mode": "absolute",
-                    "steps": [
-                      {
-                        "value": 0,
-                        "color": "green"
-                      },
-                      {
-                        "value": 80,
-                        "color": "red"
-                      }
-                    ]
-                  },
-                  "color": {
-                    "mode": "palette-classic"
-                  },
-                  "custom": {
-                    "axisBorderShow": false,
-                    "axisCenteredZero": false,
-                    "axisColorMode": "text",
-                    "axisLabel": "",
-                    "axisPlacement": "auto",
-                    "barAlignment": 0,
-                    "barWidthFactor": 0.6,
-                    "drawStyle": "line",
-                    "fillOpacity": 0,
-                    "gradientMode": "none",
-                    "hideFrom": {
-                      "legend": false,
-                      "tooltip": false,
-                      "viz": false
-                    },
-                    "insertNulls": false,
-                    "lineInterpolation": "linear",
-                    "lineWidth": 1,
-                    "pointSize": 5,
-                    "scaleDistribution": {
-                      "type": "linear"
-                    },
-                    "showPoints": "auto",
-                    "showValues": false,
-                    "spanNulls": false,
-                    "stacking": {
-                      "group": "A",
-                      "mode": "none"
-                    },
-                    "thresholdsStyle": {
-                      "mode": "off"
-                    }
-                  }
-                },
-                "overrides": []
-              }
-            }
-          }
-        }
-      },
-      "panel-9": {
-        "kind": "Panel",
-        "spec": {
-          "id": 9,
-          "title": "Controller workqueue depth",
-          "description": "",
-          "links": [],
-          "data": {
-            "kind": "QueryGroup",
-            "spec": {
-              "queries": [
-                {
-                  "kind": "PanelQuery",
-                  "spec": {
-                    "query": {
-                      "kind": "DataQuery",
-                      "group": "prometheus",
-                      "version": "v0",
-                      "datasource": {
-                        "name": "${tenant}"
-                      },
-                      "spec": {
-                        "expr": "max by (name) (workqueue_depth{name=~\".*unleash.*|.*releasechannel.*\", k8s_cluster_name=~\"$cluster\"})",
-                        "legendFormat": "{{name}}"
-                      }
-                    },
-                    "refId": "A",
-                    "hidden": false
-                  }
-                }
-              ],
-              "transformations": [],
-              "queryOptions": {}
-            }
-          },
-          "vizConfig": {
-            "kind": "VizConfig",
-            "group": "timeseries",
-            "version": "13.0.1+security-01",
-            "spec": {
-              "options": {
-                "annotations": {
-                  "clustering": -1,
-                  "multiLane": false
-                },
-                "legend": {
-                  "calcs": [],
-                  "displayMode": "table",
-                  "placement": "bottom",
-                  "showLegend": true
-                },
-                "tooltip": {
-                  "hideZeros": false,
-                  "mode": "multi",
-                  "sort": "none"
-                }
-              },
-              "fieldConfig": {
-                "defaults": {
-                  "unit": "short",
-                  "thresholds": {
-                    "mode": "absolute",
-                    "steps": [
-                      {
-                        "value": 0,
-                        "color": "green"
-                      },
-                      {
-                        "value": 80,
-                        "color": "red"
-                      }
-                    ]
-                  },
-                  "color": {
-                    "mode": "palette-classic"
-                  },
-                  "custom": {
-                    "axisBorderShow": false,
-                    "axisCenteredZero": false,
-                    "axisColorMode": "text",
-                    "axisLabel": "",
-                    "axisPlacement": "auto",
-                    "barAlignment": 0,
-                    "barWidthFactor": 0.6,
-                    "drawStyle": "line",
-                    "fillOpacity": 0,
-                    "gradientMode": "none",
-                    "hideFrom": {
-                      "legend": false,
-                      "tooltip": false,
-                      "viz": false
-                    },
-                    "insertNulls": false,
-                    "lineInterpolation": "linear",
-                    "lineWidth": 1,
-                    "pointSize": 5,
-                    "scaleDistribution": {
-                      "type": "linear"
-                    },
-                    "showPoints": "auto",
-                    "showValues": false,
-                    "spanNulls": false,
-                    "stacking": {
-                      "group": "A",
-                      "mode": "none"
-                    },
-                    "thresholdsStyle": {
-                      "mode": "off"
-                    }
-                  }
-                },
-                "overrides": []
-              }
-            }
-          }
-        }
-      }
-    },
-    "layout": {
-      "kind": "RowsLayout",
+    "hideTimepicker": false,
+    "fiscalYearStartMonth": 0
+  },
+  "title": "Unleash Tenant Overview",
+  "variables": [
+    {
+      "kind": "DatasourceVariable",
       "spec": {
-        "rows": [
-          {
-            "kind": "RowsLayoutRow",
-            "spec": {
-              "title": "Bifrost census age by tenant",
-              "collapse": false,
-              "layout": {
-                "kind": "GridLayout",
-                "spec": {
-                  "items": [
-                    {
-                      "kind": "GridLayoutItem",
-                      "spec": {
-                        "x": 0,
-                        "y": 0,
-                        "width": 6,
-                        "height": 5,
-                        "element": {
-                          "kind": "ElementReference",
-                          "name": "panel-2"
-                        },
-                        "repeat": {
-                          "mode": "variable",
-                          "value": "tenant"
-                        }
-                      }
-                    }
-                  ]
-                }
-              }
-            }
+        "name": "tenant",
+        "pluginId": "prometheus",
+        "refresh": "onDashboardLoad",
+        "regex": "",
+        "current": {
+          "text": [
+            "atil-metrics",
+            "ldir-metrics",
+            "nav-metrics",
+            "ssb-metrics"
+          ],
+          "value": [
+            "PF7D5629ECC453C64",
+            "P73126C2103EBFC69",
+            "P91A6F0B3584B90E7",
+            "PE607B8DC11CE4E99"
+          ]
+        },
+        "options": [],
+        "multi": true,
+        "includeAll": true,
+        "label": "Tenant",
+        "hide": "dontHide",
+        "skipUrlSync": false,
+        "description": "Select tenants. Panels repeat once per selected Mimir datasource.",
+        "allowCustomValue": true
+      }
+    },
+    {
+      "kind": "QueryVariable",
+      "spec": {
+        "name": "cluster",
+        "current": {
+          "text": [
+            "management"
+          ],
+          "value": [
+            "management"
+          ]
+        },
+        "label": "Cluster",
+        "hide": "dontHide",
+        "refresh": "never",
+        "skipUrlSync": false,
+        "description": "Filter by Kubernetes cluster.",
+        "query": {
+          "kind": "DataQuery",
+          "group": "prometheus",
+          "version": "v0",
+          "datasource": {
+            "name": "${tenant}"
           },
-          {
-            "kind": "RowsLayoutRow",
-            "spec": {
-              "title": "Bifrost managed instances by tenant",
-              "collapse": false,
-              "layout": {
-                "kind": "GridLayout",
-                "spec": {
-                  "items": [
-                    {
-                      "kind": "GridLayoutItem",
-                      "spec": {
-                        "x": 0,
-                        "y": 0,
-                        "width": 6,
-                        "height": 7,
-                        "element": {
-                          "kind": "ElementReference",
-                          "name": "panel-3"
-                        },
-                        "repeat": {
-                          "mode": "variable",
-                          "value": "tenant"
-                        }
-                      }
-                    }
-                  ]
-                }
-              }
-            }
-          },
-          {
-            "kind": "RowsLayoutRow",
-            "spec": {
-              "title": "Bifrost adoption state by tenant",
-              "collapse": false,
-              "layout": {
-                "kind": "GridLayout",
-                "spec": {
-                  "items": [
-                    {
-                      "kind": "GridLayoutItem",
-                      "spec": {
-                        "x": 0,
-                        "y": 0,
-                        "width": 6,
-                        "height": 5,
-                        "element": {
-                          "kind": "ElementReference",
-                          "name": "panel-4"
-                        },
-                        "repeat": {
-                          "mode": "variable",
-                          "value": "tenant"
-                        }
-                      }
-                    }
-                  ]
-                }
-              }
-            }
-          },
-          {
-            "kind": "RowsLayoutRow",
-            "spec": {
-              "title": "Bifrost reconciler actions by tenant",
-              "collapse": false,
-              "layout": {
-                "kind": "GridLayout",
-                "spec": {
-                  "items": [
-                    {
-                      "kind": "GridLayoutItem",
-                      "spec": {
-                        "x": 0,
-                        "y": 0,
-                        "width": 6,
-                        "height": 7,
-                        "element": {
-                          "kind": "ElementReference",
-                          "name": "panel-5"
-                        },
-                        "repeat": {
-                          "mode": "variable",
-                          "value": "tenant"
-                        }
-                      }
-                    }
-                  ]
-                }
-              }
-            }
-          },
-          {
-            "kind": "RowsLayoutRow",
-            "spec": {
-              "title": "ReleaseChannel health by tenant",
-              "collapse": false,
-              "layout": {
-                "kind": "GridLayout",
-                "spec": {
-                  "items": [
-                    {
-                      "kind": "GridLayoutItem",
-                      "spec": {
-                        "x": 0,
-                        "y": 0,
-                        "width": 6,
-                        "height": 5,
-                        "element": {
-                          "kind": "ElementReference",
-                          "name": "panel-7"
-                        },
-                        "repeat": {
-                          "mode": "variable",
-                          "value": "tenant"
-                        }
-                      }
-                    }
-                  ]
-                }
-              }
-            }
-          },
-          {
-            "kind": "RowsLayoutRow",
-            "spec": {
-              "title": "ReleaseChannel progress by tenant",
-              "collapse": false,
-              "layout": {
-                "kind": "GridLayout",
-                "spec": {
-                  "items": [
-                    {
-                      "kind": "GridLayoutItem",
-                      "spec": {
-                        "x": 0,
-                        "y": 0,
-                        "width": 6,
-                        "height": 7,
-                        "element": {
-                          "kind": "ElementReference",
-                          "name": "panel-8"
-                        },
-                        "repeat": {
-                          "mode": "variable",
-                          "value": "tenant"
-                        }
-                      }
-                    }
-                  ]
-                }
-              }
-            }
-          },
-          {
-            "kind": "RowsLayoutRow",
-            "spec": {
-              "title": "Unleasherator workqueue depth by tenant",
-              "collapse": false,
-              "layout": {
-                "kind": "GridLayout",
-                "spec": {
-                  "items": [
-                    {
-                      "kind": "GridLayoutItem",
-                      "spec": {
-                        "x": 0,
-                        "y": 0,
-                        "width": 6,
-                        "height": 7,
-                        "element": {
-                          "kind": "ElementReference",
-                          "name": "panel-9"
-                        },
-                        "repeat": {
-                          "mode": "variable",
-                          "value": "tenant"
-                        }
-                      }
-                    }
-                  ]
-                }
-              }
-            }
+          "spec": {
+            "__legacyStringValue": "label_values(up, k8s_cluster_name)"
           }
-        ]
+        },
+        "regex": "",
+        "regexApplyTo": "value",
+        "sort": "disabled",
+        "options": [],
+        "multi": true,
+        "includeAll": true,
+        "allValue": ".*",
+        "allowCustomValue": true
       }
-    },
-    "links": [],
-    "liveNow": false,
-    "preload": false,
-    "tags": [],
-    "timeSettings": {
-      "timezone": "browser",
-      "from": "now-6h",
-      "to": "now",
-      "autoRefresh": "",
-      "autoRefreshIntervals": [
-        "30s",
-        "1m",
-        "5m",
-        "15m",
-        "30m",
-        "1h",
-        "2h",
-        "1d"
-      ],
-      "hideTimepicker": false,
-      "fiscalYearStartMonth": 0
-    },
-    "title": "Unleash Tenant Overview",
-    "variables": [
-      {
-        "kind": "DatasourceVariable",
-        "spec": {
-          "name": "tenant",
-          "pluginId": "prometheus",
-          "refresh": "onDashboardLoad",
-          "regex": "",
-          "current": {
-            "text": [
-              "atil-metrics",
-              "ldir-metrics",
-              "nav-metrics",
-              "ssb-metrics"
-            ],
-            "value": [
-              "PF7D5629ECC453C64",
-              "P73126C2103EBFC69",
-              "P91A6F0B3584B90E7",
-              "PE607B8DC11CE4E99"
-            ]
-          },
-          "options": [],
-          "multi": true,
-          "includeAll": true,
-          "label": "Tenant",
-          "hide": "dontHide",
-          "skipUrlSync": false,
-          "description": "Select tenants. Panels repeat once per selected Mimir datasource.",
-          "allowCustomValue": true
-        }
-      },
-      {
-        "kind": "QueryVariable",
-        "spec": {
-          "name": "cluster",
-          "current": {
-            "text": [
-              "management"
-            ],
-            "value": [
-              "management"
-            ]
-          },
-          "label": "Cluster",
-          "hide": "dontHide",
-          "refresh": "never",
-          "skipUrlSync": false,
-          "description": "Filter by Kubernetes cluster.",
-          "query": {
-            "kind": "DataQuery",
-            "group": "prometheus",
-            "version": "v0",
-            "datasource": {
-              "name": "${tenant}"
-            },
-            "spec": {
-              "__legacyStringValue": "label_values(up, k8s_cluster_name)"
-            }
-          },
-          "regex": "",
-          "regexApplyTo": "value",
-          "sort": "disabled",
-          "options": [],
-          "multi": true,
-          "includeAll": true,
-          "allValue": ".*",
-          "allowCustomValue": true
-        }
-      }
-    ]
-  }
+    }
+  ]
 }

--- a/charts/unleasherator/dashboards/tenant-overview-dashboard.json
+++ b/charts/unleasherator/dashboards/tenant-overview-dashboard.json
@@ -3,20 +3,20 @@
     {
       "kind": "AnnotationQuery",
       "spec": {
-        "query": {
-          "kind": "DataQuery",
-          "group": "grafana",
-          "version": "v0",
-          "datasource": {
-            "name": "-- Grafana --"
-          },
-          "spec": {}
-        },
+        "builtIn": true,
         "enable": true,
         "hide": true,
         "iconColor": "rgba(0, 211, 255, 1)",
         "name": "Annotations & Alerts",
-        "builtIn": true
+        "query": {
+          "datasource": {
+            "name": "-- Grafana --"
+          },
+          "group": "grafana",
+          "kind": "DataQuery",
+          "spec": {},
+          "version": "v0"
+        }
       }
     }
   ],
@@ -26,10 +26,6 @@
     "panel-2": {
       "kind": "Panel",
       "spec": {
-        "id": 2,
-        "title": "Census age",
-        "description": "",
-        "links": [],
         "data": {
           "kind": "QueryGroup",
           "spec": {
@@ -37,32 +33,58 @@
               {
                 "kind": "PanelQuery",
                 "spec": {
+                  "hidden": false,
                   "query": {
-                    "kind": "DataQuery",
-                    "group": "prometheus",
-                    "version": "v0",
                     "datasource": {
                       "name": "${tenant}"
                     },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
                     "spec": {
                       "expr": "time() - max(bifrost_reconciler_instances_updated_timestamp_seconds{k8s_cluster_name=~\"$cluster\"})",
                       "legendFormat": "{{__field.name}}"
-                    }
+                    },
+                    "version": "v0"
                   },
-                  "refId": "A",
-                  "hidden": false
+                  "refId": "A"
                 }
               }
             ],
-            "transformations": [],
-            "queryOptions": {}
+            "queryOptions": {},
+            "transformations": []
           }
         },
+        "description": "",
+        "id": 2,
+        "links": [],
+        "title": "Census age",
         "vizConfig": {
-          "kind": "VizConfig",
           "group": "stat",
-          "version": "13.0.1+security-01",
+          "kind": "VizConfig",
           "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    },
+                    {
+                      "color": "yellow",
+                      "value": 900
+                    },
+                    {
+                      "color": "red",
+                      "value": 1800
+                    }
+                  ]
+                },
+                "unit": "s"
+              },
+              "overrides": []
+            },
             "options": {
               "colorMode": "background",
               "graphMode": "none",
@@ -79,41 +101,15 @@
               "showPercentChange": false,
               "textMode": "auto",
               "wideLayout": true
-            },
-            "fieldConfig": {
-              "defaults": {
-                "unit": "s",
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "value": 0,
-                      "color": "green"
-                    },
-                    {
-                      "value": 900,
-                      "color": "yellow"
-                    },
-                    {
-                      "value": 1800,
-                      "color": "red"
-                    }
-                  ]
-                }
-              },
-              "overrides": []
             }
-          }
+          },
+          "version": "13.0.1+security-01"
         }
       }
     },
     "panel-3": {
       "kind": "Panel",
       "spec": {
-        "id": 3,
-        "title": "Managed and unmanaged instances",
-        "description": "",
-        "links": [],
         "data": {
           "kind": "QueryGroup",
           "spec": {
@@ -121,84 +117,56 @@
               {
                 "kind": "PanelQuery",
                 "spec": {
+                  "hidden": false,
                   "query": {
-                    "kind": "DataQuery",
-                    "group": "prometheus",
-                    "version": "v0",
                     "datasource": {
                       "name": "${tenant}"
                     },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
                     "spec": {
                       "expr": "bifrost_reconciler_managed_instances{k8s_cluster_name=~\"$cluster\"}",
                       "legendFormat": "managed"
-                    }
+                    },
+                    "version": "v0"
                   },
-                  "refId": "A",
-                  "hidden": false
+                  "refId": "A"
                 }
               },
               {
                 "kind": "PanelQuery",
                 "spec": {
+                  "hidden": false,
                   "query": {
-                    "kind": "DataQuery",
-                    "group": "prometheus",
-                    "version": "v0",
                     "datasource": {
                       "name": "${tenant}"
                     },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
                     "spec": {
                       "expr": "bifrost_reconciler_unmanaged_instances{k8s_cluster_name=~\"$cluster\"}",
                       "legendFormat": "unmanaged"
-                    }
+                    },
+                    "version": "v0"
                   },
-                  "refId": "B",
-                  "hidden": false
+                  "refId": "B"
                 }
               }
             ],
-            "transformations": [],
-            "queryOptions": {}
+            "queryOptions": {},
+            "transformations": []
           }
         },
+        "description": "",
+        "id": 3,
+        "links": [],
+        "title": "Managed and unmanaged instances",
         "vizConfig": {
-          "kind": "VizConfig",
           "group": "timeseries",
-          "version": "13.0.1+security-01",
+          "kind": "VizConfig",
           "spec": {
-            "options": {
-              "annotations": {
-                "clustering": -1,
-                "multiLane": false
-              },
-              "legend": {
-                "calcs": [],
-                "displayMode": "table",
-                "placement": "bottom",
-                "showLegend": true
-              },
-              "tooltip": {
-                "hideZeros": false,
-                "mode": "multi",
-                "sort": "none"
-              }
-            },
             "fieldConfig": {
               "defaults": {
-                "unit": "short",
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "value": 0,
-                      "color": "green"
-                    },
-                    {
-                      "value": 80,
-                      "color": "red"
-                    }
-                  ]
-                },
                 "color": {
                   "mode": "palette-classic"
                 },
@@ -235,21 +203,49 @@
                   "thresholdsStyle": {
                     "mode": "off"
                   }
-                }
+                },
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    },
+                    {
+                      "color": "red",
+                      "value": 80
+                    }
+                  ]
+                },
+                "unit": "short"
               },
               "overrides": []
+            },
+            "options": {
+              "annotations": {
+                "clustering": -1,
+                "multiLane": false
+              },
+              "legend": {
+                "calcs": [],
+                "displayMode": "table",
+                "placement": "bottom",
+                "showLegend": true
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "mode": "multi",
+                "sort": "none"
+              }
             }
-          }
+          },
+          "version": "13.0.1+security-01"
         }
       }
     },
     "panel-4": {
       "kind": "Panel",
       "spec": {
-        "id": 4,
-        "title": "Adoption halted",
-        "description": "",
-        "links": [],
         "data": {
           "kind": "QueryGroup",
           "spec": {
@@ -257,31 +253,67 @@
               {
                 "kind": "PanelQuery",
                 "spec": {
+                  "hidden": false,
                   "query": {
-                    "kind": "DataQuery",
-                    "group": "prometheus",
-                    "version": "v0",
                     "datasource": {
                       "name": "${tenant}"
                     },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
                     "spec": {
                       "expr": "max(bifrost_reconciler_adoption_halted{k8s_cluster_name=~\"$cluster\"})"
-                    }
+                    },
+                    "version": "v0"
                   },
-                  "refId": "A",
-                  "hidden": false
+                  "refId": "A"
                 }
               }
             ],
-            "transformations": [],
-            "queryOptions": {}
+            "queryOptions": {},
+            "transformations": []
           }
         },
+        "description": "",
+        "id": 4,
+        "links": [],
+        "title": "Adoption halted",
         "vizConfig": {
-          "kind": "VizConfig",
           "group": "stat",
-          "version": "13.0.1+security-01",
+          "kind": "VizConfig",
           "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "mappings": [
+                  {
+                    "options": {
+                      "0": {
+                        "color": "green",
+                        "text": "Running"
+                      },
+                      "1": {
+                        "color": "red",
+                        "text": "Halted"
+                      }
+                    },
+                    "type": "value"
+                  }
+                ],
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    },
+                    {
+                      "color": "red",
+                      "value": 80
+                    }
+                  ]
+                }
+              },
+              "overrides": []
+            },
             "options": {
               "colorMode": "background",
               "graphMode": "none",
@@ -298,51 +330,15 @@
               "showPercentChange": false,
               "textMode": "auto",
               "wideLayout": true
-            },
-            "fieldConfig": {
-              "defaults": {
-                "mappings": [
-                  {
-                    "type": "value",
-                    "options": {
-                      "0": {
-                        "text": "Running",
-                        "color": "green"
-                      },
-                      "1": {
-                        "text": "Halted",
-                        "color": "red"
-                      }
-                    }
-                  }
-                ],
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "value": 0,
-                      "color": "green"
-                    },
-                    {
-                      "value": 80,
-                      "color": "red"
-                    }
-                  ]
-                }
-              },
-              "overrides": []
             }
-          }
+          },
+          "version": "13.0.1+security-01"
         }
       }
     },
     "panel-5": {
       "kind": "Panel",
       "spec": {
-        "id": 5,
-        "title": "Reconciler actions by reason",
-        "description": "",
-        "links": [],
         "data": {
           "kind": "QueryGroup",
           "spec": {
@@ -350,65 +346,37 @@
               {
                 "kind": "PanelQuery",
                 "spec": {
+                  "hidden": false,
                   "query": {
-                    "kind": "DataQuery",
-                    "group": "prometheus",
-                    "version": "v0",
                     "datasource": {
                       "name": "${tenant}"
                     },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
                     "spec": {
                       "expr": "sum by (action, reason) (rate(bifrost_reconciler_actions_total{k8s_cluster_name=~\"$cluster\"}[5m]))",
                       "legendFormat": "{{action}} / {{reason}}"
-                    }
+                    },
+                    "version": "v0"
                   },
-                  "refId": "A",
-                  "hidden": false
+                  "refId": "A"
                 }
               }
             ],
-            "transformations": [],
-            "queryOptions": {}
+            "queryOptions": {},
+            "transformations": []
           }
         },
+        "description": "",
+        "id": 5,
+        "links": [],
+        "title": "Reconciler actions by reason",
         "vizConfig": {
-          "kind": "VizConfig",
           "group": "timeseries",
-          "version": "13.0.1+security-01",
+          "kind": "VizConfig",
           "spec": {
-            "options": {
-              "annotations": {
-                "clustering": -1,
-                "multiLane": false
-              },
-              "legend": {
-                "calcs": [],
-                "displayMode": "table",
-                "placement": "bottom",
-                "showLegend": true
-              },
-              "tooltip": {
-                "hideZeros": false,
-                "mode": "multi",
-                "sort": "none"
-              }
-            },
             "fieldConfig": {
               "defaults": {
-                "unit": "ops",
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "value": 0,
-                      "color": "green"
-                    },
-                    {
-                      "value": 80,
-                      "color": "red"
-                    }
-                  ]
-                },
                 "color": {
                   "mode": "palette-classic"
                 },
@@ -445,21 +413,49 @@
                   "thresholdsStyle": {
                     "mode": "off"
                   }
-                }
+                },
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    },
+                    {
+                      "color": "red",
+                      "value": 80
+                    }
+                  ]
+                },
+                "unit": "ops"
               },
               "overrides": []
+            },
+            "options": {
+              "annotations": {
+                "clustering": -1,
+                "multiLane": false
+              },
+              "legend": {
+                "calcs": [],
+                "displayMode": "table",
+                "placement": "bottom",
+                "showLegend": true
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "mode": "multi",
+                "sort": "none"
+              }
             }
-          }
+          },
+          "version": "13.0.1+security-01"
         }
       }
     },
     "panel-7": {
       "kind": "Panel",
       "spec": {
-        "id": 7,
-        "title": "ReleaseChannel health",
-        "description": "",
-        "links": [],
         "data": {
           "kind": "QueryGroup",
           "spec": {
@@ -467,31 +463,71 @@
               {
                 "kind": "PanelQuery",
                 "spec": {
+                  "hidden": false,
                   "query": {
-                    "kind": "DataQuery",
-                    "group": "prometheus",
-                    "version": "v0",
                     "datasource": {
                       "name": "${tenant}"
                     },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
                     "spec": {
                       "expr": "min(unleasherator_releasechannel_status{k8s_cluster_name=~\"$cluster\"})"
-                    }
+                    },
+                    "version": "v0"
                   },
-                  "refId": "A",
-                  "hidden": false
+                  "refId": "A"
                 }
               }
             ],
-            "transformations": [],
-            "queryOptions": {}
+            "queryOptions": {},
+            "transformations": []
           }
         },
+        "description": "",
+        "id": 7,
+        "links": [],
+        "title": "ReleaseChannel health",
         "vizConfig": {
-          "kind": "VizConfig",
           "group": "stat",
-          "version": "13.0.1+security-01",
+          "kind": "VizConfig",
           "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "mappings": [
+                  {
+                    "options": {
+                      "0": {
+                        "color": "red",
+                        "text": "Failed"
+                      },
+                      "1": {
+                        "color": "green",
+                        "text": "Healthy"
+                      },
+                      "0.5": {
+                        "color": "yellow",
+                        "text": "Rolling"
+                      }
+                    },
+                    "type": "value"
+                  }
+                ],
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    },
+                    {
+                      "color": "red",
+                      "value": 80
+                    }
+                  ]
+                }
+              },
+              "overrides": []
+            },
             "options": {
               "colorMode": "background",
               "graphMode": "none",
@@ -508,55 +544,15 @@
               "showPercentChange": false,
               "textMode": "auto",
               "wideLayout": true
-            },
-            "fieldConfig": {
-              "defaults": {
-                "mappings": [
-                  {
-                    "type": "value",
-                    "options": {
-                      "0": {
-                        "text": "Failed",
-                        "color": "red"
-                      },
-                      "1": {
-                        "text": "Healthy",
-                        "color": "green"
-                      },
-                      "0.5": {
-                        "text": "Rolling",
-                        "color": "yellow"
-                      }
-                    }
-                  }
-                ],
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "value": 0,
-                      "color": "green"
-                    },
-                    {
-                      "value": 80,
-                      "color": "red"
-                    }
-                  ]
-                }
-              },
-              "overrides": []
             }
-          }
+          },
+          "version": "13.0.1+security-01"
         }
       }
     },
     "panel-8": {
       "kind": "Panel",
       "spec": {
-        "id": 8,
-        "title": "ReleaseChannel progress",
-        "description": "",
-        "links": [],
         "data": {
           "kind": "QueryGroup",
           "spec": {
@@ -564,84 +560,56 @@
               {
                 "kind": "PanelQuery",
                 "spec": {
+                  "hidden": false,
                   "query": {
-                    "kind": "DataQuery",
-                    "group": "prometheus",
-                    "version": "v0",
                     "datasource": {
                       "name": "${tenant}"
                     },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
                     "spec": {
                       "expr": "sum(unleasherator_releasechannel_instances_up_to_date{k8s_cluster_name=~\"$cluster\"})",
                       "legendFormat": "up to date"
-                    }
+                    },
+                    "version": "v0"
                   },
-                  "refId": "A",
-                  "hidden": false
+                  "refId": "A"
                 }
               },
               {
                 "kind": "PanelQuery",
                 "spec": {
+                  "hidden": false,
                   "query": {
-                    "kind": "DataQuery",
-                    "group": "prometheus",
-                    "version": "v0",
                     "datasource": {
                       "name": "${tenant}"
                     },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
                     "spec": {
                       "expr": "sum(unleasherator_releasechannel_instances_total{k8s_cluster_name=~\"$cluster\"})",
                       "legendFormat": "total"
-                    }
+                    },
+                    "version": "v0"
                   },
-                  "refId": "B",
-                  "hidden": false
+                  "refId": "B"
                 }
               }
             ],
-            "transformations": [],
-            "queryOptions": {}
+            "queryOptions": {},
+            "transformations": []
           }
         },
+        "description": "",
+        "id": 8,
+        "links": [],
+        "title": "ReleaseChannel progress",
         "vizConfig": {
-          "kind": "VizConfig",
           "group": "timeseries",
-          "version": "13.0.1+security-01",
+          "kind": "VizConfig",
           "spec": {
-            "options": {
-              "annotations": {
-                "clustering": -1,
-                "multiLane": false
-              },
-              "legend": {
-                "calcs": [],
-                "displayMode": "table",
-                "placement": "bottom",
-                "showLegend": true
-              },
-              "tooltip": {
-                "hideZeros": false,
-                "mode": "multi",
-                "sort": "none"
-              }
-            },
             "fieldConfig": {
               "defaults": {
-                "unit": "short",
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "value": 0,
-                      "color": "green"
-                    },
-                    {
-                      "value": 80,
-                      "color": "red"
-                    }
-                  ]
-                },
                 "color": {
                   "mode": "palette-classic"
                 },
@@ -678,21 +646,49 @@
                   "thresholdsStyle": {
                     "mode": "off"
                   }
-                }
+                },
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    },
+                    {
+                      "color": "red",
+                      "value": 80
+                    }
+                  ]
+                },
+                "unit": "short"
               },
               "overrides": []
+            },
+            "options": {
+              "annotations": {
+                "clustering": -1,
+                "multiLane": false
+              },
+              "legend": {
+                "calcs": [],
+                "displayMode": "table",
+                "placement": "bottom",
+                "showLegend": true
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "mode": "multi",
+                "sort": "none"
+              }
             }
-          }
+          },
+          "version": "13.0.1+security-01"
         }
       }
     },
     "panel-9": {
       "kind": "Panel",
       "spec": {
-        "id": 9,
-        "title": "Controller workqueue depth",
-        "description": "",
-        "links": [],
         "data": {
           "kind": "QueryGroup",
           "spec": {
@@ -700,65 +696,37 @@
               {
                 "kind": "PanelQuery",
                 "spec": {
+                  "hidden": false,
                   "query": {
-                    "kind": "DataQuery",
-                    "group": "prometheus",
-                    "version": "v0",
                     "datasource": {
                       "name": "${tenant}"
                     },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
                     "spec": {
                       "expr": "max by (name) (workqueue_depth{name=~\".*unleash.*|.*releasechannel.*\", k8s_cluster_name=~\"$cluster\"})",
                       "legendFormat": "{{name}}"
-                    }
+                    },
+                    "version": "v0"
                   },
-                  "refId": "A",
-                  "hidden": false
+                  "refId": "A"
                 }
               }
             ],
-            "transformations": [],
-            "queryOptions": {}
+            "queryOptions": {},
+            "transformations": []
           }
         },
+        "description": "",
+        "id": 9,
+        "links": [],
+        "title": "Controller workqueue depth",
         "vizConfig": {
-          "kind": "VizConfig",
           "group": "timeseries",
-          "version": "13.0.1+security-01",
+          "kind": "VizConfig",
           "spec": {
-            "options": {
-              "annotations": {
-                "clustering": -1,
-                "multiLane": false
-              },
-              "legend": {
-                "calcs": [],
-                "displayMode": "table",
-                "placement": "bottom",
-                "showLegend": true
-              },
-              "tooltip": {
-                "hideZeros": false,
-                "mode": "multi",
-                "sort": "none"
-              }
-            },
             "fieldConfig": {
               "defaults": {
-                "unit": "short",
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "value": 0,
-                      "color": "green"
-                    },
-                    {
-                      "value": 80,
-                      "color": "red"
-                    }
-                  ]
-                },
                 "color": {
                   "mode": "palette-classic"
                 },
@@ -795,11 +763,43 @@
                   "thresholdsStyle": {
                     "mode": "off"
                   }
-                }
+                },
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    },
+                    {
+                      "color": "red",
+                      "value": 80
+                    }
+                  ]
+                },
+                "unit": "short"
               },
               "overrides": []
+            },
+            "options": {
+              "annotations": {
+                "clustering": -1,
+                "multiLane": false
+              },
+              "legend": {
+                "calcs": [],
+                "displayMode": "table",
+                "placement": "bottom",
+                "showLegend": true
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "mode": "multi",
+                "sort": "none"
+              }
             }
-          }
+          },
+          "version": "13.0.1+security-01"
         }
       }
     }
@@ -811,7 +811,6 @@
         {
           "kind": "RowsLayoutRow",
           "spec": {
-            "title": "Bifrost census age by tenant",
             "collapse": false,
             "layout": {
               "kind": "GridLayout",
@@ -820,29 +819,30 @@
                   {
                     "kind": "GridLayoutItem",
                     "spec": {
-                      "x": 0,
-                      "y": 0,
-                      "width": 6,
-                      "height": 5,
                       "element": {
                         "kind": "ElementReference",
                         "name": "panel-2"
                       },
+                      "height": 5,
                       "repeat": {
                         "mode": "variable",
-                        "value": "tenant"
-                      }
+                        "value": "tenant",
+                        "maxPerRow": 4
+                      },
+                      "width": 6,
+                      "x": 0,
+                      "y": 0
                     }
                   }
                 ]
               }
-            }
+            },
+            "title": "Bifrost census age by tenant"
           }
         },
         {
           "kind": "RowsLayoutRow",
           "spec": {
-            "title": "Bifrost managed instances by tenant",
             "collapse": false,
             "layout": {
               "kind": "GridLayout",
@@ -851,29 +851,30 @@
                   {
                     "kind": "GridLayoutItem",
                     "spec": {
-                      "x": 0,
-                      "y": 0,
-                      "width": 6,
-                      "height": 7,
                       "element": {
                         "kind": "ElementReference",
                         "name": "panel-3"
                       },
+                      "height": 7,
                       "repeat": {
                         "mode": "variable",
-                        "value": "tenant"
-                      }
+                        "value": "tenant",
+                        "maxPerRow": 4
+                      },
+                      "width": 6,
+                      "x": 0,
+                      "y": 0
                     }
                   }
                 ]
               }
-            }
+            },
+            "title": "Bifrost managed instances by tenant"
           }
         },
         {
           "kind": "RowsLayoutRow",
           "spec": {
-            "title": "Bifrost adoption state by tenant",
             "collapse": false,
             "layout": {
               "kind": "GridLayout",
@@ -882,29 +883,30 @@
                   {
                     "kind": "GridLayoutItem",
                     "spec": {
-                      "x": 0,
-                      "y": 0,
-                      "width": 6,
-                      "height": 5,
                       "element": {
                         "kind": "ElementReference",
                         "name": "panel-4"
                       },
+                      "height": 5,
                       "repeat": {
                         "mode": "variable",
-                        "value": "tenant"
-                      }
+                        "value": "tenant",
+                        "maxPerRow": 4
+                      },
+                      "width": 6,
+                      "x": 0,
+                      "y": 0
                     }
                   }
                 ]
               }
-            }
+            },
+            "title": "Bifrost adoption state by tenant"
           }
         },
         {
           "kind": "RowsLayoutRow",
           "spec": {
-            "title": "Bifrost reconciler actions by tenant",
             "collapse": false,
             "layout": {
               "kind": "GridLayout",
@@ -913,29 +915,30 @@
                   {
                     "kind": "GridLayoutItem",
                     "spec": {
-                      "x": 0,
-                      "y": 0,
-                      "width": 6,
-                      "height": 7,
                       "element": {
                         "kind": "ElementReference",
                         "name": "panel-5"
                       },
+                      "height": 7,
                       "repeat": {
                         "mode": "variable",
-                        "value": "tenant"
-                      }
+                        "value": "tenant",
+                        "maxPerRow": 4
+                      },
+                      "width": 6,
+                      "x": 0,
+                      "y": 0
                     }
                   }
                 ]
               }
-            }
+            },
+            "title": "Bifrost reconciler actions by tenant"
           }
         },
         {
           "kind": "RowsLayoutRow",
           "spec": {
-            "title": "ReleaseChannel health by tenant",
             "collapse": false,
             "layout": {
               "kind": "GridLayout",
@@ -944,29 +947,30 @@
                   {
                     "kind": "GridLayoutItem",
                     "spec": {
-                      "x": 0,
-                      "y": 0,
-                      "width": 6,
-                      "height": 5,
                       "element": {
                         "kind": "ElementReference",
                         "name": "panel-7"
                       },
+                      "height": 5,
                       "repeat": {
                         "mode": "variable",
-                        "value": "tenant"
-                      }
+                        "value": "tenant",
+                        "maxPerRow": 4
+                      },
+                      "width": 6,
+                      "x": 0,
+                      "y": 0
                     }
                   }
                 ]
               }
-            }
+            },
+            "title": "ReleaseChannel health by tenant"
           }
         },
         {
           "kind": "RowsLayoutRow",
           "spec": {
-            "title": "ReleaseChannel progress by tenant",
             "collapse": false,
             "layout": {
               "kind": "GridLayout",
@@ -975,29 +979,30 @@
                   {
                     "kind": "GridLayoutItem",
                     "spec": {
-                      "x": 0,
-                      "y": 0,
-                      "width": 6,
-                      "height": 7,
                       "element": {
                         "kind": "ElementReference",
                         "name": "panel-8"
                       },
+                      "height": 7,
                       "repeat": {
                         "mode": "variable",
-                        "value": "tenant"
-                      }
+                        "value": "tenant",
+                        "maxPerRow": 4
+                      },
+                      "width": 6,
+                      "x": 0,
+                      "y": 0
                     }
                   }
                 ]
               }
-            }
+            },
+            "title": "ReleaseChannel progress by tenant"
           }
         },
         {
           "kind": "RowsLayoutRow",
           "spec": {
-            "title": "Unleasherator workqueue depth by tenant",
             "collapse": false,
             "layout": {
               "kind": "GridLayout",
@@ -1006,23 +1011,25 @@
                   {
                     "kind": "GridLayoutItem",
                     "spec": {
-                      "x": 0,
-                      "y": 0,
-                      "width": 6,
-                      "height": 7,
                       "element": {
                         "kind": "ElementReference",
                         "name": "panel-9"
                       },
+                      "height": 7,
                       "repeat": {
                         "mode": "variable",
-                        "value": "tenant"
-                      }
+                        "value": "tenant",
+                        "maxPerRow": 4
+                      },
+                      "width": 6,
+                      "x": 0,
+                      "y": 0
                     }
                   }
                 ]
               }
-            }
+            },
+            "title": "Unleasherator workqueue depth by tenant"
           }
         }
       ]
@@ -1033,9 +1040,6 @@
   "preload": false,
   "tags": [],
   "timeSettings": {
-    "timezone": "browser",
-    "from": "now-6h",
-    "to": "now",
     "autoRefresh": "",
     "autoRefreshIntervals": [
       "30s",
@@ -1047,18 +1051,18 @@
       "2h",
       "1d"
     ],
+    "fiscalYearStartMonth": 0,
+    "from": "now-6h",
     "hideTimepicker": false,
-    "fiscalYearStartMonth": 0
+    "timezone": "browser",
+    "to": "now"
   },
   "title": "Unleash Tenant Overview",
   "variables": [
     {
       "kind": "DatasourceVariable",
       "spec": {
-        "name": "tenant",
-        "pluginId": "prometheus",
-        "refresh": "onDashboardLoad",
-        "regex": "",
+        "allowCustomValue": true,
         "current": {
           "text": [
             "atil-metrics",
@@ -1073,20 +1077,24 @@
             "PE607B8DC11CE4E99"
           ]
         },
-        "options": [],
-        "multi": true,
+        "description": "Select tenants. Panels repeat once per selected Mimir datasource.",
+        "hide": "dontHide",
         "includeAll": true,
         "label": "Tenant",
-        "hide": "dontHide",
-        "skipUrlSync": false,
-        "description": "Select tenants. Panels repeat once per selected Mimir datasource.",
-        "allowCustomValue": true
+        "multi": true,
+        "name": "tenant",
+        "options": [],
+        "pluginId": "prometheus",
+        "refresh": "onDashboardLoad",
+        "regex": "",
+        "skipUrlSync": false
       }
     },
     {
       "kind": "QueryVariable",
       "spec": {
-        "name": "cluster",
+        "allValue": ".*",
+        "allowCustomValue": true,
         "current": {
           "text": [
             "management"
@@ -1095,30 +1103,29 @@
             "management"
           ]
         },
-        "label": "Cluster",
-        "hide": "dontHide",
-        "refresh": "never",
-        "skipUrlSync": false,
         "description": "Filter by Kubernetes cluster.",
+        "hide": "dontHide",
+        "includeAll": true,
+        "label": "Cluster",
+        "multi": true,
+        "name": "cluster",
+        "options": [],
         "query": {
-          "kind": "DataQuery",
-          "group": "prometheus",
-          "version": "v0",
           "datasource": {
             "name": "${tenant}"
           },
+          "group": "prometheus",
+          "kind": "DataQuery",
           "spec": {
             "__legacyStringValue": "label_values(up, k8s_cluster_name)"
-          }
+          },
+          "version": "v0"
         },
+        "refresh": "never",
         "regex": "",
         "regexApplyTo": "value",
-        "sort": "disabled",
-        "options": [],
-        "multi": true,
-        "includeAll": true,
-        "allValue": ".*",
-        "allowCustomValue": true
+        "skipUrlSync": false,
+        "sort": "disabled"
       }
     }
   ]

--- a/charts/unleasherator/dashboards/tenant-overview-dashboard.json
+++ b/charts/unleasherator/dashboards/tenant-overview-dashboard.json
@@ -847,6 +847,56 @@
                         "element": { "kind": "ElementReference", "name": "panel-2" },
                         "repeat": { "mode": "variable", "value": "tenant" }
                       }
+                    },
+                    {
+                      "kind": "RowsLayoutRow",
+                      "spec": {
+                        "title": "Bifrost adoption state by tenant",
+                        "collapse": false,
+                        "layout": { "kind": "GridLayout", "spec": { "items": [
+                          { "kind": "GridLayoutItem", "spec": { "x": 0, "y": 0, "width": 6, "height": 5, "element": { "kind": "ElementReference", "name": "panel-4" }, "repeat": { "mode": "variable", "value": "tenant" } } }
+                        ] } }
+                      }
+                    },
+                    {
+                      "kind": "RowsLayoutRow",
+                      "spec": {
+                        "title": "Bifrost reconciler actions by tenant",
+                        "collapse": false,
+                        "layout": { "kind": "GridLayout", "spec": { "items": [
+                          { "kind": "GridLayoutItem", "spec": { "x": 0, "y": 0, "width": 6, "height": 7, "element": { "kind": "ElementReference", "name": "panel-5" }, "repeat": { "mode": "variable", "value": "tenant" } } }
+                        ] } }
+                      }
+                    },
+                    {
+                      "kind": "RowsLayoutRow",
+                      "spec": {
+                        "title": "ReleaseChannel health by tenant",
+                        "collapse": false,
+                        "layout": { "kind": "GridLayout", "spec": { "items": [
+                          { "kind": "GridLayoutItem", "spec": { "x": 0, "y": 0, "width": 6, "height": 5, "element": { "kind": "ElementReference", "name": "panel-7" }, "repeat": { "mode": "variable", "value": "tenant" } } }
+                        ] } }
+                      }
+                    },
+                    {
+                      "kind": "RowsLayoutRow",
+                      "spec": {
+                        "title": "ReleaseChannel progress by tenant",
+                        "collapse": false,
+                        "layout": { "kind": "GridLayout", "spec": { "items": [
+                          { "kind": "GridLayoutItem", "spec": { "x": 0, "y": 0, "width": 6, "height": 7, "element": { "kind": "ElementReference", "name": "panel-8" }, "repeat": { "mode": "variable", "value": "tenant" } } }
+                        ] } }
+                      }
+                    },
+                    {
+                      "kind": "RowsLayoutRow",
+                      "spec": {
+                        "title": "Unleasherator workqueue depth by tenant",
+                        "collapse": false,
+                        "layout": { "kind": "GridLayout", "spec": { "items": [
+                          { "kind": "GridLayoutItem", "spec": { "x": 0, "y": 0, "width": 6, "height": 7, "element": { "kind": "ElementReference", "name": "panel-9" }, "repeat": { "mode": "variable", "value": "tenant" } } }
+                        ] } }
+                      }
                     }
                   ]
                 }

--- a/charts/unleasherator/dashboards/tenant-overview-dashboard.json
+++ b/charts/unleasherator/dashboards/tenant-overview-dashboard.json
@@ -843,59 +843,18 @@
                     {
                       "kind": "GridLayoutItem",
                       "spec": {
-                        "x": 0, "y": 0, "width": 6, "height": 5,
-                        "element": { "kind": "ElementReference", "name": "panel-2" },
-                        "repeat": { "mode": "variable", "value": "tenant" }
-                      }
-                    },
-                    {
-                      "kind": "RowsLayoutRow",
-                      "spec": {
-                        "title": "Bifrost adoption state by tenant",
-                        "collapse": false,
-                        "layout": { "kind": "GridLayout", "spec": { "items": [
-                          { "kind": "GridLayoutItem", "spec": { "x": 0, "y": 0, "width": 6, "height": 5, "element": { "kind": "ElementReference", "name": "panel-4" }, "repeat": { "mode": "variable", "value": "tenant" } } }
-                        ] } }
-                      }
-                    },
-                    {
-                      "kind": "RowsLayoutRow",
-                      "spec": {
-                        "title": "Bifrost reconciler actions by tenant",
-                        "collapse": false,
-                        "layout": { "kind": "GridLayout", "spec": { "items": [
-                          { "kind": "GridLayoutItem", "spec": { "x": 0, "y": 0, "width": 6, "height": 7, "element": { "kind": "ElementReference", "name": "panel-5" }, "repeat": { "mode": "variable", "value": "tenant" } } }
-                        ] } }
-                      }
-                    },
-                    {
-                      "kind": "RowsLayoutRow",
-                      "spec": {
-                        "title": "ReleaseChannel health by tenant",
-                        "collapse": false,
-                        "layout": { "kind": "GridLayout", "spec": { "items": [
-                          { "kind": "GridLayoutItem", "spec": { "x": 0, "y": 0, "width": 6, "height": 5, "element": { "kind": "ElementReference", "name": "panel-7" }, "repeat": { "mode": "variable", "value": "tenant" } } }
-                        ] } }
-                      }
-                    },
-                    {
-                      "kind": "RowsLayoutRow",
-                      "spec": {
-                        "title": "ReleaseChannel progress by tenant",
-                        "collapse": false,
-                        "layout": { "kind": "GridLayout", "spec": { "items": [
-                          { "kind": "GridLayoutItem", "spec": { "x": 0, "y": 0, "width": 6, "height": 7, "element": { "kind": "ElementReference", "name": "panel-8" }, "repeat": { "mode": "variable", "value": "tenant" } } }
-                        ] } }
-                      }
-                    },
-                    {
-                      "kind": "RowsLayoutRow",
-                      "spec": {
-                        "title": "Unleasherator workqueue depth by tenant",
-                        "collapse": false,
-                        "layout": { "kind": "GridLayout", "spec": { "items": [
-                          { "kind": "GridLayoutItem", "spec": { "x": 0, "y": 0, "width": 6, "height": 7, "element": { "kind": "ElementReference", "name": "panel-9" }, "repeat": { "mode": "variable", "value": "tenant" } } }
-                        ] } }
+                        "x": 0,
+                        "y": 0,
+                        "width": 6,
+                        "height": 5,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-2"
+                        },
+                        "repeat": {
+                          "mode": "variable",
+                          "value": "tenant"
+                        }
                       }
                     }
                   ]
@@ -922,6 +881,161 @@
                         "element": {
                           "kind": "ElementReference",
                           "name": "panel-3"
+                        },
+                        "repeat": {
+                          "mode": "variable",
+                          "value": "tenant"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "title": "Bifrost adoption state by tenant",
+              "collapse": false,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 6,
+                        "height": 5,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-4"
+                        },
+                        "repeat": {
+                          "mode": "variable",
+                          "value": "tenant"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "title": "Bifrost reconciler actions by tenant",
+              "collapse": false,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 6,
+                        "height": 7,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-5"
+                        },
+                        "repeat": {
+                          "mode": "variable",
+                          "value": "tenant"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "title": "ReleaseChannel health by tenant",
+              "collapse": false,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 6,
+                        "height": 5,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-7"
+                        },
+                        "repeat": {
+                          "mode": "variable",
+                          "value": "tenant"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "title": "ReleaseChannel progress by tenant",
+              "collapse": false,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 6,
+                        "height": 7,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-8"
+                        },
+                        "repeat": {
+                          "mode": "variable",
+                          "value": "tenant"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "title": "Unleasherator workqueue depth by tenant",
+              "collapse": false,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 6,
+                        "height": 7,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-9"
                         },
                         "repeat": {
                           "mode": "variable",

--- a/charts/unleasherator/dashboards/tenant-overview-dashboard.json
+++ b/charts/unleasherator/dashboards/tenant-overview-dashboard.json
@@ -1,1149 +1,425 @@
 {
-  "apiVersion": "dashboard.grafana.app/v2",
-  "kind": "Dashboard",
-  "metadata": {
-    "name": "unleash-overview",
-    "namespace": "default",
-    "uid": "3c6207aa-9c67-4fdb-9406-67fd0f915362",
-    "resourceVersion": "1788810569968991",
-    "generation": 2,
-    "creationTimestamp": "2026-09-07T19:49:02Z",
-    "labels": {
-      "grafana.app/deprecatedInternalID": "2875698210541568"
-    },
-    "annotations": {
-      "grafana.app/createdBy": "user:u000000003",
-      "grafana.app/folder": "2-RVnOUVz",
-      "grafana.app/saved-from-ui": "Grafana v13.0.1+security-01 (9bbe672d)",
-      "grafana.app/updatedBy": "user:u000000003",
-      "grafana.app/updatedTimestamp": "2026-09-07T19:49:29Z",
-      "grafana.app/folderTitle": "Unleash",
-      "grafana.app/folderUrl": "/dashboards/f/2-RVnOUVz/unleash"
-    }
+  "title": "Unleash Tenant Overview",
+  "uid": "nais-tenant-overview",
+  "editable": true,
+  "schemaVersion": 41,
+  "time": {
+    "from": "now-6h",
+    "to": "now"
   },
-  "spec": {
-    "annotations": [
+  "templating": {
+    "list": [
       {
-        "kind": "AnnotationQuery",
-        "spec": {
-          "query": {
-            "kind": "DataQuery",
-            "group": "grafana",
-            "version": "v0",
-            "datasource": {
-              "name": "-- Grafana --"
-            },
-            "spec": {}
-          },
-          "enable": true,
-          "hide": true,
-          "iconColor": "rgba(0, 211, 255, 1)",
-          "name": "Annotations & Alerts",
-          "builtIn": true
-        }
-      }
-    ],
-    "cursorSync": "Off",
-    "editable": true,
-    "elements": {
-      "panel-2": {
-        "kind": "Panel",
-        "spec": {
-          "id": 2,
-          "title": "Census age",
-          "description": "",
-          "links": [],
-          "data": {
-            "kind": "QueryGroup",
-            "spec": {
-              "queries": [
-                {
-                  "kind": "PanelQuery",
-                  "spec": {
-                    "query": {
-                      "kind": "DataQuery",
-                      "group": "prometheus",
-                      "version": "v0",
-                      "datasource": {
-                        "name": "${tenant}"
-                      },
-                      "spec": {
-                        "expr": "time() - max(bifrost_reconciler_instances_updated_timestamp_seconds{k8s_cluster_name=~\"$cluster\"})",
-                        "legendFormat": "{{__field.name}}"
-                      }
-                    },
-                    "refId": "A",
-                    "hidden": false
-                  }
-                }
-              ],
-              "transformations": [],
-              "queryOptions": {}
-            }
-          },
-          "vizConfig": {
-            "kind": "VizConfig",
-            "group": "stat",
-            "version": "13.0.1+security-01",
-            "spec": {
-              "options": {
-                "colorMode": "background",
-                "graphMode": "none",
-                "justifyMode": "auto",
-                "orientation": "auto",
-                "percentChangeColorMode": "standard",
-                "reduceOptions": {
-                  "calcs": [
-                    "lastNotNull"
-                  ],
-                  "fields": "",
-                  "values": false
-                },
-                "showPercentChange": false,
-                "textMode": "auto",
-                "wideLayout": true
-              },
-              "fieldConfig": {
-                "defaults": {
-                  "unit": "s",
-                  "thresholds": {
-                    "mode": "absolute",
-                    "steps": [
-                      {
-                        "value": 0,
-                        "color": "green"
-                      },
-                      {
-                        "value": 900,
-                        "color": "yellow"
-                      },
-                      {
-                        "value": 1800,
-                        "color": "red"
-                      }
-                    ]
-                  }
-                },
-                "overrides": []
-              }
-            }
-          }
-        }
-      },
-      "panel-3": {
-        "kind": "Panel",
-        "spec": {
-          "id": 3,
-          "title": "Managed and unmanaged instances",
-          "description": "",
-          "links": [],
-          "data": {
-            "kind": "QueryGroup",
-            "spec": {
-              "queries": [
-                {
-                  "kind": "PanelQuery",
-                  "spec": {
-                    "query": {
-                      "kind": "DataQuery",
-                      "group": "prometheus",
-                      "version": "v0",
-                      "datasource": {
-                        "name": "${tenant}"
-                      },
-                      "spec": {
-                        "expr": "bifrost_reconciler_managed_instances{k8s_cluster_name=~\"$cluster\"}",
-                        "legendFormat": "managed"
-                      }
-                    },
-                    "refId": "A",
-                    "hidden": false
-                  }
-                },
-                {
-                  "kind": "PanelQuery",
-                  "spec": {
-                    "query": {
-                      "kind": "DataQuery",
-                      "group": "prometheus",
-                      "version": "v0",
-                      "datasource": {
-                        "name": "${tenant}"
-                      },
-                      "spec": {
-                        "expr": "bifrost_reconciler_unmanaged_instances{k8s_cluster_name=~\"$cluster\"}",
-                        "legendFormat": "unmanaged"
-                      }
-                    },
-                    "refId": "B",
-                    "hidden": false
-                  }
-                }
-              ],
-              "transformations": [],
-              "queryOptions": {}
-            }
-          },
-          "vizConfig": {
-            "kind": "VizConfig",
-            "group": "timeseries",
-            "version": "13.0.1+security-01",
-            "spec": {
-              "options": {
-                "annotations": {
-                  "clustering": -1,
-                  "multiLane": false
-                },
-                "legend": {
-                  "calcs": [],
-                  "displayMode": "table",
-                  "placement": "bottom",
-                  "showLegend": true
-                },
-                "tooltip": {
-                  "hideZeros": false,
-                  "mode": "multi",
-                  "sort": "none"
-                }
-              },
-              "fieldConfig": {
-                "defaults": {
-                  "unit": "short",
-                  "thresholds": {
-                    "mode": "absolute",
-                    "steps": [
-                      {
-                        "value": 0,
-                        "color": "green"
-                      },
-                      {
-                        "value": 80,
-                        "color": "red"
-                      }
-                    ]
-                  },
-                  "color": {
-                    "mode": "palette-classic"
-                  },
-                  "custom": {
-                    "axisBorderShow": false,
-                    "axisCenteredZero": false,
-                    "axisColorMode": "text",
-                    "axisLabel": "",
-                    "axisPlacement": "auto",
-                    "barAlignment": 0,
-                    "barWidthFactor": 0.6,
-                    "drawStyle": "line",
-                    "fillOpacity": 0,
-                    "gradientMode": "none",
-                    "hideFrom": {
-                      "legend": false,
-                      "tooltip": false,
-                      "viz": false
-                    },
-                    "insertNulls": false,
-                    "lineInterpolation": "linear",
-                    "lineWidth": 1,
-                    "pointSize": 5,
-                    "scaleDistribution": {
-                      "type": "linear"
-                    },
-                    "showPoints": "auto",
-                    "showValues": false,
-                    "spanNulls": false,
-                    "stacking": {
-                      "group": "A",
-                      "mode": "none"
-                    },
-                    "thresholdsStyle": {
-                      "mode": "off"
-                    }
-                  }
-                },
-                "overrides": []
-              }
-            }
-          }
-        }
-      },
-      "panel-4": {
-        "kind": "Panel",
-        "spec": {
-          "id": 4,
-          "title": "Adoption halted",
-          "description": "",
-          "links": [],
-          "data": {
-            "kind": "QueryGroup",
-            "spec": {
-              "queries": [
-                {
-                  "kind": "PanelQuery",
-                  "spec": {
-                    "query": {
-                      "kind": "DataQuery",
-                      "group": "prometheus",
-                      "version": "v0",
-                      "datasource": {
-                        "name": "${tenant}"
-                      },
-                      "spec": {
-                        "expr": "max(bifrost_reconciler_adoption_halted{k8s_cluster_name=~\"$cluster\"})"
-                      }
-                    },
-                    "refId": "A",
-                    "hidden": false
-                  }
-                }
-              ],
-              "transformations": [],
-              "queryOptions": {}
-            }
-          },
-          "vizConfig": {
-            "kind": "VizConfig",
-            "group": "stat",
-            "version": "13.0.1+security-01",
-            "spec": {
-              "options": {
-                "colorMode": "background",
-                "graphMode": "none",
-                "justifyMode": "auto",
-                "orientation": "auto",
-                "percentChangeColorMode": "standard",
-                "reduceOptions": {
-                  "calcs": [
-                    "lastNotNull"
-                  ],
-                  "fields": "",
-                  "values": false
-                },
-                "showPercentChange": false,
-                "textMode": "auto",
-                "wideLayout": true
-              },
-              "fieldConfig": {
-                "defaults": {
-                  "mappings": [
-                    {
-                      "type": "value",
-                      "options": {
-                        "0": {
-                          "text": "Running",
-                          "color": "green"
-                        },
-                        "1": {
-                          "text": "Halted",
-                          "color": "red"
-                        }
-                      }
-                    }
-                  ],
-                  "thresholds": {
-                    "mode": "absolute",
-                    "steps": [
-                      {
-                        "value": 0,
-                        "color": "green"
-                      },
-                      {
-                        "value": 80,
-                        "color": "red"
-                      }
-                    ]
-                  }
-                },
-                "overrides": []
-              }
-            }
-          }
-        }
-      },
-      "panel-5": {
-        "kind": "Panel",
-        "spec": {
-          "id": 5,
-          "title": "Reconciler actions by reason",
-          "description": "",
-          "links": [],
-          "data": {
-            "kind": "QueryGroup",
-            "spec": {
-              "queries": [
-                {
-                  "kind": "PanelQuery",
-                  "spec": {
-                    "query": {
-                      "kind": "DataQuery",
-                      "group": "prometheus",
-                      "version": "v0",
-                      "datasource": {
-                        "name": "${tenant}"
-                      },
-                      "spec": {
-                        "expr": "sum by (action, reason) (rate(bifrost_reconciler_actions_total{k8s_cluster_name=~\"$cluster\"}[5m]))",
-                        "legendFormat": "{{action}} / {{reason}}"
-                      }
-                    },
-                    "refId": "A",
-                    "hidden": false
-                  }
-                }
-              ],
-              "transformations": [],
-              "queryOptions": {}
-            }
-          },
-          "vizConfig": {
-            "kind": "VizConfig",
-            "group": "timeseries",
-            "version": "13.0.1+security-01",
-            "spec": {
-              "options": {
-                "annotations": {
-                  "clustering": -1,
-                  "multiLane": false
-                },
-                "legend": {
-                  "calcs": [],
-                  "displayMode": "table",
-                  "placement": "bottom",
-                  "showLegend": true
-                },
-                "tooltip": {
-                  "hideZeros": false,
-                  "mode": "multi",
-                  "sort": "none"
-                }
-              },
-              "fieldConfig": {
-                "defaults": {
-                  "unit": "ops",
-                  "thresholds": {
-                    "mode": "absolute",
-                    "steps": [
-                      {
-                        "value": 0,
-                        "color": "green"
-                      },
-                      {
-                        "value": 80,
-                        "color": "red"
-                      }
-                    ]
-                  },
-                  "color": {
-                    "mode": "palette-classic"
-                  },
-                  "custom": {
-                    "axisBorderShow": false,
-                    "axisCenteredZero": false,
-                    "axisColorMode": "text",
-                    "axisLabel": "",
-                    "axisPlacement": "auto",
-                    "barAlignment": 0,
-                    "barWidthFactor": 0.6,
-                    "drawStyle": "line",
-                    "fillOpacity": 0,
-                    "gradientMode": "none",
-                    "hideFrom": {
-                      "legend": false,
-                      "tooltip": false,
-                      "viz": false
-                    },
-                    "insertNulls": false,
-                    "lineInterpolation": "linear",
-                    "lineWidth": 1,
-                    "pointSize": 5,
-                    "scaleDistribution": {
-                      "type": "linear"
-                    },
-                    "showPoints": "auto",
-                    "showValues": false,
-                    "spanNulls": false,
-                    "stacking": {
-                      "group": "A",
-                      "mode": "none"
-                    },
-                    "thresholdsStyle": {
-                      "mode": "off"
-                    }
-                  }
-                },
-                "overrides": []
-              }
-            }
-          }
-        }
-      },
-      "panel-7": {
-        "kind": "Panel",
-        "spec": {
-          "id": 7,
-          "title": "ReleaseChannel health",
-          "description": "",
-          "links": [],
-          "data": {
-            "kind": "QueryGroup",
-            "spec": {
-              "queries": [
-                {
-                  "kind": "PanelQuery",
-                  "spec": {
-                    "query": {
-                      "kind": "DataQuery",
-                      "group": "prometheus",
-                      "version": "v0",
-                      "datasource": {
-                        "name": "${tenant}"
-                      },
-                      "spec": {
-                        "expr": "min(unleasherator_releasechannel_status{k8s_cluster_name=~\"$cluster\"})"
-                      }
-                    },
-                    "refId": "A",
-                    "hidden": false
-                  }
-                }
-              ],
-              "transformations": [],
-              "queryOptions": {}
-            }
-          },
-          "vizConfig": {
-            "kind": "VizConfig",
-            "group": "stat",
-            "version": "13.0.1+security-01",
-            "spec": {
-              "options": {
-                "colorMode": "background",
-                "graphMode": "none",
-                "justifyMode": "auto",
-                "orientation": "auto",
-                "percentChangeColorMode": "standard",
-                "reduceOptions": {
-                  "calcs": [
-                    "lastNotNull"
-                  ],
-                  "fields": "",
-                  "values": false
-                },
-                "showPercentChange": false,
-                "textMode": "auto",
-                "wideLayout": true
-              },
-              "fieldConfig": {
-                "defaults": {
-                  "mappings": [
-                    {
-                      "type": "value",
-                      "options": {
-                        "0": {
-                          "text": "Failed",
-                          "color": "red"
-                        },
-                        "1": {
-                          "text": "Healthy",
-                          "color": "green"
-                        },
-                        "0.5": {
-                          "text": "Rolling",
-                          "color": "yellow"
-                        }
-                      }
-                    }
-                  ],
-                  "thresholds": {
-                    "mode": "absolute",
-                    "steps": [
-                      {
-                        "value": 0,
-                        "color": "green"
-                      },
-                      {
-                        "value": 80,
-                        "color": "red"
-                      }
-                    ]
-                  }
-                },
-                "overrides": []
-              }
-            }
-          }
-        }
-      },
-      "panel-8": {
-        "kind": "Panel",
-        "spec": {
-          "id": 8,
-          "title": "ReleaseChannel progress",
-          "description": "",
-          "links": [],
-          "data": {
-            "kind": "QueryGroup",
-            "spec": {
-              "queries": [
-                {
-                  "kind": "PanelQuery",
-                  "spec": {
-                    "query": {
-                      "kind": "DataQuery",
-                      "group": "prometheus",
-                      "version": "v0",
-                      "datasource": {
-                        "name": "${tenant}"
-                      },
-                      "spec": {
-                        "expr": "sum(unleasherator_releasechannel_instances_up_to_date{k8s_cluster_name=~\"$cluster\"})",
-                        "legendFormat": "up to date"
-                      }
-                    },
-                    "refId": "A",
-                    "hidden": false
-                  }
-                },
-                {
-                  "kind": "PanelQuery",
-                  "spec": {
-                    "query": {
-                      "kind": "DataQuery",
-                      "group": "prometheus",
-                      "version": "v0",
-                      "datasource": {
-                        "name": "${tenant}"
-                      },
-                      "spec": {
-                        "expr": "sum(unleasherator_releasechannel_instances_total{k8s_cluster_name=~\"$cluster\"})",
-                        "legendFormat": "total"
-                      }
-                    },
-                    "refId": "B",
-                    "hidden": false
-                  }
-                }
-              ],
-              "transformations": [],
-              "queryOptions": {}
-            }
-          },
-          "vizConfig": {
-            "kind": "VizConfig",
-            "group": "timeseries",
-            "version": "13.0.1+security-01",
-            "spec": {
-              "options": {
-                "annotations": {
-                  "clustering": -1,
-                  "multiLane": false
-                },
-                "legend": {
-                  "calcs": [],
-                  "displayMode": "table",
-                  "placement": "bottom",
-                  "showLegend": true
-                },
-                "tooltip": {
-                  "hideZeros": false,
-                  "mode": "multi",
-                  "sort": "none"
-                }
-              },
-              "fieldConfig": {
-                "defaults": {
-                  "unit": "short",
-                  "thresholds": {
-                    "mode": "absolute",
-                    "steps": [
-                      {
-                        "value": 0,
-                        "color": "green"
-                      },
-                      {
-                        "value": 80,
-                        "color": "red"
-                      }
-                    ]
-                  },
-                  "color": {
-                    "mode": "palette-classic"
-                  },
-                  "custom": {
-                    "axisBorderShow": false,
-                    "axisCenteredZero": false,
-                    "axisColorMode": "text",
-                    "axisLabel": "",
-                    "axisPlacement": "auto",
-                    "barAlignment": 0,
-                    "barWidthFactor": 0.6,
-                    "drawStyle": "line",
-                    "fillOpacity": 0,
-                    "gradientMode": "none",
-                    "hideFrom": {
-                      "legend": false,
-                      "tooltip": false,
-                      "viz": false
-                    },
-                    "insertNulls": false,
-                    "lineInterpolation": "linear",
-                    "lineWidth": 1,
-                    "pointSize": 5,
-                    "scaleDistribution": {
-                      "type": "linear"
-                    },
-                    "showPoints": "auto",
-                    "showValues": false,
-                    "spanNulls": false,
-                    "stacking": {
-                      "group": "A",
-                      "mode": "none"
-                    },
-                    "thresholdsStyle": {
-                      "mode": "off"
-                    }
-                  }
-                },
-                "overrides": []
-              }
-            }
-          }
-        }
-      },
-      "panel-9": {
-        "kind": "Panel",
-        "spec": {
-          "id": 9,
-          "title": "Controller workqueue depth",
-          "description": "",
-          "links": [],
-          "data": {
-            "kind": "QueryGroup",
-            "spec": {
-              "queries": [
-                {
-                  "kind": "PanelQuery",
-                  "spec": {
-                    "query": {
-                      "kind": "DataQuery",
-                      "group": "prometheus",
-                      "version": "v0",
-                      "datasource": {
-                        "name": "${tenant}"
-                      },
-                      "spec": {
-                        "expr": "max by (name) (workqueue_depth{name=~\".*unleash.*|.*releasechannel.*\", k8s_cluster_name=~\"$cluster\"})",
-                        "legendFormat": "{{name}}"
-                      }
-                    },
-                    "refId": "A",
-                    "hidden": false
-                  }
-                }
-              ],
-              "transformations": [],
-              "queryOptions": {}
-            }
-          },
-          "vizConfig": {
-            "kind": "VizConfig",
-            "group": "timeseries",
-            "version": "13.0.1+security-01",
-            "spec": {
-              "options": {
-                "annotations": {
-                  "clustering": -1,
-                  "multiLane": false
-                },
-                "legend": {
-                  "calcs": [],
-                  "displayMode": "table",
-                  "placement": "bottom",
-                  "showLegend": true
-                },
-                "tooltip": {
-                  "hideZeros": false,
-                  "mode": "multi",
-                  "sort": "none"
-                }
-              },
-              "fieldConfig": {
-                "defaults": {
-                  "unit": "short",
-                  "thresholds": {
-                    "mode": "absolute",
-                    "steps": [
-                      {
-                        "value": 0,
-                        "color": "green"
-                      },
-                      {
-                        "value": 80,
-                        "color": "red"
-                      }
-                    ]
-                  },
-                  "color": {
-                    "mode": "palette-classic"
-                  },
-                  "custom": {
-                    "axisBorderShow": false,
-                    "axisCenteredZero": false,
-                    "axisColorMode": "text",
-                    "axisLabel": "",
-                    "axisPlacement": "auto",
-                    "barAlignment": 0,
-                    "barWidthFactor": 0.6,
-                    "drawStyle": "line",
-                    "fillOpacity": 0,
-                    "gradientMode": "none",
-                    "hideFrom": {
-                      "legend": false,
-                      "tooltip": false,
-                      "viz": false
-                    },
-                    "insertNulls": false,
-                    "lineInterpolation": "linear",
-                    "lineWidth": 1,
-                    "pointSize": 5,
-                    "scaleDistribution": {
-                      "type": "linear"
-                    },
-                    "showPoints": "auto",
-                    "showValues": false,
-                    "spanNulls": false,
-                    "stacking": {
-                      "group": "A",
-                      "mode": "none"
-                    },
-                    "thresholdsStyle": {
-                      "mode": "off"
-                    }
-                  }
-                },
-                "overrides": []
-              }
-            }
-          }
-        }
-      }
-    },
-    "layout": {
-      "kind": "RowsLayout",
-      "spec": {
-        "rows": [
-          {
-            "kind": "RowsLayoutRow",
-            "spec": {
-              "title": "Bifrost census age by tenant",
-              "collapse": false,
-              "layout": {
-                "kind": "GridLayout",
-                "spec": {
-                  "items": [
-                    {
-                      "kind": "GridLayoutItem",
-                      "spec": {
-                        "x": 0,
-                        "y": 0,
-                        "width": 6,
-                        "height": 5,
-                        "element": {
-                          "kind": "ElementReference",
-                          "name": "panel-2"
-                        },
-                        "repeat": {
-                          "mode": "variable",
-                          "value": "tenant"
-                        }
-                      }
-                    }
-                  ]
-                }
-              }
-            }
-          },
-          {
-            "kind": "RowsLayoutRow",
-            "spec": {
-              "title": "Bifrost managed instances by tenant",
-              "collapse": false,
-              "layout": {
-                "kind": "GridLayout",
-                "spec": {
-                  "items": [
-                    {
-                      "kind": "GridLayoutItem",
-                      "spec": {
-                        "x": 0,
-                        "y": 0,
-                        "width": 6,
-                        "height": 7,
-                        "element": {
-                          "kind": "ElementReference",
-                          "name": "panel-3"
-                        },
-                        "repeat": {
-                          "mode": "variable",
-                          "value": "tenant"
-                        }
-                      }
-                    }
-                  ]
-                }
-              }
-            }
-          },
-          {
-            "kind": "RowsLayoutRow",
-            "spec": {
-              "title": "Bifrost adoption state by tenant",
-              "collapse": false,
-              "layout": {
-                "kind": "GridLayout",
-                "spec": {
-                  "items": [
-                    {
-                      "kind": "GridLayoutItem",
-                      "spec": {
-                        "x": 0,
-                        "y": 0,
-                        "width": 6,
-                        "height": 5,
-                        "element": {
-                          "kind": "ElementReference",
-                          "name": "panel-4"
-                        },
-                        "repeat": {
-                          "mode": "variable",
-                          "value": "tenant"
-                        }
-                      }
-                    }
-                  ]
-                }
-              }
-            }
-          },
-          {
-            "kind": "RowsLayoutRow",
-            "spec": {
-              "title": "Bifrost reconciler actions by tenant",
-              "collapse": false,
-              "layout": {
-                "kind": "GridLayout",
-                "spec": {
-                  "items": [
-                    {
-                      "kind": "GridLayoutItem",
-                      "spec": {
-                        "x": 0,
-                        "y": 0,
-                        "width": 6,
-                        "height": 7,
-                        "element": {
-                          "kind": "ElementReference",
-                          "name": "panel-5"
-                        },
-                        "repeat": {
-                          "mode": "variable",
-                          "value": "tenant"
-                        }
-                      }
-                    }
-                  ]
-                }
-              }
-            }
-          },
-          {
-            "kind": "RowsLayoutRow",
-            "spec": {
-              "title": "ReleaseChannel health by tenant",
-              "collapse": false,
-              "layout": {
-                "kind": "GridLayout",
-                "spec": {
-                  "items": [
-                    {
-                      "kind": "GridLayoutItem",
-                      "spec": {
-                        "x": 0,
-                        "y": 0,
-                        "width": 6,
-                        "height": 5,
-                        "element": {
-                          "kind": "ElementReference",
-                          "name": "panel-7"
-                        },
-                        "repeat": {
-                          "mode": "variable",
-                          "value": "tenant"
-                        }
-                      }
-                    }
-                  ]
-                }
-              }
-            }
-          },
-          {
-            "kind": "RowsLayoutRow",
-            "spec": {
-              "title": "ReleaseChannel progress by tenant",
-              "collapse": false,
-              "layout": {
-                "kind": "GridLayout",
-                "spec": {
-                  "items": [
-                    {
-                      "kind": "GridLayoutItem",
-                      "spec": {
-                        "x": 0,
-                        "y": 0,
-                        "width": 6,
-                        "height": 7,
-                        "element": {
-                          "kind": "ElementReference",
-                          "name": "panel-8"
-                        },
-                        "repeat": {
-                          "mode": "variable",
-                          "value": "tenant"
-                        }
-                      }
-                    }
-                  ]
-                }
-              }
-            }
-          },
-          {
-            "kind": "RowsLayoutRow",
-            "spec": {
-              "title": "Unleasherator workqueue depth by tenant",
-              "collapse": false,
-              "layout": {
-                "kind": "GridLayout",
-                "spec": {
-                  "items": [
-                    {
-                      "kind": "GridLayoutItem",
-                      "spec": {
-                        "x": 0,
-                        "y": 0,
-                        "width": 6,
-                        "height": 7,
-                        "element": {
-                          "kind": "ElementReference",
-                          "name": "panel-9"
-                        },
-                        "repeat": {
-                          "mode": "variable",
-                          "value": "tenant"
-                        }
-                      }
-                    }
-                  ]
-                }
-              }
-            }
-          }
-        ]
-      }
-    },
-    "links": [],
-    "liveNow": false,
-    "preload": false,
-    "tags": [],
-    "timeSettings": {
-      "timezone": "browser",
-      "from": "now-6h",
-      "to": "now",
-      "autoRefresh": "",
-      "autoRefreshIntervals": [
-        "30s",
-        "1m",
-        "5m",
-        "15m",
-        "30m",
-        "1h",
-        "2h",
-        "1d"
-      ],
-      "hideTimepicker": false,
-      "fiscalYearStartMonth": 0
-    },
-    "title": "Unleash Tenant Overview",
-    "variables": [
-      {
-        "kind": "DatasourceVariable",
-        "spec": {
-          "name": "tenant",
-          "pluginId": "prometheus",
-          "refresh": "onDashboardLoad",
-          "regex": "",
-          "current": {
-            "text": [
-              "atil-metrics",
-              "ldir-metrics",
-              "nav-metrics",
-              "ssb-metrics"
-            ],
-            "value": [
-              "PF7D5629ECC453C64",
-              "P73126C2103EBFC69",
-              "P91A6F0B3584B90E7",
-              "PE607B8DC11CE4E99"
-            ]
-          },
-          "options": [],
-          "multi": true,
-          "includeAll": true,
-          "label": "Tenant",
-          "hide": "dontHide",
-          "skipUrlSync": false,
-          "description": "Select tenants. Panels repeat once per selected Mimir datasource.",
-          "allowCustomValue": true
-        }
+        "name": "tenant",
+        "label": "Tenant",
+        "type": "datasource",
+        "query": "prometheus",
+        "pluginId": "prometheus",
+        "multi": true,
+        "includeAll": true,
+        "current": {
+          "text": [
+            "atil-metrics",
+            "ldir-metrics",
+            "nav-metrics",
+            "ssb-metrics"
+          ],
+          "value": [
+            "PF7D5629ECC453C64",
+            "P73126C2103EBFC69",
+            "P91A6F0B3584B90E7",
+            "PE607B8DC11CE4E99"
+          ]
+        },
+        "description": "Select tenants. Panels repeat once per selected Mimir datasource."
       },
       {
-        "kind": "QueryVariable",
-        "spec": {
-          "name": "cluster",
-          "current": {
-            "text": [
-              "management"
-            ],
-            "value": [
-              "management"
-            ]
-          },
-          "label": "Cluster",
-          "hide": "dontHide",
-          "refresh": "never",
-          "skipUrlSync": false,
-          "description": "Filter by Kubernetes cluster.",
-          "query": {
-            "kind": "DataQuery",
-            "group": "prometheus",
-            "version": "v0",
-            "datasource": {
-              "name": "${tenant}"
-            },
-            "spec": {
-              "__legacyStringValue": "label_values(up, k8s_cluster_name)"
-            }
-          },
-          "regex": "",
-          "regexApplyTo": "value",
-          "sort": "disabled",
-          "options": [],
-          "multi": true,
-          "includeAll": true,
-          "allValue": ".*",
-          "allowCustomValue": true
-        }
+        "name": "cluster",
+        "label": "Cluster",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${tenant}"
+        },
+        "query": "label_values(up, k8s_cluster_name)",
+        "multi": true,
+        "includeAll": true,
+        "allValue": ".*",
+        "current": {
+          "text": [
+            "prod"
+          ],
+          "value": [
+            "prod"
+          ]
+        },
+        "description": "Filter by Kubernetes cluster."
       }
     ]
-  }
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "row",
+      "title": "Bifrost reconciler",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "panels": []
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "Census age",
+      "repeat": "tenant",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${tenant}"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 0,
+        "y": 1
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "time() - max(bifrost_reconciler_instances_updated_timestamp_seconds{k8s_cluster_name=~\"$cluster\"})",
+          "legendFormat": "{{__field.name}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "yellow",
+                "value": 900
+              },
+              {
+                "color": "red",
+                "value": 1800
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "values": false
+        },
+        "colorMode": "background",
+        "graphMode": "none"
+      },
+      "maxPerRow": 4
+    },
+    {
+      "id": 3,
+      "type": "timeseries",
+      "title": "Managed and unmanaged instances",
+      "repeat": "tenant",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${tenant}"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 4,
+        "y": 1
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "bifrost_reconciler_managed_instances{k8s_cluster_name=~\"$cluster\"}",
+          "legendFormat": "managed"
+        },
+        {
+          "refId": "B",
+          "expr": "bifrost_reconciler_unmanaged_instances{k8s_cluster_name=~\"$cluster\"}",
+          "legendFormat": "unmanaged"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "maxPerRow": 4
+    },
+    {
+      "id": 4,
+      "type": "stat",
+      "title": "Adoption halted",
+      "repeat": "tenant",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${tenant}"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 12,
+        "y": 1
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "max(bifrost_reconciler_adoption_halted{k8s_cluster_name=~\"$cluster\"})"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "0": {
+                  "text": "Running",
+                  "color": "green"
+                },
+                "1": {
+                  "text": "Halted",
+                  "color": "red"
+                }
+              }
+            }
+          ]
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "values": false
+        },
+        "colorMode": "background",
+        "graphMode": "none"
+      },
+      "maxPerRow": 4
+    },
+    {
+      "id": 5,
+      "type": "timeseries",
+      "title": "Reconciler actions by reason",
+      "repeat": "tenant",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${tenant}"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 1
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (action, reason) (rate(bifrost_reconciler_actions_total{k8s_cluster_name=~\"$cluster\"}[5m]))",
+          "legendFormat": "{{action}} / {{reason}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "maxPerRow": 4
+    },
+    {
+      "id": 6,
+      "type": "row",
+      "title": "Unleasherator rollouts",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 8
+      },
+      "panels": []
+    },
+    {
+      "id": 7,
+      "type": "stat",
+      "title": "ReleaseChannel health",
+      "repeat": "tenant",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${tenant}"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 0,
+        "y": 9
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "min(unleasherator_releasechannel_status{k8s_cluster_name=~\"$cluster\"})"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "0": {
+                  "text": "Failed",
+                  "color": "red"
+                },
+                "0.5": {
+                  "text": "Rolling",
+                  "color": "yellow"
+                },
+                "1": {
+                  "text": "Healthy",
+                  "color": "green"
+                }
+              }
+            }
+          ]
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "values": false
+        },
+        "colorMode": "background",
+        "graphMode": "none"
+      },
+      "maxPerRow": 4
+    },
+    {
+      "id": 8,
+      "type": "timeseries",
+      "title": "ReleaseChannel progress",
+      "repeat": "tenant",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${tenant}"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 4,
+        "y": 9
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(unleasherator_releasechannel_instances_up_to_date{k8s_cluster_name=~\"$cluster\"})",
+          "legendFormat": "up to date"
+        },
+        {
+          "refId": "B",
+          "expr": "sum(unleasherator_releasechannel_instances_total{k8s_cluster_name=~\"$cluster\"})",
+          "legendFormat": "total"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "maxPerRow": 4
+    },
+    {
+      "id": 9,
+      "type": "timeseries",
+      "title": "Controller workqueue depth",
+      "repeat": "tenant",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${tenant}"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 9
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "max by (name) (workqueue_depth{name=~\".*unleash.*|.*releasechannel.*\", k8s_cluster_name=~\"$cluster\"})",
+          "legendFormat": "{{name}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "maxPerRow": 4
+    }
+  ]
 }

--- a/charts/unleasherator/dashboards/tenant-overview-dashboard.json
+++ b/charts/unleasherator/dashboards/tenant-overview-dashboard.json
@@ -1,109 +1,985 @@
 {
-  "title": "Nais Tenant Overview",
-  "uid": "nais-tenant-overview",
-  "editable": true,
-  "schemaVersion": 41,
-  "time": { "from": "now-6h", "to": "now" },
-  "templating": {
-    "list": [
+  "apiVersion": "dashboard.grafana.app/v2",
+  "kind": "Dashboard",
+  "metadata": {
+    "name": "unleash-overview",
+    "namespace": "default",
+    "uid": "3c6207aa-9c67-4fdb-9406-67fd0f915362",
+    "resourceVersion": "1788810569968991",
+    "generation": 2,
+    "creationTimestamp": "2026-09-07T19:49:02Z",
+    "labels": {
+      "grafana.app/deprecatedInternalID": "2875698210541568"
+    },
+    "annotations": {
+      "grafana.app/createdBy": "user:u000000003",
+      "grafana.app/folder": "2-RVnOUVz",
+      "grafana.app/saved-from-ui": "Grafana v13.0.1+security-01 (9bbe672d)",
+      "grafana.app/updatedBy": "user:u000000003",
+      "grafana.app/updatedTimestamp": "2026-09-07T19:49:29Z",
+      "grafana.app/folderTitle": "Unleash",
+      "grafana.app/folderUrl": "/dashboards/f/2-RVnOUVz/unleash"
+    }
+  },
+  "spec": {
+    "annotations": [
       {
-        "name": "tenant",
-        "label": "Tenant",
-        "type": "datasource",
-        "query": "prometheus",
-        "pluginId": "prometheus",
-        "multi": true,
-        "includeAll": true,
-        "current": {
-          "text": ["atil-metrics", "ldir-metrics", "nav-metrics", "ssb-metrics"],
-          "value": ["PF7D5629ECC453C64", "P73126C2103EBFC69", "P91A6F0B3584B90E7", "PE607B8DC11CE4E99"]
-        },
-        "description": "Select tenants. Panels repeat once per selected Mimir datasource."
+        "kind": "AnnotationQuery",
+        "spec": {
+          "query": {
+            "kind": "DataQuery",
+            "group": "grafana",
+            "version": "v0",
+            "datasource": {
+              "name": "-- Grafana --"
+            },
+            "spec": {}
+          },
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "builtIn": true
+        }
+      }
+    ],
+    "cursorSync": "Off",
+    "editable": true,
+    "elements": {
+      "panel-2": {
+        "kind": "Panel",
+        "spec": {
+          "id": 2,
+          "title": "Census age",
+          "description": "",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "${tenant}"
+                      },
+                      "spec": {
+                        "expr": "time() - max(bifrost_reconciler_instances_updated_timestamp_seconds{k8s_cluster_name=~\"$cluster\"})",
+                        "legendFormat": "{{__field.name}}"
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.1+security-01",
+            "spec": {
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "s",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      },
+                      {
+                        "value": 900,
+                        "color": "yellow"
+                      },
+                      {
+                        "value": 1800,
+                        "color": "red"
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-3": {
+        "kind": "Panel",
+        "spec": {
+          "id": 3,
+          "title": "Managed and unmanaged instances",
+          "description": "",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "${tenant}"
+                      },
+                      "spec": {
+                        "expr": "bifrost_reconciler_managed_instances{k8s_cluster_name=~\"$cluster\"}",
+                        "legendFormat": "managed"
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "${tenant}"
+                      },
+                      "spec": {
+                        "expr": "bifrost_reconciler_unmanaged_instances{k8s_cluster_name=~\"$cluster\"}",
+                        "legendFormat": "unmanaged"
+                      }
+                    },
+                    "refId": "B",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "timeseries",
+            "version": "13.0.1+security-01",
+            "spec": {
+              "options": {
+                "annotations": {
+                  "clustering": -1,
+                  "multiLane": false
+                },
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "table",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      },
+                      {
+                        "value": 80,
+                        "color": "red"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-4": {
+        "kind": "Panel",
+        "spec": {
+          "id": 4,
+          "title": "Adoption halted",
+          "description": "",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "${tenant}"
+                      },
+                      "spec": {
+                        "expr": "max(bifrost_reconciler_adoption_halted{k8s_cluster_name=~\"$cluster\"})"
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.1+security-01",
+            "spec": {
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "mappings": [
+                    {
+                      "type": "value",
+                      "options": {
+                        "0": {
+                          "text": "Running",
+                          "color": "green"
+                        },
+                        "1": {
+                          "text": "Halted",
+                          "color": "red"
+                        }
+                      }
+                    }
+                  ],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      },
+                      {
+                        "value": 80,
+                        "color": "red"
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-5": {
+        "kind": "Panel",
+        "spec": {
+          "id": 5,
+          "title": "Reconciler actions by reason",
+          "description": "",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "${tenant}"
+                      },
+                      "spec": {
+                        "expr": "sum by (action, reason) (rate(bifrost_reconciler_actions_total{k8s_cluster_name=~\"$cluster\"}[5m]))",
+                        "legendFormat": "{{action}} / {{reason}}"
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "timeseries",
+            "version": "13.0.1+security-01",
+            "spec": {
+              "options": {
+                "annotations": {
+                  "clustering": -1,
+                  "multiLane": false
+                },
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "table",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "ops",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      },
+                      {
+                        "value": 80,
+                        "color": "red"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-7": {
+        "kind": "Panel",
+        "spec": {
+          "id": 7,
+          "title": "ReleaseChannel health",
+          "description": "",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "${tenant}"
+                      },
+                      "spec": {
+                        "expr": "min(unleasherator_releasechannel_status{k8s_cluster_name=~\"$cluster\"})"
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.1+security-01",
+            "spec": {
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "mappings": [
+                    {
+                      "type": "value",
+                      "options": {
+                        "0": {
+                          "text": "Failed",
+                          "color": "red"
+                        },
+                        "1": {
+                          "text": "Healthy",
+                          "color": "green"
+                        },
+                        "0.5": {
+                          "text": "Rolling",
+                          "color": "yellow"
+                        }
+                      }
+                    }
+                  ],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      },
+                      {
+                        "value": 80,
+                        "color": "red"
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-8": {
+        "kind": "Panel",
+        "spec": {
+          "id": 8,
+          "title": "ReleaseChannel progress",
+          "description": "",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "${tenant}"
+                      },
+                      "spec": {
+                        "expr": "sum(unleasherator_releasechannel_instances_up_to_date{k8s_cluster_name=~\"$cluster\"})",
+                        "legendFormat": "up to date"
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "${tenant}"
+                      },
+                      "spec": {
+                        "expr": "sum(unleasherator_releasechannel_instances_total{k8s_cluster_name=~\"$cluster\"})",
+                        "legendFormat": "total"
+                      }
+                    },
+                    "refId": "B",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "timeseries",
+            "version": "13.0.1+security-01",
+            "spec": {
+              "options": {
+                "annotations": {
+                  "clustering": -1,
+                  "multiLane": false
+                },
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "table",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      },
+                      {
+                        "value": 80,
+                        "color": "red"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-9": {
+        "kind": "Panel",
+        "spec": {
+          "id": 9,
+          "title": "Controller workqueue depth",
+          "description": "",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "${tenant}"
+                      },
+                      "spec": {
+                        "expr": "max by (name) (workqueue_depth{name=~\".*unleash.*|.*releasechannel.*\", k8s_cluster_name=~\"$cluster\"})",
+                        "legendFormat": "{{name}}"
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "timeseries",
+            "version": "13.0.1+security-01",
+            "spec": {
+              "options": {
+                "annotations": {
+                  "clustering": -1,
+                  "multiLane": false
+                },
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "table",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      },
+                      {
+                        "value": 80,
+                        "color": "red"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      }
+    },
+    "layout": {
+      "kind": "RowsLayout",
+      "spec": {
+        "rows": [
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "title": "Bifrost census age by tenant",
+              "collapse": false,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 0, "y": 0, "width": 6, "height": 5,
+                        "element": { "kind": "ElementReference", "name": "panel-2" },
+                        "repeat": { "mode": "variable", "value": "tenant" }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "title": "Bifrost managed instances by tenant",
+              "collapse": false,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 6,
+                        "height": 7,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-3"
+                        },
+                        "repeat": {
+                          "mode": "variable",
+                          "value": "tenant"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    "links": [],
+    "liveNow": false,
+    "preload": false,
+    "tags": [],
+    "timeSettings": {
+      "timezone": "browser",
+      "from": "now-6h",
+      "to": "now",
+      "autoRefresh": "",
+      "autoRefreshIntervals": [
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+      ],
+      "hideTimepicker": false,
+      "fiscalYearStartMonth": 0
+    },
+    "title": "Unleash Tenant Overview",
+    "variables": [
+      {
+        "kind": "DatasourceVariable",
+        "spec": {
+          "name": "tenant",
+          "pluginId": "prometheus",
+          "refresh": "onDashboardLoad",
+          "regex": "",
+          "current": {
+            "text": [
+              "atil-metrics",
+              "ldir-metrics",
+              "nav-metrics",
+              "ssb-metrics"
+            ],
+            "value": [
+              "PF7D5629ECC453C64",
+              "P73126C2103EBFC69",
+              "P91A6F0B3584B90E7",
+              "PE607B8DC11CE4E99"
+            ]
+          },
+          "options": [],
+          "multi": true,
+          "includeAll": true,
+          "label": "Tenant",
+          "hide": "dontHide",
+          "skipUrlSync": false,
+          "description": "Select tenants. Panels repeat once per selected Mimir datasource.",
+          "allowCustomValue": true
+        }
       },
       {
-        "name": "cluster",
-        "label": "Cluster",
-        "type": "query",
-        "datasource": { "type": "prometheus", "uid": "${tenant}" },
-        "query": "label_values(up, k8s_cluster_name)",
-        "multi": true,
-        "includeAll": true,
-        "allValue": ".*",
-        "current": { "text": ["prod"], "value": ["prod"] },
-        "description": "Filter by Kubernetes cluster."
+        "kind": "QueryVariable",
+        "spec": {
+          "name": "cluster",
+          "current": {
+            "text": [
+              "management"
+            ],
+            "value": [
+              "management"
+            ]
+          },
+          "label": "Cluster",
+          "hide": "dontHide",
+          "refresh": "never",
+          "skipUrlSync": false,
+          "description": "Filter by Kubernetes cluster.",
+          "query": {
+            "kind": "DataQuery",
+            "group": "prometheus",
+            "version": "v0",
+            "datasource": {
+              "name": "${tenant}"
+            },
+            "spec": {
+              "__legacyStringValue": "label_values(up, k8s_cluster_name)"
+            }
+          },
+          "regex": "",
+          "regexApplyTo": "value",
+          "sort": "disabled",
+          "options": [],
+          "multi": true,
+          "includeAll": true,
+          "allValue": ".*",
+          "allowCustomValue": true
+        }
       }
     ]
-  },
-  "panels": [
-    {
-      "id": 1, "type": "row", "title": "Bifrost reconciler", "collapsed": false,
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 }, "panels": []
-    },
-    {
-      "id": 2, "type": "stat", "title": "Census age", "repeat": "tenant",
-      "datasource": { "type": "prometheus", "uid": "${tenant}" },
-      "gridPos": { "h": 5, "w": 4, "x": 0, "y": 1 },
-      "targets": [{ "refId": "A", "expr": "time() - max(bifrost_reconciler_instances_updated_timestamp_seconds{k8s_cluster_name=~\"$cluster\"})", "legendFormat": "{{__field.name}}" }],
-      "fieldConfig": { "defaults": { "unit": "s", "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": 0 }, { "color": "yellow", "value": 900 }, { "color": "red", "value": 1800 }] } }, "overrides": [] },
-      "options": { "reduceOptions": { "calcs": ["lastNotNull"], "values": false }, "colorMode": "background", "graphMode": "none" }
-    },
-    {
-      "id": 3, "type": "timeseries", "title": "Managed and unmanaged instances", "repeat": "tenant",
-      "datasource": { "type": "prometheus", "uid": "${tenant}" },
-      "gridPos": { "h": 7, "w": 8, "x": 4, "y": 1 },
-      "targets": [
-        { "refId": "A", "expr": "bifrost_reconciler_managed_instances{k8s_cluster_name=~\"$cluster\"}", "legendFormat": "managed" },
-        { "refId": "B", "expr": "bifrost_reconciler_unmanaged_instances{k8s_cluster_name=~\"$cluster\"}", "legendFormat": "unmanaged" }
-      ],
-      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
-      "options": { "legend": { "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi" } }
-    },
-    {
-      "id": 4, "type": "stat", "title": "Adoption halted", "repeat": "tenant",
-      "datasource": { "type": "prometheus", "uid": "${tenant}" },
-      "gridPos": { "h": 5, "w": 4, "x": 12, "y": 1 },
-      "targets": [{ "refId": "A", "expr": "max(bifrost_reconciler_adoption_halted{k8s_cluster_name=~\"$cluster\"})" }],
-      "fieldConfig": { "defaults": { "mappings": [{ "type": "value", "options": { "0": { "text": "Running", "color": "green" }, "1": { "text": "Halted", "color": "red" } } }] }, "overrides": [] },
-      "options": { "reduceOptions": { "calcs": ["lastNotNull"], "values": false }, "colorMode": "background", "graphMode": "none" }
-    },
-    {
-      "id": 5, "type": "timeseries", "title": "Reconciler actions by reason", "repeat": "tenant",
-      "datasource": { "type": "prometheus", "uid": "${tenant}" },
-      "gridPos": { "h": 7, "w": 8, "x": 16, "y": 1 },
-      "targets": [{ "refId": "A", "expr": "sum by (action, reason) (rate(bifrost_reconciler_actions_total{k8s_cluster_name=~\"$cluster\"}[5m]))", "legendFormat": "{{action}} / {{reason}}" }],
-      "fieldConfig": { "defaults": { "unit": "ops" }, "overrides": [] },
-      "options": { "legend": { "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi" } }
-    },
-    {
-      "id": 6, "type": "row", "title": "Unleasherator rollouts", "collapsed": false,
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 8 }, "panels": []
-    },
-    {
-      "id": 7, "type": "stat", "title": "ReleaseChannel health", "repeat": "tenant",
-      "datasource": { "type": "prometheus", "uid": "${tenant}" },
-      "gridPos": { "h": 5, "w": 4, "x": 0, "y": 9 },
-      "targets": [{ "refId": "A", "expr": "min(unleasherator_releasechannel_status{k8s_cluster_name=~\"$cluster\"})" }],
-      "fieldConfig": { "defaults": { "mappings": [{ "type": "value", "options": { "0": { "text": "Failed", "color": "red" }, "0.5": { "text": "Rolling", "color": "yellow" }, "1": { "text": "Healthy", "color": "green" } } }] }, "overrides": [] },
-      "options": { "reduceOptions": { "calcs": ["lastNotNull"], "values": false }, "colorMode": "background", "graphMode": "none" }
-    },
-    {
-      "id": 8, "type": "timeseries", "title": "ReleaseChannel progress", "repeat": "tenant",
-      "datasource": { "type": "prometheus", "uid": "${tenant}" },
-      "gridPos": { "h": 7, "w": 8, "x": 4, "y": 9 },
-      "targets": [
-        { "refId": "A", "expr": "sum(unleasherator_releasechannel_instances_up_to_date{k8s_cluster_name=~\"$cluster\"})", "legendFormat": "up to date" },
-        { "refId": "B", "expr": "sum(unleasherator_releasechannel_instances_total{k8s_cluster_name=~\"$cluster\"})", "legendFormat": "total" }
-      ],
-      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
-      "options": { "legend": { "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi" } }
-    },
-    {
-      "id": 9, "type": "timeseries", "title": "Controller workqueue depth", "repeat": "tenant",
-      "datasource": { "type": "prometheus", "uid": "${tenant}" },
-      "gridPos": { "h": 7, "w": 12, "x": 12, "y": 9 },
-      "targets": [{ "refId": "A", "expr": "max by (name) (workqueue_depth{name=~\".*unleash.*|.*releasechannel.*\", k8s_cluster_name=~\"$cluster\"})", "legendFormat": "{{name}}" }],
-      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
-      "options": { "legend": { "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi" } }
-    }
-  ]
+  }
 }

--- a/charts/unleasherator/dashboards/tenant-overview-dashboard.json
+++ b/charts/unleasherator/dashboards/tenant-overview-dashboard.json
@@ -57,7 +57,7 @@
         "description": "",
         "id": 2,
         "links": [],
-        "title": "Census age",
+        "title": "Census age (${tenant})",
         "vizConfig": {
           "group": "stat",
           "kind": "VizConfig",
@@ -160,7 +160,7 @@
         "description": "",
         "id": 3,
         "links": [],
-        "title": "Managed and unmanaged instances",
+        "title": "Instances mngmt (${tenant})",
         "vizConfig": {
           "group": "timeseries",
           "kind": "VizConfig",
@@ -276,7 +276,7 @@
         "description": "",
         "id": 4,
         "links": [],
-        "title": "Adoption halted",
+        "title": "Adoption (${tenant})",
         "vizConfig": {
           "group": "stat",
           "kind": "VizConfig",
@@ -370,7 +370,7 @@
         "description": "",
         "id": 5,
         "links": [],
-        "title": "Reconciler actions by reason",
+        "title": "Reconciler (${tenant})",
         "vizConfig": {
           "group": "timeseries",
           "kind": "VizConfig",
@@ -486,7 +486,7 @@
         "description": "",
         "id": 7,
         "links": [],
-        "title": "ReleaseChannel health",
+        "title": "ReleaseChannel (${tenant})",
         "vizConfig": {
           "group": "stat",
           "kind": "VizConfig",
@@ -603,7 +603,7 @@
         "description": "",
         "id": 8,
         "links": [],
-        "title": "ReleaseChannel progress",
+        "title": "ReleaseChannel (${tenant})",
         "vizConfig": {
           "group": "timeseries",
           "kind": "VizConfig",
@@ -720,7 +720,7 @@
         "description": "",
         "id": 9,
         "links": [],
-        "title": "Controller workqueue depth",
+        "title": "Workqueue depth (${tenant})",
         "vizConfig": {
           "group": "timeseries",
           "kind": "VizConfig",
@@ -811,6 +811,7 @@
         {
           "kind": "RowsLayoutRow",
           "spec": {
+            "title": "Bifrost reconciliation",
             "collapse": false,
             "layout": {
               "kind": "GridLayout",
@@ -819,126 +820,84 @@
                   {
                     "kind": "GridLayoutItem",
                     "spec": {
+                      "x": 0,
+                      "y": 0,
+                      "width": 24,
+                      "height": 4,
                       "element": {
                         "kind": "ElementReference",
                         "name": "panel-2"
                       },
-                      "height": 5,
                       "repeat": {
                         "mode": "variable",
                         "value": "tenant",
                         "maxPerRow": 4
-                      },
-                      "width": 6,
-                      "x": 0,
-                      "y": 0
+                      }
                     }
-                  }
-                ]
-              }
-            },
-            "title": "Bifrost census age by tenant"
-          }
-        },
-        {
-          "kind": "RowsLayoutRow",
-          "spec": {
-            "collapse": false,
-            "layout": {
-              "kind": "GridLayout",
-              "spec": {
-                "items": [
+                  },
                   {
                     "kind": "GridLayoutItem",
                     "spec": {
+                      "x": 0,
+                      "y": 4,
+                      "width": 24,
+                      "height": 5,
                       "element": {
                         "kind": "ElementReference",
                         "name": "panel-3"
                       },
-                      "height": 7,
                       "repeat": {
                         "mode": "variable",
                         "value": "tenant",
                         "maxPerRow": 4
-                      },
-                      "width": 6,
-                      "x": 0,
-                      "y": 0
+                      }
                     }
-                  }
-                ]
-              }
-            },
-            "title": "Bifrost managed instances by tenant"
-          }
-        },
-        {
-          "kind": "RowsLayoutRow",
-          "spec": {
-            "collapse": false,
-            "layout": {
-              "kind": "GridLayout",
-              "spec": {
-                "items": [
+                  },
                   {
                     "kind": "GridLayoutItem",
                     "spec": {
+                      "x": 0,
+                      "y": 9,
+                      "width": 24,
+                      "height": 5,
                       "element": {
                         "kind": "ElementReference",
                         "name": "panel-4"
                       },
-                      "height": 5,
                       "repeat": {
                         "mode": "variable",
                         "value": "tenant",
                         "maxPerRow": 4
-                      },
-                      "width": 6,
-                      "x": 0,
-                      "y": 0
+                      }
                     }
-                  }
-                ]
-              }
-            },
-            "title": "Bifrost adoption state by tenant"
-          }
-        },
-        {
-          "kind": "RowsLayoutRow",
-          "spec": {
-            "collapse": false,
-            "layout": {
-              "kind": "GridLayout",
-              "spec": {
-                "items": [
+                  },
                   {
                     "kind": "GridLayoutItem",
                     "spec": {
+                      "x": 0,
+                      "y": 14,
+                      "width": 24,
+                      "height": 5,
                       "element": {
                         "kind": "ElementReference",
                         "name": "panel-5"
                       },
-                      "height": 7,
                       "repeat": {
                         "mode": "variable",
                         "value": "tenant",
                         "maxPerRow": 4
-                      },
-                      "width": 6,
-                      "x": 0,
-                      "y": 0
+                      }
                     }
                   }
                 ]
               }
-            },
-            "title": "Bifrost reconciler actions by tenant"
+            }
           }
         },
         {
           "kind": "RowsLayoutRow",
           "spec": {
+            "title": "Unleasherator rollout health",
             "collapse": false,
             "layout": {
               "kind": "GridLayout",
@@ -947,89 +906,60 @@
                   {
                     "kind": "GridLayoutItem",
                     "spec": {
+                      "x": 0,
+                      "y": 0,
+                      "width": 24,
+                      "height": 5,
                       "element": {
                         "kind": "ElementReference",
                         "name": "panel-7"
                       },
-                      "height": 5,
                       "repeat": {
                         "mode": "variable",
                         "value": "tenant",
                         "maxPerRow": 4
-                      },
-                      "width": 6,
-                      "x": 0,
-                      "y": 0
+                      }
                     }
-                  }
-                ]
-              }
-            },
-            "title": "ReleaseChannel health by tenant"
-          }
-        },
-        {
-          "kind": "RowsLayoutRow",
-          "spec": {
-            "collapse": false,
-            "layout": {
-              "kind": "GridLayout",
-              "spec": {
-                "items": [
+                  },
                   {
                     "kind": "GridLayoutItem",
                     "spec": {
+                      "x": 0,
+                      "y": 5,
+                      "width": 24,
+                      "height": 7,
                       "element": {
                         "kind": "ElementReference",
                         "name": "panel-8"
                       },
-                      "height": 7,
                       "repeat": {
                         "mode": "variable",
                         "value": "tenant",
                         "maxPerRow": 4
-                      },
-                      "width": 6,
-                      "x": 0,
-                      "y": 0
+                      }
                     }
-                  }
-                ]
-              }
-            },
-            "title": "ReleaseChannel progress by tenant"
-          }
-        },
-        {
-          "kind": "RowsLayoutRow",
-          "spec": {
-            "collapse": false,
-            "layout": {
-              "kind": "GridLayout",
-              "spec": {
-                "items": [
+                  },
                   {
                     "kind": "GridLayoutItem",
                     "spec": {
+                      "x": 0,
+                      "y": 12,
+                      "width": 24,
+                      "height": 7,
                       "element": {
                         "kind": "ElementReference",
                         "name": "panel-9"
                       },
-                      "height": 7,
                       "repeat": {
                         "mode": "variable",
                         "value": "tenant",
                         "maxPerRow": 4
-                      },
-                      "width": 6,
-                      "x": 0,
-                      "y": 0
+                      }
                     }
                   }
                 ]
               }
-            },
-            "title": "Unleasherator workqueue depth by tenant"
+            }
           }
         }
       ]
@@ -1052,7 +982,7 @@
       "1d"
     ],
     "fiscalYearStartMonth": 0,
-    "from": "now-6h",
+    "from": "now-24h",
     "hideTimepicker": false,
     "timezone": "browser",
     "to": "now"

--- a/charts/unleasherator/dashboards/tenant-overview-dashboard.json
+++ b/charts/unleasherator/dashboards/tenant-overview-dashboard.json
@@ -811,7 +811,6 @@
         {
           "kind": "RowsLayoutRow",
           "spec": {
-            "title": "Bifrost reconciliation",
             "collapse": false,
             "layout": {
               "kind": "GridLayout",
@@ -820,84 +819,84 @@
                   {
                     "kind": "GridLayoutItem",
                     "spec": {
-                      "x": 0,
-                      "y": 0,
-                      "width": 24,
-                      "height": 4,
                       "element": {
                         "kind": "ElementReference",
                         "name": "panel-2"
                       },
+                      "height": 4,
                       "repeat": {
+                        "maxPerRow": 4,
                         "mode": "variable",
-                        "value": "tenant",
-                        "maxPerRow": 4
-                      }
+                        "value": "tenant"
+                      },
+                      "width": 24,
+                      "x": 0,
+                      "y": 0
                     }
                   },
                   {
                     "kind": "GridLayoutItem",
                     "spec": {
-                      "x": 0,
-                      "y": 4,
-                      "width": 24,
-                      "height": 5,
                       "element": {
                         "kind": "ElementReference",
                         "name": "panel-3"
                       },
+                      "height": 5,
                       "repeat": {
+                        "maxPerRow": 4,
                         "mode": "variable",
-                        "value": "tenant",
-                        "maxPerRow": 4
-                      }
+                        "value": "tenant"
+                      },
+                      "width": 24,
+                      "x": 0,
+                      "y": 4
                     }
                   },
                   {
                     "kind": "GridLayoutItem",
                     "spec": {
-                      "x": 0,
-                      "y": 9,
-                      "width": 24,
-                      "height": 5,
                       "element": {
                         "kind": "ElementReference",
                         "name": "panel-4"
                       },
+                      "height": 5,
                       "repeat": {
+                        "maxPerRow": 4,
                         "mode": "variable",
-                        "value": "tenant",
-                        "maxPerRow": 4
-                      }
+                        "value": "tenant"
+                      },
+                      "width": 24,
+                      "x": 0,
+                      "y": 9
                     }
                   },
                   {
                     "kind": "GridLayoutItem",
                     "spec": {
-                      "x": 0,
-                      "y": 14,
-                      "width": 24,
-                      "height": 5,
                       "element": {
                         "kind": "ElementReference",
                         "name": "panel-5"
                       },
+                      "height": 5,
                       "repeat": {
+                        "maxPerRow": 4,
                         "mode": "variable",
-                        "value": "tenant",
-                        "maxPerRow": 4
-                      }
+                        "value": "tenant"
+                      },
+                      "width": 24,
+                      "x": 0,
+                      "y": 14
                     }
                   }
                 ]
               }
-            }
+            },
+            "title": "Bifrost reconciliation"
           }
         },
         {
           "kind": "RowsLayoutRow",
           "spec": {
-            "title": "Unleasherator rollout health",
             "collapse": false,
             "layout": {
               "kind": "GridLayout",
@@ -906,60 +905,61 @@
                   {
                     "kind": "GridLayoutItem",
                     "spec": {
-                      "x": 0,
-                      "y": 0,
-                      "width": 24,
-                      "height": 5,
                       "element": {
                         "kind": "ElementReference",
                         "name": "panel-7"
                       },
+                      "height": 5,
                       "repeat": {
+                        "maxPerRow": 4,
                         "mode": "variable",
-                        "value": "tenant",
-                        "maxPerRow": 4
-                      }
+                        "value": "tenant"
+                      },
+                      "width": 24,
+                      "x": 0,
+                      "y": 0
                     }
                   },
                   {
                     "kind": "GridLayoutItem",
                     "spec": {
-                      "x": 0,
-                      "y": 5,
-                      "width": 24,
-                      "height": 7,
                       "element": {
                         "kind": "ElementReference",
                         "name": "panel-8"
                       },
+                      "height": 7,
                       "repeat": {
+                        "maxPerRow": 4,
                         "mode": "variable",
-                        "value": "tenant",
-                        "maxPerRow": 4
-                      }
+                        "value": "tenant"
+                      },
+                      "width": 24,
+                      "x": 0,
+                      "y": 5
                     }
                   },
                   {
                     "kind": "GridLayoutItem",
                     "spec": {
-                      "x": 0,
-                      "y": 12,
-                      "width": 24,
-                      "height": 7,
                       "element": {
                         "kind": "ElementReference",
                         "name": "panel-9"
                       },
+                      "height": 7,
                       "repeat": {
+                        "maxPerRow": 4,
                         "mode": "variable",
-                        "value": "tenant",
-                        "maxPerRow": 4
-                      }
+                        "value": "tenant"
+                      },
+                      "width": 24,
+                      "x": 0,
+                      "y": 12
                     }
                   }
                 ]
               }
-            }
+            },
+            "title": "Unleasherator rollout health"
           }
         }
       ]

--- a/charts/unleasherator/dashboards/tenant-overview-dashboard.json
+++ b/charts/unleasherator/dashboards/tenant-overview-dashboard.json
@@ -1,425 +1,1149 @@
 {
-  "title": "Unleash Tenant Overview",
-  "uid": "nais-tenant-overview",
-  "editable": true,
-  "schemaVersion": 41,
-  "time": {
-    "from": "now-6h",
-    "to": "now"
+  "apiVersion": "dashboard.grafana.app/v2",
+  "kind": "Dashboard",
+  "metadata": {
+    "name": "unleash-overview",
+    "namespace": "default",
+    "uid": "3c6207aa-9c67-4fdb-9406-67fd0f915362",
+    "resourceVersion": "1788810569968991",
+    "generation": 2,
+    "creationTimestamp": "2026-09-07T19:49:02Z",
+    "labels": {
+      "grafana.app/deprecatedInternalID": "2875698210541568"
+    },
+    "annotations": {
+      "grafana.app/createdBy": "user:u000000003",
+      "grafana.app/folder": "2-RVnOUVz",
+      "grafana.app/saved-from-ui": "Grafana v13.0.1+security-01 (9bbe672d)",
+      "grafana.app/updatedBy": "user:u000000003",
+      "grafana.app/updatedTimestamp": "2026-09-07T19:49:29Z",
+      "grafana.app/folderTitle": "Unleash",
+      "grafana.app/folderUrl": "/dashboards/f/2-RVnOUVz/unleash"
+    }
   },
-  "templating": {
-    "list": [
+  "spec": {
+    "annotations": [
       {
-        "name": "tenant",
-        "label": "Tenant",
-        "type": "datasource",
-        "query": "prometheus",
-        "pluginId": "prometheus",
-        "multi": true,
-        "includeAll": true,
-        "current": {
-          "text": [
-            "atil-metrics",
-            "ldir-metrics",
-            "nav-metrics",
-            "ssb-metrics"
-          ],
-          "value": [
-            "PF7D5629ECC453C64",
-            "P73126C2103EBFC69",
-            "P91A6F0B3584B90E7",
-            "PE607B8DC11CE4E99"
-          ]
-        },
-        "description": "Select tenants. Panels repeat once per selected Mimir datasource."
+        "kind": "AnnotationQuery",
+        "spec": {
+          "query": {
+            "kind": "DataQuery",
+            "group": "grafana",
+            "version": "v0",
+            "datasource": {
+              "name": "-- Grafana --"
+            },
+            "spec": {}
+          },
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "builtIn": true
+        }
+      }
+    ],
+    "cursorSync": "Off",
+    "editable": true,
+    "elements": {
+      "panel-2": {
+        "kind": "Panel",
+        "spec": {
+          "id": 2,
+          "title": "Census age",
+          "description": "",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "${tenant}"
+                      },
+                      "spec": {
+                        "expr": "time() - max(bifrost_reconciler_instances_updated_timestamp_seconds{k8s_cluster_name=~\"$cluster\"})",
+                        "legendFormat": "{{__field.name}}"
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.1+security-01",
+            "spec": {
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "s",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      },
+                      {
+                        "value": 900,
+                        "color": "yellow"
+                      },
+                      {
+                        "value": 1800,
+                        "color": "red"
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-3": {
+        "kind": "Panel",
+        "spec": {
+          "id": 3,
+          "title": "Managed and unmanaged instances",
+          "description": "",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "${tenant}"
+                      },
+                      "spec": {
+                        "expr": "bifrost_reconciler_managed_instances{k8s_cluster_name=~\"$cluster\"}",
+                        "legendFormat": "managed"
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "${tenant}"
+                      },
+                      "spec": {
+                        "expr": "bifrost_reconciler_unmanaged_instances{k8s_cluster_name=~\"$cluster\"}",
+                        "legendFormat": "unmanaged"
+                      }
+                    },
+                    "refId": "B",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "timeseries",
+            "version": "13.0.1+security-01",
+            "spec": {
+              "options": {
+                "annotations": {
+                  "clustering": -1,
+                  "multiLane": false
+                },
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "table",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      },
+                      {
+                        "value": 80,
+                        "color": "red"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-4": {
+        "kind": "Panel",
+        "spec": {
+          "id": 4,
+          "title": "Adoption halted",
+          "description": "",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "${tenant}"
+                      },
+                      "spec": {
+                        "expr": "max(bifrost_reconciler_adoption_halted{k8s_cluster_name=~\"$cluster\"})"
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.1+security-01",
+            "spec": {
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "mappings": [
+                    {
+                      "type": "value",
+                      "options": {
+                        "0": {
+                          "text": "Running",
+                          "color": "green"
+                        },
+                        "1": {
+                          "text": "Halted",
+                          "color": "red"
+                        }
+                      }
+                    }
+                  ],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      },
+                      {
+                        "value": 80,
+                        "color": "red"
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-5": {
+        "kind": "Panel",
+        "spec": {
+          "id": 5,
+          "title": "Reconciler actions by reason",
+          "description": "",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "${tenant}"
+                      },
+                      "spec": {
+                        "expr": "sum by (action, reason) (rate(bifrost_reconciler_actions_total{k8s_cluster_name=~\"$cluster\"}[5m]))",
+                        "legendFormat": "{{action}} / {{reason}}"
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "timeseries",
+            "version": "13.0.1+security-01",
+            "spec": {
+              "options": {
+                "annotations": {
+                  "clustering": -1,
+                  "multiLane": false
+                },
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "table",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "ops",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      },
+                      {
+                        "value": 80,
+                        "color": "red"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-7": {
+        "kind": "Panel",
+        "spec": {
+          "id": 7,
+          "title": "ReleaseChannel health",
+          "description": "",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "${tenant}"
+                      },
+                      "spec": {
+                        "expr": "min(unleasherator_releasechannel_status{k8s_cluster_name=~\"$cluster\"})"
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.1+security-01",
+            "spec": {
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "mappings": [
+                    {
+                      "type": "value",
+                      "options": {
+                        "0": {
+                          "text": "Failed",
+                          "color": "red"
+                        },
+                        "1": {
+                          "text": "Healthy",
+                          "color": "green"
+                        },
+                        "0.5": {
+                          "text": "Rolling",
+                          "color": "yellow"
+                        }
+                      }
+                    }
+                  ],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      },
+                      {
+                        "value": 80,
+                        "color": "red"
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-8": {
+        "kind": "Panel",
+        "spec": {
+          "id": 8,
+          "title": "ReleaseChannel progress",
+          "description": "",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "${tenant}"
+                      },
+                      "spec": {
+                        "expr": "sum(unleasherator_releasechannel_instances_up_to_date{k8s_cluster_name=~\"$cluster\"})",
+                        "legendFormat": "up to date"
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "${tenant}"
+                      },
+                      "spec": {
+                        "expr": "sum(unleasherator_releasechannel_instances_total{k8s_cluster_name=~\"$cluster\"})",
+                        "legendFormat": "total"
+                      }
+                    },
+                    "refId": "B",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "timeseries",
+            "version": "13.0.1+security-01",
+            "spec": {
+              "options": {
+                "annotations": {
+                  "clustering": -1,
+                  "multiLane": false
+                },
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "table",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      },
+                      {
+                        "value": 80,
+                        "color": "red"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-9": {
+        "kind": "Panel",
+        "spec": {
+          "id": 9,
+          "title": "Controller workqueue depth",
+          "description": "",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "${tenant}"
+                      },
+                      "spec": {
+                        "expr": "max by (name) (workqueue_depth{name=~\".*unleash.*|.*releasechannel.*\", k8s_cluster_name=~\"$cluster\"})",
+                        "legendFormat": "{{name}}"
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "timeseries",
+            "version": "13.0.1+security-01",
+            "spec": {
+              "options": {
+                "annotations": {
+                  "clustering": -1,
+                  "multiLane": false
+                },
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "table",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      },
+                      {
+                        "value": 80,
+                        "color": "red"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      }
+    },
+    "layout": {
+      "kind": "RowsLayout",
+      "spec": {
+        "rows": [
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "title": "Bifrost census age by tenant",
+              "collapse": false,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 6,
+                        "height": 5,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-2"
+                        },
+                        "repeat": {
+                          "mode": "variable",
+                          "value": "tenant"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "title": "Bifrost managed instances by tenant",
+              "collapse": false,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 6,
+                        "height": 7,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-3"
+                        },
+                        "repeat": {
+                          "mode": "variable",
+                          "value": "tenant"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "title": "Bifrost adoption state by tenant",
+              "collapse": false,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 6,
+                        "height": 5,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-4"
+                        },
+                        "repeat": {
+                          "mode": "variable",
+                          "value": "tenant"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "title": "Bifrost reconciler actions by tenant",
+              "collapse": false,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 6,
+                        "height": 7,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-5"
+                        },
+                        "repeat": {
+                          "mode": "variable",
+                          "value": "tenant"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "title": "ReleaseChannel health by tenant",
+              "collapse": false,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 6,
+                        "height": 5,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-7"
+                        },
+                        "repeat": {
+                          "mode": "variable",
+                          "value": "tenant"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "title": "ReleaseChannel progress by tenant",
+              "collapse": false,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 6,
+                        "height": 7,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-8"
+                        },
+                        "repeat": {
+                          "mode": "variable",
+                          "value": "tenant"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "title": "Unleasherator workqueue depth by tenant",
+              "collapse": false,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 6,
+                        "height": 7,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-9"
+                        },
+                        "repeat": {
+                          "mode": "variable",
+                          "value": "tenant"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    "links": [],
+    "liveNow": false,
+    "preload": false,
+    "tags": [],
+    "timeSettings": {
+      "timezone": "browser",
+      "from": "now-6h",
+      "to": "now",
+      "autoRefresh": "",
+      "autoRefreshIntervals": [
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+      ],
+      "hideTimepicker": false,
+      "fiscalYearStartMonth": 0
+    },
+    "title": "Unleash Tenant Overview",
+    "variables": [
+      {
+        "kind": "DatasourceVariable",
+        "spec": {
+          "name": "tenant",
+          "pluginId": "prometheus",
+          "refresh": "onDashboardLoad",
+          "regex": "",
+          "current": {
+            "text": [
+              "atil-metrics",
+              "ldir-metrics",
+              "nav-metrics",
+              "ssb-metrics"
+            ],
+            "value": [
+              "PF7D5629ECC453C64",
+              "P73126C2103EBFC69",
+              "P91A6F0B3584B90E7",
+              "PE607B8DC11CE4E99"
+            ]
+          },
+          "options": [],
+          "multi": true,
+          "includeAll": true,
+          "label": "Tenant",
+          "hide": "dontHide",
+          "skipUrlSync": false,
+          "description": "Select tenants. Panels repeat once per selected Mimir datasource.",
+          "allowCustomValue": true
+        }
       },
       {
-        "name": "cluster",
-        "label": "Cluster",
-        "type": "query",
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${tenant}"
-        },
-        "query": "label_values(up, k8s_cluster_name)",
-        "multi": true,
-        "includeAll": true,
-        "allValue": ".*",
-        "current": {
-          "text": [
-            "prod"
-          ],
-          "value": [
-            "prod"
-          ]
-        },
-        "description": "Filter by Kubernetes cluster."
+        "kind": "QueryVariable",
+        "spec": {
+          "name": "cluster",
+          "current": {
+            "text": [
+              "management"
+            ],
+            "value": [
+              "management"
+            ]
+          },
+          "label": "Cluster",
+          "hide": "dontHide",
+          "refresh": "never",
+          "skipUrlSync": false,
+          "description": "Filter by Kubernetes cluster.",
+          "query": {
+            "kind": "DataQuery",
+            "group": "prometheus",
+            "version": "v0",
+            "datasource": {
+              "name": "${tenant}"
+            },
+            "spec": {
+              "__legacyStringValue": "label_values(up, k8s_cluster_name)"
+            }
+          },
+          "regex": "",
+          "regexApplyTo": "value",
+          "sort": "disabled",
+          "options": [],
+          "multi": true,
+          "includeAll": true,
+          "allValue": ".*",
+          "allowCustomValue": true
+        }
       }
     ]
-  },
-  "panels": [
-    {
-      "id": 1,
-      "type": "row",
-      "title": "Bifrost reconciler",
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 0
-      },
-      "panels": []
-    },
-    {
-      "id": 2,
-      "type": "stat",
-      "title": "Census age",
-      "repeat": "tenant",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${tenant}"
-      },
-      "gridPos": {
-        "h": 5,
-        "w": 4,
-        "x": 0,
-        "y": 1
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "expr": "time() - max(bifrost_reconciler_instances_updated_timestamp_seconds{k8s_cluster_name=~\"$cluster\"})",
-          "legendFormat": "{{__field.name}}"
-        }
-      ],
-      "fieldConfig": {
-        "defaults": {
-          "unit": "s",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "yellow",
-                "value": 900
-              },
-              {
-                "color": "red",
-                "value": 1800
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "options": {
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "values": false
-        },
-        "colorMode": "background",
-        "graphMode": "none"
-      },
-      "maxPerRow": 4
-    },
-    {
-      "id": 3,
-      "type": "timeseries",
-      "title": "Managed and unmanaged instances",
-      "repeat": "tenant",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${tenant}"
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 8,
-        "x": 4,
-        "y": 1
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "expr": "bifrost_reconciler_managed_instances{k8s_cluster_name=~\"$cluster\"}",
-          "legendFormat": "managed"
-        },
-        {
-          "refId": "B",
-          "expr": "bifrost_reconciler_unmanaged_instances{k8s_cluster_name=~\"$cluster\"}",
-          "legendFormat": "unmanaged"
-        }
-      ],
-      "fieldConfig": {
-        "defaults": {
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "options": {
-        "legend": {
-          "displayMode": "table",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "multi"
-        }
-      },
-      "maxPerRow": 4
-    },
-    {
-      "id": 4,
-      "type": "stat",
-      "title": "Adoption halted",
-      "repeat": "tenant",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${tenant}"
-      },
-      "gridPos": {
-        "h": 5,
-        "w": 4,
-        "x": 12,
-        "y": 1
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "expr": "max(bifrost_reconciler_adoption_halted{k8s_cluster_name=~\"$cluster\"})"
-        }
-      ],
-      "fieldConfig": {
-        "defaults": {
-          "mappings": [
-            {
-              "type": "value",
-              "options": {
-                "0": {
-                  "text": "Running",
-                  "color": "green"
-                },
-                "1": {
-                  "text": "Halted",
-                  "color": "red"
-                }
-              }
-            }
-          ]
-        },
-        "overrides": []
-      },
-      "options": {
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "values": false
-        },
-        "colorMode": "background",
-        "graphMode": "none"
-      },
-      "maxPerRow": 4
-    },
-    {
-      "id": 5,
-      "type": "timeseries",
-      "title": "Reconciler actions by reason",
-      "repeat": "tenant",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${tenant}"
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 8,
-        "x": 16,
-        "y": 1
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "expr": "sum by (action, reason) (rate(bifrost_reconciler_actions_total{k8s_cluster_name=~\"$cluster\"}[5m]))",
-          "legendFormat": "{{action}} / {{reason}}"
-        }
-      ],
-      "fieldConfig": {
-        "defaults": {
-          "unit": "ops"
-        },
-        "overrides": []
-      },
-      "options": {
-        "legend": {
-          "displayMode": "table",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "multi"
-        }
-      },
-      "maxPerRow": 4
-    },
-    {
-      "id": 6,
-      "type": "row",
-      "title": "Unleasherator rollouts",
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 8
-      },
-      "panels": []
-    },
-    {
-      "id": 7,
-      "type": "stat",
-      "title": "ReleaseChannel health",
-      "repeat": "tenant",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${tenant}"
-      },
-      "gridPos": {
-        "h": 5,
-        "w": 4,
-        "x": 0,
-        "y": 9
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "expr": "min(unleasherator_releasechannel_status{k8s_cluster_name=~\"$cluster\"})"
-        }
-      ],
-      "fieldConfig": {
-        "defaults": {
-          "mappings": [
-            {
-              "type": "value",
-              "options": {
-                "0": {
-                  "text": "Failed",
-                  "color": "red"
-                },
-                "0.5": {
-                  "text": "Rolling",
-                  "color": "yellow"
-                },
-                "1": {
-                  "text": "Healthy",
-                  "color": "green"
-                }
-              }
-            }
-          ]
-        },
-        "overrides": []
-      },
-      "options": {
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "values": false
-        },
-        "colorMode": "background",
-        "graphMode": "none"
-      },
-      "maxPerRow": 4
-    },
-    {
-      "id": 8,
-      "type": "timeseries",
-      "title": "ReleaseChannel progress",
-      "repeat": "tenant",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${tenant}"
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 8,
-        "x": 4,
-        "y": 9
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "expr": "sum(unleasherator_releasechannel_instances_up_to_date{k8s_cluster_name=~\"$cluster\"})",
-          "legendFormat": "up to date"
-        },
-        {
-          "refId": "B",
-          "expr": "sum(unleasherator_releasechannel_instances_total{k8s_cluster_name=~\"$cluster\"})",
-          "legendFormat": "total"
-        }
-      ],
-      "fieldConfig": {
-        "defaults": {
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "options": {
-        "legend": {
-          "displayMode": "table",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "multi"
-        }
-      },
-      "maxPerRow": 4
-    },
-    {
-      "id": 9,
-      "type": "timeseries",
-      "title": "Controller workqueue depth",
-      "repeat": "tenant",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${tenant}"
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 12,
-        "x": 12,
-        "y": 9
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "expr": "max by (name) (workqueue_depth{name=~\".*unleash.*|.*releasechannel.*\", k8s_cluster_name=~\"$cluster\"})",
-          "legendFormat": "{{name}}"
-        }
-      ],
-      "fieldConfig": {
-        "defaults": {
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "options": {
-        "legend": {
-          "displayMode": "table",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "multi"
-        }
-      },
-      "maxPerRow": 4
-    }
-  ]
+  }
 }


### PR DESCRIPTION
## Summary

Adds **Unleash Tenant Overview**, a Grafana dashboard for comparing Bifrost reconciliation and Unleasherator rollout health across all selected Mimir tenants.

## Dashboard coverage

- Bifrost reconciler census freshness
- Managed and unmanaged Unleash instances
- Automatic-adoption status
- Reconciler actions grouped by action and reason
- ReleaseChannel health and rollout progress
- Unleasherator workqueue depth

## Layout

The dashboard uses the existing multi-select `tenant` datasource variable and `cluster` filter. Panels repeat in four columns, one per selected tenant, and are grouped into:

- **Bifrost reconciliation**
- **Unleasherator rollout health**

## Operational notes

Current fleet data shows no unmanaged instances. The unmanaged-instance panel remains to detect future drift or legacy CRs that have not been intentionally adopted.

## Validation

- Dashboard JSON parses successfully.
- Grafana v2 root-spec schema is used.
