### PR TITLE
fix(controller): make Unleash readiness generation-aware

### DIFF
--- a/api/v1/unleash_types.go
+++ b/api/v1/unleash_types.go
@@ -393,5 +393,5 @@ func (u *Unleash) ApiClient(ctx context.Context, client client.Client, namespace
 // IsReady returns true if the Unleash instance is ready.
 // We define ready as having both the Available and Connection conditions set to true.
 func (u *Unleash) IsReady() bool {
-	return conditionStatusIsReady(u.Status.Conditions)
+	return conditionStatusIsReadyForGeneration(u.Status.Conditions, u.Generation)
 }

--- a/api/v1/unleash_types_test.go
+++ b/api/v1/unleash_types_test.go
@@ -10,11 +10,15 @@ import (
 
 func TestUnleashIsReady(t *testing.T) {
 	unleash := Unleash{
+		ObjectMeta: metav1.ObjectMeta{
+			Generation: 2,
+		},
 		Status: UnleashStatus{
 			Conditions: []metav1.Condition{
 				{
-					Type:   UnleashStatusConditionTypeReconciled,
-					Status: metav1.ConditionFalse,
+					Type:               UnleashStatusConditionTypeReconciled,
+					Status:             metav1.ConditionFalse,
+					ObservedGeneration: 2,
 				},
 			},
 		},
@@ -26,13 +30,17 @@ func TestUnleashIsReady(t *testing.T) {
 	assert.Equal(t, unleash.IsReady(), false, "Unleash should not be ready when connection condition is missing")
 
 	unleash.Status.Conditions = append(unleash.Status.Conditions, metav1.Condition{
-		Type:   UnleashStatusConditionTypeConnected,
-		Status: metav1.ConditionFalse,
+		Type:               UnleashStatusConditionTypeConnected,
+		Status:             metav1.ConditionFalse,
+		ObservedGeneration: 2,
 	})
 	assert.Equal(t, unleash.IsReady(), false, "Unleash should not be ready when connection condition is false")
 
 	unleash.Status.Conditions[1].Status = metav1.ConditionTrue
 	assert.Equal(t, unleash.IsReady(), true, "Unleash should be ready when available and connection conditions are true")
+
+	unleash.Generation++
+	assert.False(t, unleash.IsReady(), "Unleash should not be ready when true conditions belong to the previous generation")
 }
 
 func TestUnleashNamespacedName(t *testing.T) {

--- a/internal/controller/releasechannel_controller.go
+++ b/internal/controller/releasechannel_controller.go
@@ -1787,6 +1787,7 @@ func (r *ReleaseChannelReconciler) terminalInstanceFailure(ctx context.Context, 
 		for _, condition := range currentInstance.Status.Conditions {
 			if condition.Type == unleashv1.UnleashStatusConditionTypeReconciled &&
 				condition.Status == metav1.ConditionFalse &&
+				condition.ObservedGeneration == currentInstance.Generation &&
 				condition.Reason == "Failed" {
 				return fmt.Errorf("instance %s failed: %s", currentInstance.Name, condition.Message)
 			}
@@ -1861,13 +1862,7 @@ func (r *ReleaseChannelReconciler) isInstanceReady(instance *unleashv1.Unleash) 
 }
 
 func instanceReady(instance *unleashv1.Unleash) bool {
-	// Check for Ready condition
-	for _, condition := range instance.Status.Conditions {
-		if condition.Type == unleashv1.UnleashStatusConditionTypeReconciled {
-			return condition.Status == metav1.ConditionTrue
-		}
-	}
-	return false
+	return instanceConditionIsTrueForCurrentGeneration(instance, unleashv1.UnleashStatusConditionTypeReconciled)
 }
 
 func (r *ReleaseChannelReconciler) isInstanceConnected(instance *unleashv1.Unleash) bool {
@@ -1875,9 +1870,14 @@ func (r *ReleaseChannelReconciler) isInstanceConnected(instance *unleashv1.Unlea
 }
 
 func instanceConnected(instance *unleashv1.Unleash) bool {
+	return instanceConditionIsTrueForCurrentGeneration(instance, unleashv1.UnleashStatusConditionTypeConnected)
+}
+
+func instanceConditionIsTrueForCurrentGeneration(instance *unleashv1.Unleash, conditionType string) bool {
 	for _, condition := range instance.Status.Conditions {
-		if condition.Type == unleashv1.UnleashStatusConditionTypeConnected {
-			return condition.Status == metav1.ConditionTrue
+		if condition.Type == conditionType {
+			return condition.Status == metav1.ConditionTrue &&
+				condition.ObservedGeneration == instance.Generation
 		}
 	}
 	return false
@@ -1921,6 +1921,7 @@ func (r *ReleaseChannelReconciler) performHealthChecks(ctx context.Context, inst
 		for _, condition := range currentInstance.Status.Conditions {
 			if condition.Type == unleashv1.UnleashStatusConditionTypeReconciled &&
 				condition.Status == metav1.ConditionFalse &&
+				condition.ObservedGeneration == currentInstance.Generation &&
 				condition.Reason == "Failed" {
 				// Record failed health check
 				releaseChannelHealthChecks.WithLabelValues(releaseChannel.ObjectMeta.Namespace, releaseChannel.ObjectMeta.Name, "failed").Inc()
@@ -1929,15 +1930,7 @@ func (r *ReleaseChannelReconciler) performHealthChecks(ctx context.Context, inst
 		}
 
 		// Check if instance is connected (healthy) via Kubernetes conditions
-		connected := false
-		for _, condition := range currentInstance.Status.Conditions {
-			if condition.Type == unleashv1.UnleashStatusConditionTypeConnected {
-				connected = condition.Status == metav1.ConditionTrue
-				break
-			}
-		}
-
-		if !connected {
+		if !instanceConnected(currentInstance) {
 			log.V(1).Info("Instance not connected/healthy yet", "name", instance.ObjectMeta.Name)
 			return false, nil
 		}

--- a/internal/controller/releasechannel_controller_unit_test.go
+++ b/internal/controller/releasechannel_controller_unit_test.go
@@ -315,7 +315,7 @@ func TestGetExpectedImageForInstance(t *testing.T) {
 				Spec: unleashv1.ReleaseChannelSpec{
 					Image:           "test:v2",
 					BreakGlassImage: "test:v2",
-					Rollback:       unleashv1.RollbackConfig{PreviousImage: "test:v1.5"},
+					Rollback:        unleashv1.RollbackConfig{PreviousImage: "test:v1.5"},
 				},
 				Status: unleashv1.ReleaseChannelStatus{Phase: unleashv1.ReleaseChannelPhaseRollingBack},
 			},
@@ -1002,16 +1002,34 @@ func TestIsInstanceReady(t *testing.T) {
 		{
 			name: "ready instance",
 			instance: &unleashv1.Unleash{
+				ObjectMeta: metav1.ObjectMeta{Generation: 2},
 				Status: unleashv1.UnleashStatus{
 					Conditions: []metav1.Condition{
 						{
-							Type:   unleashv1.UnleashStatusConditionTypeReconciled,
-							Status: metav1.ConditionTrue,
+							Type:               unleashv1.UnleashStatusConditionTypeReconciled,
+							Status:             metav1.ConditionTrue,
+							ObservedGeneration: 2,
 						},
 					},
 				},
 			},
 			expected: true,
+		},
+		{
+			name: "stale ready condition",
+			instance: &unleashv1.Unleash{
+				ObjectMeta: metav1.ObjectMeta{Generation: 2},
+				Status: unleashv1.UnleashStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:               unleashv1.UnleashStatusConditionTypeReconciled,
+							Status:             metav1.ConditionTrue,
+							ObservedGeneration: 1,
+						},
+					},
+				},
+			},
+			expected: false,
 		},
 		{
 			name: "not ready instance",
@@ -1070,6 +1088,57 @@ func TestIsInstanceReady(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result := reconciler.isInstanceReady(tt.instance)
 			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestInstanceConnected(t *testing.T) {
+	tests := []struct {
+		name               string
+		generation         int64
+		observedGeneration int64
+		status             metav1.ConditionStatus
+		expected           bool
+	}{
+		{
+			name:               "connected for current generation",
+			generation:         2,
+			observedGeneration: 2,
+			status:             metav1.ConditionTrue,
+			expected:           true,
+		},
+		{
+			name:               "stale connected condition",
+			generation:         2,
+			observedGeneration: 1,
+			status:             metav1.ConditionTrue,
+			expected:           false,
+		},
+		{
+			name:               "current generation not connected",
+			generation:         2,
+			observedGeneration: 2,
+			status:             metav1.ConditionFalse,
+			expected:           false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			instance := &unleashv1.Unleash{
+				ObjectMeta: metav1.ObjectMeta{Generation: tt.generation},
+				Status: unleashv1.UnleashStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:               unleashv1.UnleashStatusConditionTypeConnected,
+							Status:             tt.status,
+							ObservedGeneration: tt.observedGeneration,
+						},
+					},
+				},
+			}
+
+			assert.Equal(t, tt.expected, instanceConnected(instance))
 		})
 	}
 }

--- a/internal/controller/unleash_controller.go
+++ b/internal/controller/unleash_controller.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -51,6 +52,8 @@ const (
 	unleashPublishMetricStatusFailed  = "failed"
 	unleashPublishMetricStatusSkipped = "skipped"
 )
+
+var errUnleashGenerationChanged = errors.New("unleash generation changed during reconciliation")
 
 var (
 	// Unleash controller timings - prefixed to avoid conflicts with other controllers
@@ -131,6 +134,7 @@ func (r *UnleashReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		log.Error(err, "Failed to get Unleash")
 		return ctrl.Result{}, err
 	}
+	reconciledGeneration := unleash.Generation
 
 	// Check if marked for deletion
 	if unleash.GetDeletionTimestamp() != nil {
@@ -213,10 +217,11 @@ func (r *UnleashReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 				return nil // Already has conditions
 			}
 			meta.SetStatusCondition(&unleash.Status.Conditions, metav1.Condition{
-				Type:    unleashv1.UnleashStatusConditionTypeReconciled,
-				Status:  metav1.ConditionUnknown,
-				Reason:  "Reconciling",
-				Message: "Starting reconciliation",
+				Type:               unleashv1.UnleashStatusConditionTypeReconciled,
+				Status:             metav1.ConditionUnknown,
+				ObservedGeneration: reconciledGeneration,
+				Reason:             "Reconciling",
+				Message:            "Starting reconciliation",
 			})
 			return r.Status().Update(ctx, unleash)
 		})
@@ -265,7 +270,7 @@ func (r *UnleashReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "Failed to reconcile Secrets")
-		_ = r.updateStatusReconcileFailed(ctx, unleash, err, "Failed to reconcile Secrets")
+		_ = r.updateStatusReconcileFailed(ctx, unleash, reconciledGeneration, err, "Failed to reconcile Secrets")
 		return ctrl.Result{}, err
 	} else if res.RequeueAfter > 0 {
 		return res, nil
@@ -276,18 +281,22 @@ func (r *UnleashReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "Failed to reconcile NetworkPolicy")
-		_ = r.updateStatusReconcileFailed(ctx, unleash, err, "Failed to reconcile NetworkPolicy")
+		_ = r.updateStatusReconcileFailed(ctx, unleash, reconciledGeneration, err, "Failed to reconcile NetworkPolicy")
 		return ctrl.Result{}, err
 	} else if res.RequeueAfter > 0 {
 		return res, nil
 	}
 
 	span.AddEvent("Reconciling Deployment")
-	res, err = r.reconcileDeployment(ctx, unleash)
+	res, err = r.reconcileDeployment(ctx, unleash, reconciledGeneration)
 	if err != nil {
+		if errors.Is(err, errUnleashGenerationChanged) {
+			log.Info("Unleash generation changed while reconciling Deployment; requeuing")
+			return ctrl.Result{Requeue: true}, nil
+		}
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "Failed to reconcile Deployment")
-		_ = r.updateStatusReconcileFailed(ctx, unleash, err, "Failed to reconcile Deployment")
+		_ = r.updateStatusReconcileFailed(ctx, unleash, reconciledGeneration, err, "Failed to reconcile Deployment")
 		return ctrl.Result{}, err
 	} else if res.RequeueAfter > 0 {
 		return res, nil
@@ -298,7 +307,7 @@ func (r *UnleashReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "Failed to reconcile Service")
-		_ = r.updateStatusReconcileFailed(ctx, unleash, err, "Failed to reconcile Service")
+		_ = r.updateStatusReconcileFailed(ctx, unleash, reconciledGeneration, err, "Failed to reconcile Service")
 		return ctrl.Result{}, err
 	} else if res.RequeueAfter > 0 {
 		return res, nil
@@ -309,7 +318,7 @@ func (r *UnleashReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "Failed to reconcile Ingresses")
-		_ = r.updateStatusReconcileFailed(ctx, unleash, err, "Failed to reconcile Ingresses")
+		_ = r.updateStatusReconcileFailed(ctx, unleash, reconciledGeneration, err, "Failed to reconcile Ingresses")
 		return ctrl.Result{}, err
 	} else if res.RequeueAfter > 0 {
 		return res, nil
@@ -320,7 +329,7 @@ func (r *UnleashReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "Failed to reconcile ServiceMonitor")
-		_ = r.updateStatusReconcileFailed(ctx, unleash, err, "Failed to reconcile ServiceMonitor")
+		_ = r.updateStatusReconcileFailed(ctx, unleash, reconciledGeneration, err, "Failed to reconcile ServiceMonitor")
 		return ctrl.Result{}, err
 	} else if res.RequeueAfter > 0 {
 		return res, nil
@@ -335,7 +344,7 @@ func (r *UnleashReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 	deployment := &appsv1.Deployment{}
 	if err := r.Client.Get(ctx, req.NamespacedName, deployment); err != nil {
-		if statusErr := r.updateStatusReconcileFailed(ctx, unleash, err, "Failed to get Deployment status"); statusErr != nil {
+		if statusErr := r.updateStatusReconcileFailed(ctx, unleash, reconciledGeneration, err, "Failed to get Deployment status"); statusErr != nil {
 			return ctrl.Result{}, statusErr
 		}
 		return ctrl.Result{}, err
@@ -343,14 +352,14 @@ func (r *UnleashReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 	if failureReason, failed := utils.DeploymentFailure(deployment); failed {
 		failure := fmt.Errorf("deployment reported failure: %s", failureReason)
-		if err := r.updateStatusDeploymentFailed(ctx, unleash, failure, fmt.Sprintf("Deployment rollout failed: %s", failureReason)); err != nil {
+		if err := r.updateStatusDeploymentFailed(ctx, unleash, reconciledGeneration, failure, fmt.Sprintf("Deployment rollout failed: %s", failureReason)); err != nil {
 			return ctrl.Result{}, err
 		}
 		return ctrl.Result{RequeueAfter: unleashControllerRequeueAfter}, nil
 	}
 
 	if !utils.DeploymentIsReady(deployment) {
-		if err := r.updateStatusReconcileProgressing(ctx, unleash); err != nil {
+		if err := r.updateStatusReconcileProgressing(ctx, unleash, reconciledGeneration); err != nil {
 			return ctrl.Result{}, err
 		}
 		log.V(1).Info("Deployment rollout is still progressing")
@@ -359,14 +368,18 @@ func (r *UnleashReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 	// Set the reconcile status of the Unleash instance to available
 	log.Info("Successfully reconciled Unleash resources")
-	if err = r.updateStatusReconcileSuccess(ctx, unleash); err != nil {
+	if err = r.updateStatusReconcileSuccess(ctx, unleash, reconciledGeneration); err != nil {
+		if errors.Is(err, errUnleashGenerationChanged) {
+			log.Info("Unleash generation changed before reconcile status update; requeuing")
+			return ctrl.Result{Requeue: true}, nil
+		}
 		return ctrl.Result{}, err
 	}
 
 	span.AddEvent("Testing connection to Unleash instance")
 	stats, err := r.testConnection(unleash, ctx, log)
 	if err != nil {
-		if err := r.updateStatusConnectionFailed(ctx, unleash, err, "Failed to connect to Unleash instance"); err != nil {
+		if err := r.updateStatusConnectionFailed(ctx, unleash, reconciledGeneration, err, "Failed to connect to Unleash instance"); err != nil {
 			return ctrl.Result{}, err
 		}
 
@@ -376,7 +389,11 @@ func (r *UnleashReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	span.SetAttributes(attribute.String("unleash.version", stats.VersionOSS))
 
 	// Set the connection status of the Unleash instance to available
-	if err = r.updateStatusConnectionSuccess(ctx, unleash, stats); err != nil {
+	if err = r.updateStatusConnectionSuccess(ctx, unleash, reconciledGeneration, stats); err != nil {
+		if errors.Is(err, errUnleashGenerationChanged) {
+			log.Info("Unleash generation changed before connection status update; requeuing")
+			return ctrl.Result{Requeue: true}, nil
+		}
 		return ctrl.Result{}, err
 	}
 
@@ -778,7 +795,7 @@ func (r *UnleashReconciler) reconcileSecrets(ctx context.Context, unleash *unlea
 }
 
 // reconcileDeployment will ensure that the required deployment is created
-func (r *UnleashReconciler) reconcileDeployment(ctx context.Context, unleash *unleashv1.Unleash) (ctrl.Result, error) {
+func (r *UnleashReconciler) reconcileDeployment(ctx context.Context, unleash *unleashv1.Unleash, reconciledGeneration int64) (ctrl.Result, error) {
 	log := log.FromContext(ctx).WithName("unleash")
 
 	found := &appsv1.Deployment{}
@@ -831,7 +848,10 @@ func (r *UnleashReconciler) reconcileDeployment(ctx context.Context, unleash *un
 			log.Info("Updating Unleash status with new resolved image",
 				"oldImage", unleash.Status.ResolvedReleaseChannelImage,
 				"newImage", resolvedImage)
-			if err := r.markReleaseChannelAssignmentPending(ctx, unleash, resolvedImage); err != nil {
+			if err := r.markReleaseChannelAssignmentPending(ctx, unleash, reconciledGeneration, resolvedImage); err != nil {
+				if errors.Is(err, errUnleashGenerationChanged) {
+					return ctrl.Result{}, err
+				}
 				log.Error(err, "Failed to update Unleash status")
 				return ctrl.Result{}, err
 			}
@@ -970,8 +990,8 @@ func (r *UnleashReconciler) getDefaultImage() string {
 	return image
 }
 
-func (r *UnleashReconciler) updateStatusReconcileSuccess(ctx context.Context, unleash *unleashv1.Unleash) error {
-	return r.updateStatus(ctx, unleash, nil, metav1.Condition{
+func (r *UnleashReconciler) updateStatusReconcileSuccess(ctx context.Context, unleash *unleashv1.Unleash, reconciledGeneration int64) error {
+	return r.updateStatus(ctx, unleash, reconciledGeneration, nil, metav1.Condition{
 		Type:    unleashv1.UnleashStatusConditionTypeReconciled,
 		Status:  metav1.ConditionTrue,
 		Reason:  "Reconciling",
@@ -979,8 +999,8 @@ func (r *UnleashReconciler) updateStatusReconcileSuccess(ctx context.Context, un
 	})
 }
 
-func (r *UnleashReconciler) updateStatusReconcileProgressing(ctx context.Context, unleash *unleashv1.Unleash) error {
-	return r.updateStatus(ctx, unleash, nil, metav1.Condition{
+func (r *UnleashReconciler) updateStatusReconcileProgressing(ctx context.Context, unleash *unleashv1.Unleash, reconciledGeneration int64) error {
+	return r.updateStatus(ctx, unleash, reconciledGeneration, nil, metav1.Condition{
 		Type:    unleashv1.UnleashStatusConditionTypeReconciled,
 		Status:  metav1.ConditionUnknown,
 		Reason:  "DeploymentProgressing",
@@ -988,36 +1008,46 @@ func (r *UnleashReconciler) updateStatusReconcileProgressing(ctx context.Context
 	})
 }
 
-func (r *UnleashReconciler) markReleaseChannelAssignmentPending(ctx context.Context, unleash *unleashv1.Unleash, image string) error {
+func (r *UnleashReconciler) markReleaseChannelAssignmentPending(ctx context.Context, unleash *unleashv1.Unleash, reconciledGeneration int64, image string) error {
 	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-		if err := r.Get(ctx, unleash.NamespacedName(), unleash); err != nil {
+		fresh := &unleashv1.Unleash{}
+		if err := r.Get(ctx, unleash.NamespacedName(), fresh); err != nil {
 			return err
 		}
+		if fresh.Generation != reconciledGeneration {
+			return fmt.Errorf("%w: reconciled generation %d, current generation %d", errUnleashGenerationChanged, reconciledGeneration, fresh.Generation)
+		}
 
-		unleash.Status.ResolvedReleaseChannelImage = image
-		unleash.Status.ReleaseChannelName = unleash.Spec.ReleaseChannel.Name
-		unleash.Status.Reconciled = false
-		unleash.Status.Connected = false
-		meta.SetStatusCondition(&unleash.Status.Conditions, metav1.Condition{
-			Type:    unleashv1.UnleashStatusConditionTypeReconciled,
-			Status:  metav1.ConditionUnknown,
-			Reason:  "DeploymentProgressing",
-			Message: "Waiting for the current Deployment generation to become available",
+		fresh.Status.ResolvedReleaseChannelImage = image
+		fresh.Status.ReleaseChannelName = fresh.Spec.ReleaseChannel.Name
+		fresh.Status.Reconciled = false
+		fresh.Status.Connected = false
+		meta.SetStatusCondition(&fresh.Status.Conditions, metav1.Condition{
+			Type:               unleashv1.UnleashStatusConditionTypeReconciled,
+			Status:             metav1.ConditionUnknown,
+			ObservedGeneration: reconciledGeneration,
+			Reason:             "DeploymentProgressing",
+			Message:            "Waiting for the current Deployment generation to become available",
 		})
-		meta.SetStatusCondition(&unleash.Status.Conditions, metav1.Condition{
-			Type:    unleashv1.UnleashStatusConditionTypeConnected,
-			Status:  metav1.ConditionUnknown,
-			Reason:  "DeploymentProgressing",
-			Message: "Waiting for the current Deployment generation to become available",
+		meta.SetStatusCondition(&fresh.Status.Conditions, metav1.Condition{
+			Type:               unleashv1.UnleashStatusConditionTypeConnected,
+			Status:             metav1.ConditionUnknown,
+			ObservedGeneration: reconciledGeneration,
+			Reason:             "DeploymentProgressing",
+			Message:            "Waiting for the current Deployment generation to become available",
 		})
 
-		return r.Status().Update(ctx, unleash)
+		if err := r.Status().Update(ctx, fresh); err != nil {
+			return err
+		}
+		*unleash = *fresh
+		return nil
 	})
 }
 
-func (r *UnleashReconciler) updateStatusDeploymentFailed(ctx context.Context, unleash *unleashv1.Unleash, err error, message string) error {
+func (r *UnleashReconciler) updateStatusDeploymentFailed(ctx context.Context, unleash *unleashv1.Unleash, reconciledGeneration int64, err error, message string) error {
 	log.FromContext(ctx).WithName("unleash").Error(err, message)
-	return r.updateStatus(ctx, unleash, nil, metav1.Condition{
+	return r.updateStatus(ctx, unleash, reconciledGeneration, nil, metav1.Condition{
 		Type:    unleashv1.UnleashStatusConditionTypeReconciled,
 		Status:  metav1.ConditionFalse,
 		Reason:  "Failed",
@@ -1025,7 +1055,7 @@ func (r *UnleashReconciler) updateStatusDeploymentFailed(ctx context.Context, un
 	})
 }
 
-func (r *UnleashReconciler) updateStatusReconcileFailed(ctx context.Context, unleash *unleashv1.Unleash, err error, message string) error {
+func (r *UnleashReconciler) updateStatusReconcileFailed(ctx context.Context, unleash *unleashv1.Unleash, reconciledGeneration int64, err error, message string) error {
 	log := log.FromContext(ctx).WithName("unleash")
 
 	if verr, ok := err.(*resources.ValidationError); ok {
@@ -1033,7 +1063,7 @@ func (r *UnleashReconciler) updateStatusReconcileFailed(ctx context.Context, unl
 	}
 
 	log.Error(err, message)
-	return r.updateStatus(ctx, unleash, nil, metav1.Condition{
+	return r.updateStatus(ctx, unleash, reconciledGeneration, nil, metav1.Condition{
 		Type:    unleashv1.UnleashStatusConditionTypeReconciled,
 		Status:  metav1.ConditionFalse,
 		Reason:  "Reconciling",
@@ -1041,8 +1071,8 @@ func (r *UnleashReconciler) updateStatusReconcileFailed(ctx context.Context, unl
 	})
 }
 
-func (r *UnleashReconciler) updateStatusConnectionSuccess(ctx context.Context, unleash *unleashv1.Unleash, stats *unleashclient.InstanceAdminStatsResult) error {
-	return r.updateStatus(ctx, unleash, stats, metav1.Condition{
+func (r *UnleashReconciler) updateStatusConnectionSuccess(ctx context.Context, unleash *unleashv1.Unleash, reconciledGeneration int64, stats *unleashclient.InstanceAdminStatsResult) error {
+	return r.updateStatus(ctx, unleash, reconciledGeneration, stats, metav1.Condition{
 		Type:    unleashv1.UnleashStatusConditionTypeConnected,
 		Status:  metav1.ConditionTrue,
 		Reason:  "Reconciling",
@@ -1050,11 +1080,11 @@ func (r *UnleashReconciler) updateStatusConnectionSuccess(ctx context.Context, u
 	})
 }
 
-func (r *UnleashReconciler) updateStatusConnectionFailed(ctx context.Context, unleash *unleashv1.Unleash, err error, message string) error {
+func (r *UnleashReconciler) updateStatusConnectionFailed(ctx context.Context, unleash *unleashv1.Unleash, reconciledGeneration int64, err error, message string) error {
 	log := log.FromContext(ctx).WithName("unleash")
 
 	log.Error(err, fmt.Sprintf("%s for Unleash", message))
-	return r.updateStatus(ctx, unleash, nil, metav1.Condition{
+	return r.updateStatus(ctx, unleash, reconciledGeneration, nil, metav1.Condition{
 		Type:    unleashv1.UnleashStatusConditionTypeConnected,
 		Status:  metav1.ConditionFalse,
 		Reason:  "Reconciling",
@@ -1062,19 +1092,51 @@ func (r *UnleashReconciler) updateStatusConnectionFailed(ctx context.Context, un
 	})
 }
 
-func (r *UnleashReconciler) updateStatus(ctx context.Context, unleash *unleashv1.Unleash, stats *unleashclient.InstanceAdminStatsResult, status metav1.Condition) error {
+func (r *UnleashReconciler) updateStatus(ctx context.Context, unleash *unleashv1.Unleash, reconciledGeneration int64, stats *unleashclient.InstanceAdminStatsResult, status metav1.Condition) error {
 	log := log.FromContext(ctx).WithName("unleash")
+	status.ObservedGeneration = reconciledGeneration
 
-	// Derive version from stats if available (same logic as status update below)
-	// to ensure metric label matches what we're about to write to status
-	version := unleash.Status.Version
-	if stats != nil {
-		if stats.VersionEnterprise != "" {
-			version = stats.VersionEnterprise
-		} else if stats.VersionOSS != "" {
-			version = stats.VersionOSS
+	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		fresh := &unleashv1.Unleash{}
+		if err := r.Get(ctx, types.NamespacedName{Name: unleash.Name, Namespace: unleash.Namespace}, fresh); err != nil {
+			return err
 		}
+		if status.Status == metav1.ConditionTrue && fresh.Generation != reconciledGeneration {
+			return fmt.Errorf("%w: reconciled generation %d, current generation %d", errUnleashGenerationChanged, reconciledGeneration, fresh.Generation)
+		}
+
+		switch status.Type {
+		case unleashv1.UnleashStatusConditionTypeReconciled:
+			fresh.Status.Reconciled = status.Status == metav1.ConditionTrue
+		case unleashv1.UnleashStatusConditionTypeConnected:
+			fresh.Status.Connected = status.Status == metav1.ConditionTrue
+		}
+
+		if stats != nil {
+			if stats.VersionEnterprise != "" {
+				fresh.Status.Version = stats.VersionEnterprise
+			} else if stats.VersionOSS != "" {
+				fresh.Status.Version = stats.VersionOSS
+			}
+		}
+
+		meta.SetStatusCondition(&fresh.Status.Conditions, status)
+		if err := r.Status().Update(ctx, fresh); err != nil {
+			return err
+		}
+		*unleash = *fresh
+		return nil
+	})
+
+	if err != nil {
+		if errors.Is(err, errUnleashGenerationChanged) {
+			return err
+		}
+		log.Error(err, "Failed to update status for Unleash")
+		return err
 	}
+
+	version := unleash.Status.Version
 	if version == "" {
 		version = "unknown"
 	}
@@ -1084,39 +1146,10 @@ func (r *UnleashReconciler) updateStatus(ctx context.Context, unleash *unleashv1
 	}
 
 	// Delete stale metrics with old label values (version/release_channel can change)
-	// before setting new ones to prevent alerts from matching outdated time series
+	// before setting new ones to prevent alerts from matching outdated time series.
 	val := promGaugeValueForStatus(status.Status)
 	unleashStatus.DeletePartialMatch(prometheus.Labels{"name": unleash.Name, "status": status.Type})
 	unleashStatus.WithLabelValues(unleash.Name, status.Type, version, releaseChannel).Set(val)
-
-	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-		if err := r.Get(ctx, types.NamespacedName{Name: unleash.Name, Namespace: unleash.Namespace}, unleash); err != nil {
-			return err
-		}
-
-		switch status.Type {
-		case unleashv1.UnleashStatusConditionTypeReconciled:
-			unleash.Status.Reconciled = status.Status == metav1.ConditionTrue
-		case unleashv1.UnleashStatusConditionTypeConnected:
-			unleash.Status.Connected = status.Status == metav1.ConditionTrue
-		}
-
-		if stats != nil {
-			if stats.VersionEnterprise != "" {
-				unleash.Status.Version = stats.VersionEnterprise
-			} else if stats.VersionOSS != "" {
-				unleash.Status.Version = stats.VersionOSS
-			}
-		}
-
-		meta.SetStatusCondition(&unleash.Status.Conditions, status)
-		return r.Status().Update(ctx, unleash)
-	})
-
-	if err != nil {
-		log.Error(err, "Failed to update status for Unleash")
-		return err
-	}
 
 	return nil
 }

--- a/internal/controller/unleash_status_test.go
+++ b/internal/controller/unleash_status_test.go
@@ -1,0 +1,151 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	unleashv1 "github.com/nais/unleasherator/api/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+)
+
+func TestUpdateStatusSuccessRefusesNewGenerationAfterConflict(t *testing.T) {
+	ctx := context.Background()
+	scheme := runtime.NewScheme()
+	require.NoError(t, unleashv1.AddToScheme(scheme))
+
+	const reconciledGeneration = int64(1)
+	unleash := &unleashv1.Unleash{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "test",
+			Namespace:  "default",
+			Generation: reconciledGeneration,
+		},
+	}
+
+	updateCalls := 0
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(unleash.DeepCopy()).
+		WithStatusSubresource(unleash).
+		WithInterceptorFuncs(interceptor.Funcs{
+			SubResourceUpdate: func(ctx context.Context, c client.Client, subResourceName string, obj client.Object, opts ...client.SubResourceUpdateOption) error {
+				updateCalls++
+				if updateCalls == 1 {
+					current := &unleashv1.Unleash{}
+					if err := c.Get(ctx, client.ObjectKeyFromObject(obj), current); err != nil {
+						return err
+					}
+					current.Generation++
+					if err := c.Update(ctx, current); err != nil {
+						return err
+					}
+					return apierrors.NewConflict(
+						schema.GroupResource{Group: "unleash.nais.io", Resource: "unleashes"},
+						obj.GetName(),
+						fmt.Errorf("the object has been modified"),
+					)
+				}
+				return c.Status().Update(ctx, obj, opts...)
+			},
+		}).
+		Build()
+
+	reconciler := &UnleashReconciler{Client: fakeClient}
+	err := reconciler.updateStatusReconcileSuccess(ctx, unleash, reconciledGeneration)
+
+	require.ErrorIs(t, err, errUnleashGenerationChanged)
+	assert.Equal(t, 1, updateCalls)
+
+	stored := &unleashv1.Unleash{}
+	require.NoError(t, fakeClient.Get(ctx, client.ObjectKeyFromObject(unleash), stored))
+	assert.Equal(t, reconciledGeneration+1, stored.Generation)
+	assert.Empty(t, stored.Status.Conditions)
+	assert.False(t, stored.Status.Reconciled)
+}
+
+func TestUpdateStatusSuccessUsesReconciledGeneration(t *testing.T) {
+	ctx := context.Background()
+	scheme := runtime.NewScheme()
+	require.NoError(t, unleashv1.AddToScheme(scheme))
+
+	const reconciledGeneration = int64(3)
+	unleash := &unleashv1.Unleash{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "success",
+			Namespace:  "default",
+			Generation: reconciledGeneration,
+		},
+	}
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(unleash.DeepCopy()).
+		WithStatusSubresource(unleash).
+		Build()
+
+	reconciler := &UnleashReconciler{Client: fakeClient}
+	require.NoError(t, reconciler.updateStatusReconcileSuccess(ctx, unleash, reconciledGeneration))
+
+	stored := &unleashv1.Unleash{}
+	require.NoError(t, fakeClient.Get(ctx, client.ObjectKeyFromObject(unleash), stored))
+	require.Len(t, stored.Status.Conditions, 1)
+	assert.Equal(t, reconciledGeneration, stored.Status.Conditions[0].ObservedGeneration)
+	assert.Equal(t, metav1.ConditionTrue, stored.Status.Conditions[0].Status)
+	assert.True(t, stored.Status.Reconciled)
+}
+
+func TestUpdateStatusNonSuccessKeepsReconciledGeneration(t *testing.T) {
+	tests := []struct {
+		name   string
+		status metav1.ConditionStatus
+	}{
+		{name: "progressing", status: metav1.ConditionUnknown},
+		{name: "failed", status: metav1.ConditionFalse},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			scheme := runtime.NewScheme()
+			require.NoError(t, unleashv1.AddToScheme(scheme))
+
+			const reconciledGeneration = int64(1)
+			unleash := &unleashv1.Unleash{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       tt.name,
+					Namespace:  "default",
+					Generation: reconciledGeneration + 1,
+				},
+			}
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(unleash.DeepCopy()).
+				WithStatusSubresource(unleash).
+				Build()
+
+			reconciler := &UnleashReconciler{Client: fakeClient}
+			err := reconciler.updateStatus(ctx, unleash, reconciledGeneration, nil, metav1.Condition{
+				Type:    unleashv1.UnleashStatusConditionTypeReconciled,
+				Status:  tt.status,
+				Reason:  "Test",
+				Message: tt.name,
+			})
+			require.NoError(t, err)
+
+			stored := &unleashv1.Unleash{}
+			require.NoError(t, fakeClient.Get(ctx, client.ObjectKeyFromObject(unleash), stored))
+			require.Len(t, stored.Status.Conditions, 1)
+			assert.Equal(t, reconciledGeneration, stored.Status.Conditions[0].ObservedGeneration)
+			assert.Equal(t, tt.status, stored.Status.Conditions[0].Status)
+			assert.False(t, stored.IsReady())
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Records `ObservedGeneration` on `Reconciled` and `Connected` status conditions.
- Rejects stale successful status writes if the Unleash spec generation changed during a conflict retry.
- Requires current-generation readiness in `Unleash.IsReady()` and ReleaseChannel instance readiness checks.
- Adds coverage for stale conditions and status-update races.

## Why

Bifrost’s v6-to-v7 migration must not treat a previous v6 `Reconciled=True` and `Connected=True` status as proof that the newly assigned v7 generation is healthy.

## Validation

`make all`

## Rollout

Deploy this controller change before enabling Bifrost channel-migration admission. Existing conditions become eligible only after the controller has reconciled the current Unleash generation.
